### PR TITLE
fix: Re-enable test_goto_definition_not_found with proper mocking

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -322,9 +322,19 @@ class TestGotoDefinition:
 
     @patch("pycodemcp.server.get_analyzer")
     @pytest.mark.asyncio
-    async def test_goto_definition_not_found(self, mock_get_analyzer):  # noqa: ARG002
+    async def test_goto_definition_not_found(self, mock_get_analyzer):
         """Test goto definition when symbol not found."""
-        pytest.skip("Test needs refactoring after architecture changes")
+        # Mock analyzer
+        mock_analyzer = AsyncMock()
+        mock_get_analyzer.return_value = mock_analyzer
+
+        # Mock returning None (no definition found)
+        mock_analyzer.goto_definition.return_value = None
+
+        result = await goto_definition("test.py", 10, 5)
+
+        assert result is None
+        mock_analyzer.goto_definition.assert_called_with("test.py", 10, 5)
 
 
 class TestFindReferences:


### PR DESCRIPTION
## Summary
- Re-enabled the previously skipped `test_goto_definition_not_found` test in `tests/test_server.py`
- Updated the test to use the new architecture introduced in PR #17

## Background
During the refactoring in PR #17, the Jedi-related logic was moved from `server.py` directly into the `JediAnalyzer` class for better separation of concerns. The test was skipped at that time because it needed to be updated to mock the analyzer instead of Jedi directly.

## Changes Made
- Updated the test to mock the analyzer (following the pattern of the working `test_goto_definition` test)
- Mock now returns `None` to simulate no definition found
- Test verifies that `goto_definition` correctly returns `None` when no definition is found
- Test verifies the analyzer was called with the correct parameters

## Test Results
- The specific test now passes ✅
- All tests pass with full coverage requirements met ✅
- Coverage remains above the 85% threshold ✅

Fixes #130