### PR TITLE
fix: Add CODECOV_TOKEN to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   type-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds CODECOV_TOKEN to the Codecov upload step in CI workflow
- Resolves 429 rate limit errors preventing coverage uploads
- Enables the coverage badge to display actual percentage

## Test Plan
- [x] Workflow syntax is valid
- [x] Token reference uses correct GitHub secrets syntax
- [ ] Codecov upload will succeed with token (verified after merge)

Fixes #28

🤖 Generated with [Claude Code](https://claude.ai/code)