### PR TITLE
feat: Add workflow_dispatch trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds workflow_dispatch trigger to enable manual CI runs
- Useful for testing CI changes and Codecov integration

## Test Plan
- [x] Workflow syntax is valid
- [ ] Manual trigger works after merge

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)