### PR TITLE
fix: correct CI badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python Code Intelligence MCP Server
 
-[![CI](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml)
+[![CI](https://github.com/okeefeco/python-code-intelligence-mcp/workflows/CI/badge.svg)](https://github.com/okeefeco/python-code-intelligence-mcp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp/graph/badge.svg?token=XE5T93O8EC)](https://codecov.io/gh/okeefeco/python-code-intelligence-mcp)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
## Summary
- Fixed incorrect CI badge URL format in README.md
- Changed from  to 

## Problem
The README was displaying a failing CI badge even though CI was passing on the main branch. The badge URL was using an incorrect format that resulted in a 404.

## Solution
Updated line 3 in README.md to use the correct GitHub workflows badge URL format as confirmed by the GitHub API.

## Testing
- Badge URL format verified against GitHub API
- Pre-commit hooks passed
- Badge will display correctly for authenticated users (private repo)

Fixes #54