### PR TITLE
fix: Use Codecov's native badge format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Python Code Intelligence MCP Server
 
 [![CI](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/codecov/c/github/okeefeco/python-code-intelligence-mcp)](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp)
+[![codecov](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp/graph/badge.svg)](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
## Summary
- Switches from shields.io wrapper to Codecov's native badge format
- This may resolve the "unknown" coverage display issue

## Context
The shields.io badge wrapper shows "unknown" even though Codecov has the coverage data. Using Codecov's native badge format might work better.

## Test Plan
- [x] Badge syntax is valid
- [ ] Check if badge displays coverage percentage after merge

Related to #26

🤖 Generated with [Claude Code](https://claude.ai/code)