### PR TITLE
feat: Add CI pipeline status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Python Code Intelligence MCP Server
 
+[![CI](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+
 An extensible MCP (Model Context Protocol) server that provides intelligent Python code analysis, navigation, and understanding capabilities for AI assistants like Claude.
 
 ## Features


### PR DESCRIPTION
## Summary
- Added CI pipeline status badges to README for better visibility of build health
- Includes badges for CI workflow, Python version, code style (black, ruff), and pre-commit

## Changes
- GitHub Actions CI workflow badge - shows current build status
- Python 3.10+ version badge - indicates supported Python versions
- Code style badges for black and ruff - shows code formatting standards
- Pre-commit enabled badge - indicates quality checks are enforced

Closes #9

## Test plan
- [x] Badges render correctly in README
- [x] Badge links navigate to appropriate resources
- [x] CI workflow continues to pass

🤖 Generated with [Claude Code](https://claude.ai/code)