### PR TITLE
fix: Replace environment variable configuration with override files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,11 @@ cython_debug/
 # Cache directory for our MCP server
 .pycodemcp_cache/
 
+# Local override configuration files
+.pycodemcp.override.json
+.pycodemcp.local.json
+*.override.json
+
 # uv
 uv.lock
 .venv/

--- a/README.md
+++ b/README.md
@@ -123,13 +123,31 @@ The server can be configured to analyze packages in other locations. Create a `.
 
 ### Configuration Methods
 
-1. **Config File**: `.pycodemcp.json` in project root
-2. **pyproject.toml**: `[tool.pycodemcp]` section
-3. **Environment Variables**:
-   - `PYCODEMCP_PACKAGES=/path1:/path2`
-   - `PYCODEMCP_NAMESPACE_company=~/repos/company-auth:~/repos/company-api`
-4. **Global Config**: `~/.config/pycodemcp/config.json`
-5. **Auto-Discovery**: Automatically finds sibling packages
+Configuration is loaded in the following order (later sources override earlier ones):
+
+1. **Global Config**: `~/.config/pycodemcp/config.json` or `~/.pycodemcp.json` - User defaults
+2. **Project Config**: `.pycodemcp.json` in project root or `[tool.pycodemcp]` in `pyproject.toml`
+3. **Override File**: `.pycodemcp.override.json` - Local development overrides (git-ignored)
+4. **Auto-Discovery**: Automatically finds sibling packages if no packages configured
+
+### Using Override Files
+
+Override files are perfect for local development configurations that shouldn't be committed:
+
+```json
+// .pycodemcp.override.json (git-ignored)
+{
+  "packages": [
+    "../my-local-dev-package",
+    "~/dev/experimental"
+  ],
+  "namespaces": {
+    "company.feature": ["/home/user/feature-branch"]
+  }
+}
+```
+
+This file is automatically ignored by git and takes precedence over all other configuration sources.
 
 ## Core Tools
 

--- a/src/pycodemcp/config.py
+++ b/src/pycodemcp/config.py
@@ -34,19 +34,28 @@ class ProjectConfig:
         self.load_config()
 
     def load_config(self) -> None:
-        """Load configuration from various sources."""
-        # 1. Check for config files in project
+        """Load configuration from various sources.
+
+        Loading order (later sources override earlier ones):
+        1. Global config (~/.config/pycodemcp/config.json)
+        2. Project config files (.pycodemcp.json, pyproject.toml, etc.)
+        3. Override file (.pycodemcp.override.json) - for local development
+        4. Auto-discovery (if no packages configured)
+        """
+        # 1. Load global config first (lowest precedence)
+        self._load_global_config()
+
+        # 2. Load project config files
         for config_file in self.CONFIG_FILES:
             config_path = self.project_path / config_file
             if config_path.exists():
                 self._load_from_file(config_path)
                 break
 
-        # 2. Check environment variables
-        self._load_from_env()
-
-        # 3. Check for global config
-        self._load_global_config()
+        # 3. Load override file (highest precedence)
+        override_path = self.project_path / ".pycodemcp.override.json"
+        if override_path.exists():
+            self._load_from_file(override_path)
 
         # 4. Auto-discover if no config found
         if not self.config.get("packages"):
@@ -83,21 +92,11 @@ class ProjectConfig:
         except Exception as e:
             logger.error(f"Error loading config from {config_path}: {e}")
 
-    def _load_from_env(self) -> None:
-        """Load configuration from environment variables."""
-        # PYCODEMCP_PACKAGES=/path/to/pkg1:/path/to/pkg2
-        if "PYCODEMCP_PACKAGES" in os.environ:
-            packages = os.environ["PYCODEMCP_PACKAGES"].split(":")
-            self.config.setdefault("packages", []).extend(packages)
-
-        # PYCODEMCP_NAMESPACE_company=/repos/company-*
-        for key, value in os.environ.items():
-            if key.startswith("PYCODEMCP_NAMESPACE_"):
-                namespace = key.replace("PYCODEMCP_NAMESPACE_", "").replace("_", ".")
-                self.config.setdefault("namespaces", {})[namespace] = value.split(":")
-
     def _load_global_config(self) -> None:
-        """Load global configuration from user home."""
+        """Load global configuration from user home.
+
+        Global config provides defaults that can be overridden by project config.
+        """
         global_configs = [
             Path.home() / ".config" / "pycodemcp" / "config.json",
             Path.home() / ".pycodemcp.json",
@@ -108,9 +107,9 @@ class ProjectConfig:
                 try:
                     with open(config_path) as f:
                         global_config = json.load(f)
-                        # Global config has lower precedence
-                        for key, value in global_config.items():
-                            self.config.setdefault(key, value)
+                        # Global config loaded first, so just update
+                        self.config.update(global_config)
+                        logger.info(f"Loaded global config from {config_path}")
                         break
                 except Exception as e:
                     logger.error(f"Error loading global config: {e}")

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -208,33 +208,32 @@ class User(BaseModel):
 
     def test_configuration_precedence_workflow(self, temp_project_dir):
         """Test configuration loading from multiple sources."""
-        import os
 
         # 1. Create local config
         local_config = temp_project_dir / ".pycodemcp.json"
         local_config.write_text(json.dumps({"packages": ["local_package"], "cache_ttl": 100}))
 
-        # 2. Set environment variables
-        with patch.dict(
-            os.environ, {"PYCODEMCP_PACKAGES": "env_package", "PYCODEMCP_CACHE_TTL": "200"}
-        ):
-            # 3. Create global config
-            global_dir = temp_project_dir / ".config" / "pycodemcp"
-            global_dir.mkdir(parents=True)
-            global_config = global_dir / "config.json"
-            global_config.write_text(json.dumps({"packages": ["global_package"], "cache_ttl": 300}))
+        # 2. Create override config (replaces ENV vars)
+        override_config = temp_project_dir / ".pycodemcp.override.json"
+        override_config.write_text(json.dumps({"packages": ["override_package"], "debug": True}))
 
-            # Load configuration
-            with patch.object(Path, "home", return_value=temp_project_dir):
-                config = ProjectConfig(str(temp_project_dir))
+        # 3. Create global config
+        global_dir = temp_project_dir / ".config" / "pycodemcp"
+        global_dir.mkdir(parents=True)
+        global_config = global_dir / "config.json"
+        global_config.write_text(json.dumps({"packages": ["global_package"], "cache_ttl": 300}))
 
-                # Local config should take precedence for cache_ttl
-                assert config.config["cache_ttl"] == 100
+        # Load configuration
+        with patch.object(Path, "home", return_value=temp_project_dir):
+            config = ProjectConfig(str(temp_project_dir))
 
-                # Packages should be merged
-                packages = config.config.get("packages", [])
-                assert "local_package" in packages
-                assert "env_package" in packages
+            # Local config cache_ttl should be preserved
+            assert config.config["cache_ttl"] == 100
+
+            # Override packages should win
+            packages = config.config.get("packages", [])
+            assert "override_package" in packages
+            assert config.config.get("debug") is True
 
     def test_error_recovery_workflow(self, temp_project_dir):
         """Test system recovery from various error conditions."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,21 +96,44 @@ packages = {json.dumps(toml_config["packages"])}
         # JSON should take precedence
         assert config.config["packages"] == ["json_package"]
 
-    def test_load_from_environment(self, temp_project_dir, monkeypatch):
-        """Test loading configuration from environment variables."""
-        monkeypatch.setenv("PYCODEMCP_PACKAGES", "/path1:/path2:/path3")
-        monkeypatch.setenv("PYCODEMCP_NAMESPACE_company_auth", "/repos/auth:/repos/login")
-        monkeypatch.setenv("PYCODEMCP_NAMESPACE_company_api", "/repos/api")
+    def test_load_override_file(self, temp_project_dir):
+        """Test loading configuration from override file."""
+        # Create base config
+        base_config = {"packages": ["base_package"], "namespaces": {"base.ns": ["/base/path"]}}
+        config_file = temp_project_dir / ".pycodemcp.json"
+        config_file.write_text(json.dumps(base_config))
+
+        # Create override config
+        override_config = {
+            "packages": ["override_package"],
+            "namespaces": {"override.ns": ["/override/path"]},
+        }
+        override_file = temp_project_dir / ".pycodemcp.override.json"
+        override_file.write_text(json.dumps(override_config))
 
         config = ProjectConfig(str(temp_project_dir))
 
-        assert "/path1" in config.config.get("packages", [])
-        assert "/path2" in config.config.get("packages", [])
-        assert "/path3" in config.config.get("packages", [])
+        # Override should replace base values
+        assert "override_package" in config.config.get("packages", [])
+        assert "override.ns" in config.config.get("namespaces", {})
 
-        namespaces = config.config.get("namespaces", {})
-        assert "company.auth" in namespaces
-        assert "/repos/auth" in namespaces["company.auth"]
+    def test_override_precedence(self, temp_project_dir):
+        """Test that override file has highest precedence."""
+        # Create base config with a value
+        base_config = {"cache_ttl": 100, "packages": ["base"]}
+        config_file = temp_project_dir / ".pycodemcp.json"
+        config_file.write_text(json.dumps(base_config))
+
+        # Create override config with different value
+        override_config = {"cache_ttl": 500, "packages": ["override"]}
+        override_file = temp_project_dir / ".pycodemcp.override.json"
+        override_file.write_text(json.dumps(override_config))
+
+        config = ProjectConfig(str(temp_project_dir))
+
+        # Override values should win
+        assert config.config.get("cache_ttl") == 500
+        assert config.config.get("packages") == ["override"]
 
     @patch.object(Path, "home")
     def test_load_global_config(self, mock_home, temp_project_dir):
@@ -150,23 +173,25 @@ packages = {json.dumps(toml_config["packages"])}
             if not config.config.get("packages"):
                 mock_discover.assert_called()
 
-    def test_merge_configs(self, temp_project_dir, monkeypatch):
+    def test_merge_configs(self, temp_project_dir):
         """Test that configs from different sources are merged."""
-        # Local config
-        local_config = {"packages": ["local_pkg"], "cache_ttl": 300}
+        # Base config
+        base_config = {"packages": ["base_pkg"], "cache_ttl": 300}
         config_file = temp_project_dir / ".pycodemcp.json"
-        config_file.write_text(json.dumps(local_config))
+        config_file.write_text(json.dumps(base_config))
 
-        # Environment config
-        monkeypatch.setenv("PYCODEMCP_PACKAGES", "/env_pkg")
+        # Override config
+        override_config = {"packages": ["override_pkg"], "debug": True}
+        override_file = temp_project_dir / ".pycodemcp.override.json"
+        override_file.write_text(json.dumps(override_config))
 
         config = ProjectConfig(str(temp_project_dir))
 
-        # Should have both local and env packages
+        # Override should replace packages but other settings remain
         packages = config.config.get("packages", [])
-        assert "local_pkg" in packages
-        assert "/env_pkg" in packages
-        assert config.config["cache_ttl"] == 300
+        assert "override_pkg" in packages
+        assert config.config.get("cache_ttl") == 300  # From base
+        assert config.config.get("debug") is True  # From override
 
     def test_invalid_json_config(self, temp_project_dir, caplog):
         """Test handling of invalid JSON config files."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -625,9 +625,13 @@ class TestFindSymbolMulti:
 
         result = find_symbol_multi("test", ["/proj1", "/proj2"])
 
-        assert "/proj1" in result
-        assert "/proj2" in result
+        # Check that both projects are in results, handling platform-specific paths
+        result_keys = list(result.keys())
         assert len(result) == 2
+        # On Windows, paths may be resolved to full paths like "D:\proj1"
+        # Check that keys end with the expected directory names
+        assert any("proj1" in key for key in result_keys)
+        assert any("proj2" in key for key in result_keys)
         # Should call get_project for each path
         assert mock_manager.get_project.call_count == 2
 


### PR DESCRIPTION
## Summary

This PR replaces the problematic environment variable configuration system with a cleaner override file approach, fixing Windows test failures and providing a better configuration experience.

## Changes

- 🗑️ Removed  method and all ENV var parsing code
- ✨ Added support for  file (git-ignored)
- 🔄 Updated configuration loading order: global → project → override
- 🐛 Fixed cross-platform path issues in 
- ✅ Updated tests to use override files instead of ENV vars
- 📝 Updated documentation with new configuration approach

## Problem Solved

The environment variable configuration had fundamental flaws:
1. **Windows test failures** - ENV var names become uppercase on Windows
2. **Namespace encoding issues** - Can't distinguish  vs 
3. **Non-reversible transformation** - Information lost in encoding

## New Configuration System

### Loading Order (later overrides earlier):
1. Global config ()
2. Project config ( or )
3. Override file () - for local development

### Example Override File:
```json
// .pycodemcp.override.json (git-ignored)
{
  "packages": ["../my-local-dev-package"],
  "namespaces": {
    "company.feature": ["/home/user/feature-branch"]
  }
}
```

## Testing

- ✅ All configuration tests pass
- ✅ Cross-platform path test fixed
- ✅ Integration tests updated
- ✅ Pre-commit hooks pass

## Breaking Change

⚠️ **Breaking**: Environment variable configuration is removed. Users must migrate to override files:

**Before:**
```bash
export PYCODEMCP_PACKAGES="/path1:/path2"
```

**After:**
```bash
echo '{"packages": ["/path1", "/path2"]}' > .pycodemcp.override.json
```

Fixes #19