### PR TITLE
feat: Add comprehensive input validation and sanitization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,13 +26,7 @@ repos:
         language_version: python3.12
         args: ['--line-length=100']
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ['--profile', 'black', '--line-length', '100']
-
-  # Linting
+  # Linting (Note: Ruff handles import sorting via the "I" rule)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.9
     hooks:

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,9 +7,10 @@
 3. [Configuration](#configuration)
 4. [Tools Reference](#tools-reference)
 5. [Architecture](#architecture)
-6. [Use Cases](#use-cases)
-7. [Plugin Development](#plugin-development)
-8. [Troubleshooting](#troubleshooting)
+6. [Security](#security)
+7. [Use Cases](#use-cases)
+8. [Plugin Development](#plugin-development)
+9. [Troubleshooting](#troubleshooting)
 
 ## Overview
 
@@ -421,6 +422,107 @@ The server automatically detects and activates framework-specific tools when it 
 - Automatic cache invalidation
 - Per-project watchers
 - Minimal performance overhead
+
+## Security
+
+### Input Validation
+
+The MCP server implements comprehensive input validation to prevent security vulnerabilities:
+
+#### Path Validation
+
+All file paths are validated to prevent path traversal attacks:
+
+- **Path Traversal Prevention**: Rejects paths containing `../` or similar patterns
+- **Null Byte Protection**: Blocks paths with null bytes that could bypass security checks
+- **Absolute Path Resolution**: Resolves all paths to absolute form to detect escape attempts
+- **Base Directory Restriction**: Optional restriction to keep paths within project boundaries
+
+Example of blocked patterns:
+
+```python
+# These paths will be rejected:
+"../../etc/passwd"           # Path traversal
+"/home/user/../../../etc"    # Absolute path traversal
+"file\x00.txt"              # Null byte injection
+```
+
+#### Input Sanitization
+
+All user inputs are sanitized before processing:
+
+- **Identifier Validation**: Python identifiers must match `[a-zA-Z_][a-zA-Z0-9_]*`
+- **Module Name Validation**: Module names allow dots but must be valid Python modules
+- **Line/Column Validation**: Numbers are range-checked to prevent overflow
+- **String Sanitization**: Control characters are removed, length is limited
+
+#### Sensitive Path Warnings
+
+The server warns when accessing potentially sensitive paths:
+
+- `.git/` - Git repository data
+- `.ssh/` - SSH keys
+- `.aws/` - AWS credentials
+- `.env` - Environment files
+- `*.pem`, `*.key` - Certificate and key files
+
+These paths are logged but not blocked (they may be legitimate for analysis).
+
+### Configuration Security
+
+When loading configuration from files:
+
+- Paths from configuration files are validated
+- Invalid paths are logged and skipped
+- Glob patterns are expanded safely
+- User home directory (`~`) is properly expanded
+
+### Best Practices
+
+1. **Restrict Base Directory**: Use the `base_path` parameter to limit file access:
+
+   ```python
+   PathValidator.validate_path(user_path, base_path="/project/root")
+   ```
+
+2. **Monitor Logs**: Watch for warnings about sensitive file access:
+
+   ```text
+   WARNING: Accessing potentially sensitive path: /home/user/.ssh/id_rsa
+   ```
+
+3. **File Size Limits**: Large files are rejected (default 10MB limit):
+
+   ```python
+   PathValidator.is_safe_to_read(path, max_size=5*1024*1024)  # 5MB limit
+   ```
+
+4. **Use Validation Decorator**: All MCP tools use the `@validate_mcp_inputs` decorator:
+
+   ```python
+   @mcp.tool()
+   @validate_mcp_inputs
+   def find_symbol(name: str, project_path: str = "."):
+       # Inputs are automatically validated
+       pass
+   ```
+
+### Security Testing
+
+The validation module includes comprehensive tests:
+
+```bash
+# Run security tests
+uv run pytest tests/test_validation.py -v
+```
+
+Tests cover:
+
+- Path traversal attempts
+- Null byte injection
+- Invalid identifiers
+- Boundary conditions
+- Decorator validation
 
 ## Use Cases
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ packages = ["src/pycodemcp"]
 line-length = 100
 target-version = "py310"
 
+[tool.ruff.lint.isort]
+# Make ruff's import sorting compatible with black
+combine-as-imports = true
+force-wrap-aliases = true
+
 [tool.ruff.lint]
 select = [
     "E",    # pycodestyle errors
@@ -96,9 +101,7 @@ check_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 
-[tool.isort]
-profile = "black"
-line_length = 100
+# isort configuration removed - using ruff's import sorting instead
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/src/pycodemcp/config.py
+++ b/src/pycodemcp/config.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from .validation import PathValidator, ValidationError
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +64,7 @@ class ProjectConfig:
 
             elif config_path.suffix in [".yaml", ".yml"]:
                 with open(config_path) as f:
-                    import yaml  # type: ignore
+                    import yaml  # type: ignore[import-untyped]
 
                     data = yaml.safe_load(f)
                     self.config.update(data.get("pycodemcp", data))
@@ -157,29 +159,45 @@ class ProjectConfig:
 
         # Add configured packages
         for package in self.config.get("packages", []):
-            # Support glob patterns
-            if "*" in package:
-                from glob import glob
+            try:
+                # Support glob patterns
+                if "*" in package:
+                    from glob import glob
 
-                expanded = glob(os.path.expanduser(package))
-                paths.extend(expanded)
-            else:
-                path = Path(package).expanduser().resolve()
-                if path.exists():
-                    paths.append(str(path))
+                    expanded = glob(os.path.expanduser(package))
+                    for exp_path in expanded:
+                        # Validate each expanded path
+                        validated = PathValidator.validate_path(exp_path)
+                        paths.append(str(validated))
+                else:
+                    # Validate the path
+                    validated = PathValidator.validate_path(package)
+                    if validated.exists():
+                        paths.append(str(validated))
+            except ValidationError as e:
+                logger.warning(f"Skipping invalid package path {package}: {e}")
+                continue
 
         # Add namespace paths
         for _namespace, ns_paths in self.config.get("namespaces", {}).items():
             for ns_path in ns_paths:
-                if "*" in ns_path:
-                    from glob import glob
+                try:
+                    if "*" in ns_path:
+                        from glob import glob
 
-                    expanded = glob(os.path.expanduser(ns_path))
-                    paths.extend(expanded)
-                else:
-                    path = Path(ns_path).expanduser().resolve()
-                    if path.exists():
-                        paths.append(str(path))
+                        expanded = glob(os.path.expanduser(ns_path))
+                        for exp_path in expanded:
+                            # Validate each expanded path
+                            validated = PathValidator.validate_path(exp_path)
+                            paths.append(str(validated))
+                    else:
+                        # Validate the path
+                        validated = PathValidator.validate_path(ns_path)
+                        if validated.exists():
+                            paths.append(str(validated))
+                except ValidationError as e:
+                    logger.warning(f"Skipping invalid namespace path {ns_path}: {e}")
+                    continue
 
         # Always include current project
         paths.insert(0, str(self.project_path))

--- a/src/pycodemcp/server.py
+++ b/src/pycodemcp/server.py
@@ -12,6 +12,7 @@ from .plugins.django import DjangoPlugin
 from .plugins.flask import FlaskPlugin
 from .plugins.pydantic import PydanticPlugin
 from .project_manager import get_project_manager
+from .validation import validate_mcp_inputs
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -89,6 +90,7 @@ def get_jedi_project(project_path: str | list[str] | dict[str, Any] = ".") -> je
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def configure_packages(
     packages: list[str] | None = None,
     namespaces: dict[str, list[str]] | None = None,
@@ -146,6 +148,7 @@ def configure_packages(
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def find_symbol(
     name: str, project_path: str = ".", fuzzy: bool = False, use_config: bool = True
 ) -> list[dict[str, Any]]:
@@ -202,6 +205,7 @@ def find_symbol(
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def goto_definition(
     file: str, line: int, column: int, project_path: str = "."
 ) -> dict[str, Any] | None:
@@ -250,6 +254,7 @@ def goto_definition(
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def find_references(
     file: str, line: int, column: int, project_path: str = ".", include_definitions: bool = True
 ) -> list[dict[str, Any]]:
@@ -304,6 +309,7 @@ def find_references(
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def get_type_info(file: str, line: int, column: int, project_path: str = ".") -> dict[str, Any]:
     """Get type information at a specific position.
 
@@ -360,6 +366,7 @@ def get_type_info(file: str, line: int, column: int, project_path: str = ".") ->
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def find_imports(module_name: str, project_path: str = ".") -> list[dict[str, Any]]:
     """Find all imports of a specific module in the project.
 
@@ -410,6 +417,7 @@ def find_imports(module_name: str, project_path: str = ".") -> list[dict[str, An
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def get_call_hierarchy(
     function_name: str, file: str | None = None, project_path: str = "."
 ) -> dict[str, Any]:
@@ -492,6 +500,7 @@ def get_call_hierarchy(
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def configure_namespace_package(namespace: str, repo_paths: list[str]) -> dict[str, Any]:
     """Configure a namespace package spread across multiple repositories.
 
@@ -544,6 +553,7 @@ def configure_namespace_package(namespace: str, repo_paths: list[str]) -> dict[s
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def find_in_namespace(import_path: str, namespace_repos: list[str]) -> dict[str, Any]:
     """Find a module/class within a namespace package spread across repos.
 
@@ -611,6 +621,7 @@ def find_in_namespace(import_path: str, namespace_repos: list[str]) -> dict[str,
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def find_symbol_multi(
     name: str, project_paths: list[str], fuzzy: bool = False
 ) -> dict[str, list[dict[str, Any]]]:
@@ -662,6 +673,7 @@ def find_symbol_multi(
 
 
 @mcp.tool()
+@validate_mcp_inputs
 def list_project_structure(project_path: str = ".", max_depth: int = 3) -> dict[str, Any]:
     """List the Python project structure.
 

--- a/src/pycodemcp/validation.py
+++ b/src/pycodemcp/validation.py
@@ -1,0 +1,330 @@
+"""Input validation and sanitization for file paths and user inputs."""
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+class ValidationError(Exception):
+    """Raised when input validation fails."""
+
+    pass
+
+
+class PathValidator:
+    """Validates and sanitizes file paths for security."""
+
+    # Patterns that might indicate path traversal attempts
+    SUSPICIOUS_PATTERNS = [
+        r"\.\./",  # Directory traversal
+        r"\.\.$",  # Directory traversal at end
+        r"^\.\.",  # Starting with ..
+        r"/\.\./",  # Directory traversal with slash
+        r"\\\.\.",  # Windows-style traversal
+        r"\.\.\\",  # Windows-style traversal
+    ]
+
+    # Patterns for potentially dangerous file names
+    DANGEROUS_NAMES = [
+        r"\.git/",  # Git directory
+        r"\.ssh/",  # SSH keys
+        r"\.aws/",  # AWS credentials
+        r"^\.env$",  # Environment files
+        r"\.pem$",  # Certificate files
+        r"\.key$",  # Key files
+        r"^/etc/",  # System config (Unix)
+        r"^/proc/",  # Process info (Unix)
+        r"^/sys/",  # System info (Unix)
+    ]
+
+    @classmethod
+    def validate_path(cls, path: str | Path, base_path: str | Path | None = None) -> Path:
+        """Validate and sanitize a file path.
+
+        Args:
+            path: The path to validate
+            base_path: Optional base path to restrict access within
+
+        Returns:
+            Validated Path object
+
+        Raises:
+            ValidationError: If the path is invalid or potentially dangerous
+        """
+        if not path:
+            raise ValidationError("Path cannot be empty")
+
+        # Convert to string for validation
+        path_str = str(path)
+
+        # Check for null bytes
+        if "\x00" in path_str:
+            raise ValidationError("Path contains null bytes")
+
+        # Check for suspicious patterns
+        for pattern in cls.SUSPICIOUS_PATTERNS:
+            if re.search(pattern, path_str):
+                raise ValidationError(f"Path contains suspicious pattern: {pattern}")
+
+        # Convert to Path object and resolve
+        try:
+            path_obj = Path(path_str)
+            # Resolve to absolute path to handle any remaining .. or .
+            resolved_path = path_obj.resolve()
+        except (ValueError, RuntimeError) as e:
+            raise ValidationError(f"Invalid path: {e}") from e
+
+        # If base_path is provided, ensure the path is within it
+        if base_path:
+            base = Path(base_path).resolve()
+            try:
+                # Check if resolved path is relative to base
+                resolved_path.relative_to(base)
+            except ValueError as e:
+                raise ValidationError(
+                    f"Path {resolved_path} is outside base directory {base}"
+                ) from e
+
+        # Check for dangerous file names
+        path_str_normalized = str(resolved_path).replace("\\", "/")
+        for pattern in cls.DANGEROUS_NAMES:
+            if re.search(pattern, path_str_normalized, re.IGNORECASE):
+                # Log warning but don't block - these might be legitimate
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    f"Accessing potentially sensitive path: {path_str_normalized}"
+                )
+
+        return resolved_path
+
+    @classmethod
+    def is_safe_to_read(cls, path: str | Path, max_size: int = 10 * 1024 * 1024) -> bool:
+        """Check if a file is safe to read.
+
+        Args:
+            path: Path to check
+            max_size: Maximum file size in bytes (default 10MB)
+
+        Returns:
+            True if the file appears safe to read
+        """
+        try:
+            path_obj = cls.validate_path(path)
+
+            # Check if file exists
+            if not path_obj.exists():
+                return False
+
+            # Check if it's a regular file
+            if not path_obj.is_file():
+                return False
+
+            # Check file size
+            if path_obj.stat().st_size > max_size:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    f"File too large: {path_obj} ({path_obj.stat().st_size} bytes)"
+                )
+                return False
+
+            # Check if it's a symlink pointing outside project
+            if path_obj.is_symlink():
+                target = path_obj.resolve()
+                # Could add additional checks here
+                import logging
+
+                logging.getLogger(__name__).info(f"Following symlink: {path_obj} -> {target}")
+
+            return True
+
+        except (ValidationError, OSError):
+            return False
+
+
+class InputValidator:
+    """General input validation utilities."""
+
+    @staticmethod
+    def validate_identifier(name: str, allow_dots: bool = True) -> str:
+        """Validate a Python identifier or module name.
+
+        Args:
+            name: The identifier to validate
+            allow_dots: Whether to allow dots (for module names)
+
+        Returns:
+            The validated identifier
+
+        Raises:
+            ValidationError: If the identifier is invalid
+        """
+        if not name:
+            raise ValidationError("Identifier cannot be empty")
+
+        # Check length
+        if len(name) > 255:
+            raise ValidationError("Identifier too long")
+
+        # Check for null bytes
+        if "\x00" in name:
+            raise ValidationError("Identifier contains null bytes")
+
+        # Validate format
+        if allow_dots:
+            # Module name format: word.word.word
+            pattern = r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$"
+        else:
+            # Simple identifier
+            pattern = r"^[a-zA-Z_][a-zA-Z0-9_]*$"
+
+        if not re.match(pattern, name):
+            raise ValidationError(f"Invalid identifier format: {name}")
+
+        return name
+
+    @staticmethod
+    def validate_line_number(line: Any, max_line: int = 1000000) -> int:
+        """Validate a line number.
+
+        Args:
+            line: The line number to validate
+            max_line: Maximum allowed line number
+
+        Returns:
+            The validated line number
+
+        Raises:
+            ValidationError: If the line number is invalid
+        """
+        try:
+            line_num = int(line)
+        except (TypeError, ValueError) as e:
+            raise ValidationError(f"Invalid line number: {line}") from e
+
+        if line_num < 1:
+            raise ValidationError("Line number must be positive")
+
+        if line_num > max_line:
+            raise ValidationError(f"Line number too large: {line_num}")
+
+        return line_num
+
+    @staticmethod
+    def validate_column_number(column: Any, max_column: int = 10000) -> int:
+        """Validate a column number.
+
+        Args:
+            column: The column number to validate
+            max_column: Maximum allowed column number
+
+        Returns:
+            The validated column number
+
+        Raises:
+            ValidationError: If the column number is invalid
+        """
+        try:
+            col_num = int(column)
+        except (TypeError, ValueError) as e:
+            raise ValidationError(f"Invalid column number: {column}") from e
+
+        if col_num < 0:
+            raise ValidationError("Column number must be non-negative")
+
+        if col_num > max_column:
+            raise ValidationError(f"Column number too large: {col_num}")
+
+        return col_num
+
+    @staticmethod
+    def sanitize_string(text: str, max_length: int = 10000) -> str:
+        """Sanitize a string for safe use.
+
+        Args:
+            text: The string to sanitize
+            max_length: Maximum allowed length
+
+        Returns:
+            The sanitized string
+        """
+        if not text:
+            return ""
+
+        # Remove null bytes
+        text = text.replace("\x00", "")
+
+        # Truncate if too long
+        if len(text) > max_length:
+            text = text[:max_length]
+
+        # Remove control characters except common ones (tab, newline, etc.)
+        text = re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "", text)
+
+        return text
+
+
+def validate_mcp_inputs(func: Any) -> Any:
+    """Decorator to validate inputs for MCP tool functions."""
+    import functools
+    import inspect
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        # Get function signature
+        sig = inspect.signature(func)
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+
+        # Validate based on parameter names
+        for param_name, value in bound.arguments.items():
+            if value is None:
+                continue
+
+            # File path validation
+            if param_name in ["file", "file_path", "path", "project_path"]:
+                try:
+                    validated = PathValidator.validate_path(value)
+                    bound.arguments[param_name] = str(validated)
+                except ValidationError as e:
+                    return {"error": f"Invalid {param_name}: {e}"}
+
+            # Line number validation
+            elif param_name == "line":
+                try:
+                    bound.arguments[param_name] = InputValidator.validate_line_number(value)
+                except ValidationError as e:
+                    return {"error": f"Invalid line number: {e}"}
+
+            # Column number validation
+            elif param_name == "column":
+                try:
+                    bound.arguments[param_name] = InputValidator.validate_column_number(value)
+                except ValidationError as e:
+                    return {"error": f"Invalid column number: {e}"}
+
+            # Module/identifier name validation
+            elif param_name in ["name", "module_name", "function_name", "import_path"]:
+                try:
+                    bound.arguments[param_name] = InputValidator.validate_identifier(
+                        value, allow_dots=param_name in ["module_name", "import_path"]
+                    )
+                except ValidationError as e:
+                    return {"error": f"Invalid {param_name}: {e}"}
+
+            # List validation for paths
+            elif param_name in ["paths", "repo_paths", "project_paths", "packages"]:
+                if isinstance(value, list):
+                    validated_list = []
+                    for item in value:
+                        try:
+                            validated = PathValidator.validate_path(item)
+                            validated_list.append(str(validated))
+                        except ValidationError as e:
+                            return {"error": f"Invalid path in {param_name}: {e}"}
+                    bound.arguments[param_name] = validated_list
+
+        return func(*bound.args, **bound.kwargs)
+
+    return wrapper

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,272 @@
+"""Tests for input validation and sanitization."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from pycodemcp.validation import InputValidator, PathValidator, ValidationError, validate_mcp_inputs
+
+
+class TestPathValidator:
+    """Test path validation and sanitization."""
+
+    def test_validate_normal_path(self):
+        """Test validation of normal paths."""
+        # Absolute path
+        result = PathValidator.validate_path("/home/user/project/file.py")
+        assert isinstance(result, Path)
+        assert result.is_absolute()
+
+        # Relative path
+        result = PathValidator.validate_path("src/module.py")
+        assert isinstance(result, Path)
+
+    def test_reject_path_traversal(self):
+        """Test rejection of path traversal attempts."""
+        dangerous_paths = [
+            "../../../etc/passwd",
+            "../../.ssh/id_rsa",
+            "/home/user/../../../etc/shadow",
+            "test/../../secret.txt",
+            "..\\..\\windows\\system32",
+        ]
+
+        for path in dangerous_paths:
+            with pytest.raises(ValidationError) as exc_info:
+                PathValidator.validate_path(path)
+            assert "suspicious pattern" in str(exc_info.value).lower()
+
+    def test_reject_null_bytes(self):
+        """Test rejection of paths with null bytes."""
+        with pytest.raises(ValidationError) as exc_info:
+            PathValidator.validate_path("/path/with\x00null")
+        assert "null bytes" in str(exc_info.value).lower()
+
+    def test_empty_path(self):
+        """Test rejection of empty paths."""
+        with pytest.raises(ValidationError) as exc_info:
+            PathValidator.validate_path("")
+        assert "empty" in str(exc_info.value).lower()
+
+    def test_base_path_restriction(self):
+        """Test path restriction within base directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            allowed = base / "subdir" / "file.py"
+
+            # Should allow paths within base
+            result = PathValidator.validate_path(allowed, base)
+            assert result.is_absolute()
+
+            # Should reject paths outside base
+            outside = Path("/etc/passwd")
+            with pytest.raises(ValidationError) as exc_info:
+                PathValidator.validate_path(outside, base)
+            assert "outside base directory" in str(exc_info.value)
+
+    def test_warns_on_sensitive_paths(self, caplog):
+        """Test warning on potentially sensitive paths."""
+        import logging
+
+        # Set logging level to capture warnings
+        caplog.set_level(logging.WARNING)
+        # This should warn but not fail
+        PathValidator.validate_path(".git/config")
+        assert "potentially sensitive" in caplog.text.lower()
+
+    def test_is_safe_to_read(self):
+        """Test file safety checks."""
+        with tempfile.NamedTemporaryFile(suffix=".py") as tmpfile:
+            # Write some content
+            tmpfile.write(b"print('hello')")
+            tmpfile.flush()
+
+            # Should be safe to read
+            assert PathValidator.is_safe_to_read(tmpfile.name)
+
+            # Non-existent file
+            assert not PathValidator.is_safe_to_read("/nonexistent/file.py")
+
+            # Directory (not a file)
+            assert not PathValidator.is_safe_to_read(Path(tmpfile.name).parent)
+
+    def test_large_file_warning(self, caplog):
+        """Test warning for large files."""
+        with tempfile.NamedTemporaryFile(suffix=".py") as tmpfile:
+            # Write large content
+            tmpfile.write(b"x" * (11 * 1024 * 1024))  # 11MB
+            tmpfile.flush()
+
+            # Should not be safe to read
+            assert not PathValidator.is_safe_to_read(tmpfile.name)
+            assert "too large" in caplog.text.lower()
+
+
+class TestInputValidator:
+    """Test general input validation."""
+
+    def test_validate_identifier(self):
+        """Test Python identifier validation."""
+        # Valid identifiers
+        assert InputValidator.validate_identifier("my_function") == "my_function"
+        assert InputValidator.validate_identifier("_private") == "_private"
+        assert InputValidator.validate_identifier("Class123") == "Class123"
+
+        # Valid module names (with dots)
+        assert (
+            InputValidator.validate_identifier("package.module", allow_dots=True)
+            == "package.module"
+        )
+        assert InputValidator.validate_identifier("a.b.c.d", allow_dots=True) == "a.b.c.d"
+
+        # Invalid identifiers
+        with pytest.raises(ValidationError):
+            InputValidator.validate_identifier("123invalid")
+
+        with pytest.raises(ValidationError):
+            InputValidator.validate_identifier("my-function")
+
+        with pytest.raises(ValidationError):
+            InputValidator.validate_identifier("module.name", allow_dots=False)
+
+    def test_validate_line_number(self):
+        """Test line number validation."""
+        # Valid line numbers
+        assert InputValidator.validate_line_number(1) == 1
+        assert InputValidator.validate_line_number("42") == 42
+        assert InputValidator.validate_line_number(10000) == 10000
+
+        # Invalid line numbers
+        with pytest.raises(ValidationError):
+            InputValidator.validate_line_number(0)
+
+        with pytest.raises(ValidationError):
+            InputValidator.validate_line_number(-5)
+
+        with pytest.raises(ValidationError):
+            InputValidator.validate_line_number(10000000)
+
+        with pytest.raises(ValidationError):
+            InputValidator.validate_line_number("not a number")
+
+    def test_validate_column_number(self):
+        """Test column number validation."""
+        # Valid column numbers
+        assert InputValidator.validate_column_number(0) == 0
+        assert InputValidator.validate_column_number("42") == 42
+        assert InputValidator.validate_column_number(100) == 100
+
+        # Invalid column numbers
+        with pytest.raises(ValidationError):
+            InputValidator.validate_column_number(-1)
+
+        with pytest.raises(ValidationError):
+            InputValidator.validate_column_number(100000)
+
+        with pytest.raises(ValidationError):
+            InputValidator.validate_column_number("invalid")
+
+    def test_sanitize_string(self):
+        """Test string sanitization."""
+        # Normal string
+        assert InputValidator.sanitize_string("hello world") == "hello world"
+
+        # String with null bytes
+        assert InputValidator.sanitize_string("hello\x00world") == "helloworld"
+
+        # String with control characters
+        assert InputValidator.sanitize_string("hello\x07\x08world") == "helloworld"
+
+        # Long string (should truncate)
+        long_str = "x" * 20000
+        result = InputValidator.sanitize_string(long_str)
+        assert len(result) == 10000
+
+        # Empty string
+        assert InputValidator.sanitize_string("") == ""
+        assert InputValidator.sanitize_string(None) == ""
+
+
+class TestValidateMCPInputsDecorator:
+    """Test the validation decorator for MCP functions."""
+
+    def test_decorator_validates_paths(self):
+        """Test that decorator validates path parameters."""
+
+        @validate_mcp_inputs
+        def test_func(file: str, project_path: str = "."):
+            return {"file": file, "project_path": project_path}
+
+        # Valid paths
+        result = test_func("/valid/path.py", "/project")
+        assert "error" not in result
+
+        # Invalid path
+        result = test_func("../../etc/passwd", "/project")
+        assert "error" in result
+        assert "Invalid file" in result["error"]
+
+    def test_decorator_validates_line_column(self):
+        """Test that decorator validates line and column parameters."""
+
+        @validate_mcp_inputs
+        def test_func(line: int, column: int):
+            return {"line": line, "column": column}
+
+        # Valid values
+        result = test_func(10, 5)
+        assert result == {"line": 10, "column": 5}
+
+        # Invalid line
+        result = test_func(-1, 5)
+        assert "error" in result
+        assert "Invalid line" in result["error"]
+
+        # Invalid column
+        result = test_func(10, -1)
+        assert "error" in result
+        assert "Invalid column" in result["error"]
+
+    def test_decorator_validates_identifiers(self):
+        """Test that decorator validates identifier parameters."""
+
+        @validate_mcp_inputs
+        def test_func(name: str, module_name: str):
+            return {"name": name, "module_name": module_name}
+
+        # Valid identifiers
+        result = test_func("my_func", "package.module")
+        assert result == {"name": "my_func", "module_name": "package.module"}
+
+        # Invalid identifier
+        result = test_func("123invalid", "package.module")
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_decorator_validates_path_lists(self):
+        """Test that decorator validates lists of paths."""
+
+        @validate_mcp_inputs
+        def test_func(paths: list, packages: list):
+            return {"paths": paths, "packages": packages}
+
+        # Valid paths
+        result = test_func(["/path1", "/path2"], ["/pkg1", "/pkg2"])
+        assert "error" not in result
+
+        # List with invalid path
+        result = test_func(["/valid", "../../etc/passwd"], ["/pkg1"])
+        assert "error" in result
+        assert "Invalid path in paths" in result["error"]
+
+    def test_decorator_handles_none_values(self):
+        """Test that decorator handles None values gracefully."""
+
+        @validate_mcp_inputs
+        def test_func(file: str = None, name: str = None):
+            return {"file": file, "name": name}
+
+        # None values should pass through
+        result = test_func()
+        assert result == {"file": None, "name": None}
+        assert "error" not in result


### PR DESCRIPTION
## Summary
Implements comprehensive input validation and sanitization to prevent security vulnerabilities such as path traversal attacks, null byte injection, and invalid inputs.

## Changes

### Security Enhancements
- **PathValidator class** for secure file path handling
  - Prevents path traversal attacks (`../`, `..\\`)
  - Blocks null byte injection
  - Validates paths stay within base directory
  - Warns on access to sensitive paths (`.git/`, `.ssh/`, `.env`, etc.)

- **InputValidator class** for general input sanitization
  - Validates Python identifiers and module names
  - Range-checks line and column numbers  
  - Sanitizes strings (removes control characters, enforces length limits)

- **@validate_mcp_inputs decorator**
  - Applied to all MCP tool functions
  - Automatically validates paths, identifiers, and numeric inputs
  - Returns clear error messages for invalid inputs

### Implementation Details
- Updated configuration module to validate paths from config files
- Safe glob pattern expansion
- Invalid paths are logged and skipped rather than causing crashes
- All file access points now use validation

### Testing
- Added comprehensive test suite with 17 tests
- Tests cover path traversal prevention, input sanitization, and decorator functionality
- All tests passing

### Documentation
- Added Security section to DOCUMENTATION.md
- Includes best practices, examples of blocked patterns, and configuration recommendations

### Additional Fixes
- Resolved pre-commit configuration conflict between isort and ruff
- Removed standalone isort hook (ruff handles import sorting via "I" rule)
- Configured ruff's isort settings for black compatibility

Closes #1

## Test Plan
- [x] All tests pass (`uv run pytest tests/test_validation.py -v`)
- [x] Pre-commit hooks pass
- [x] Security vulnerabilities blocked (path traversal, null bytes)
- [x] Valid inputs work normally
- [x] Invalid inputs return helpful error messages

🤖 Generated with [Claude Code](https://claude.ai/code)