### PR TITLE
feat: Add coverage percentage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Python Code Intelligence MCP Server
 
 [![CI](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/okeefeco/python-code-intelligence-mcp)](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
## Summary
- Adds a Codecov coverage badge to display the current test coverage percentage
- Badge is positioned after the CI badge for logical grouping  
- Links directly to the Codecov dashboard for detailed coverage reports

## Test Plan
- [x] Badge syntax is valid and follows shields.io format
- [x] Badge URL correctly points to the project's Codecov page
- [ ] Badge displays coverage percentage after next CI run

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/code)