### PR TITLE
fix: Add token to Codecov badge for private repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Python Code Intelligence MCP Server
 
 [![CI](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp/graph/badge.svg)](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp)
+[![codecov](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp/graph/badge.svg?token=XE5T93O8EC)](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
## Summary
- Adds badge token to Codecov badge URL to enable coverage display
- Required for private repositories to show coverage percentage

## Test Plan
- [x] Badge URL is valid with token parameter
- [ ] Badge should display actual coverage percentage (currently 66%)

Fixes #33

🤖 Generated with [Claude Code](https://claude.ai/code)