### PR TITLE
refactor: Replace print statements with logging in settings.py

### DIFF
--- a/src/pycodemcp/settings.py
+++ b/src/pycodemcp/settings.py
@@ -1,6 +1,9 @@
 """Performance settings for Python Code Intelligence MCP Server."""
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 
 class PerformanceSettings:
@@ -77,16 +80,16 @@ class PerformanceSettings:
             value = int(os.getenv(key, str(default)))
 
             if min_val is not None and value < min_val:
-                print(f"Warning: {key}={value} below minimum {min_val}, using {min_val}")
+                logger.warning(f"{key}={value} below minimum {min_val}, using {min_val}")
                 return min_val
 
             if max_val is not None and value > max_val:
-                print(f"Warning: {key}={value} above maximum {max_val}, using {max_val}")
+                logger.warning(f"{key}={value} above maximum {max_val}, using {max_val}")
                 return max_val
 
             return value
         except ValueError:
-            print(f"Warning: Invalid value for {key}, using default {default}")
+            logger.warning(f"Invalid value for {key}, using default {default}")
             return default
 
     def _get_float_env(
@@ -111,16 +114,16 @@ class PerformanceSettings:
             value = float(os.getenv(key, str(default)))
 
             if min_val is not None and value < min_val:
-                print(f"Warning: {key}={value} below minimum {min_val}, using {min_val}")
+                logger.warning(f"{key}={value} below minimum {min_val}, using {min_val}")
                 return min_val
 
             if max_val is not None and value > max_val:
-                print(f"Warning: {key}={value} above maximum {max_val}, using {max_val}")
+                logger.warning(f"{key}={value} above maximum {max_val}, using {max_val}")
                 return max_val
 
             return value
         except ValueError:
-            print(f"Warning: Invalid value for {key}, using default {default}")
+            logger.warning(f"Invalid value for {key}, using default {default}")
             return default
 
     def _get_bool_env(self, key: str, default: bool) -> bool:


### PR DESCRIPTION
## Summary
- Replace 6 print statements with proper logging in `src/pycodemcp/settings.py`
- Add logging import and logger setup
- Convert validation warnings to use `logger.warning()` instead of `print()`

## Changes Made
- Added logging import and logger instance to settings.py
- Replaced print statements on lines 83, 87, 92 (integer validation)
- Replaced print statements on lines 117, 121, 126 (float validation)

## Benefits
- Consistent with rest of codebase logging patterns
- Allows users to control warning output through logging configuration
- Maintains proper separation between user warnings and debug info

## Testing
- All tests pass (87.38% coverage, exceeds 85% requirement)
- Pre-commit hooks pass
- No breaking changes

Fixes #139

🤖 Generated with [Claude Code](https://claude.ai/code)