### PR TITLE
🚨 CRITICAL: Fix syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: dist/python-code-intelligence-mcp-${{ steps.version.outputs.version }}.tar.gz
-          asset_name: python-code-intelligence-mcp-${{ steps.version.outputs.version }.tar.gz
+          asset_name: python-code-intelligence-mcp-${{ steps.version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 
   # Notify about the release


### PR DESCRIPTION
## 🚨 Critical Fix for Release Workflow

This PR fixes a **critical syntax error** that was preventing the release workflow from running.

### The Bug
Line 184 of `.github/workflows/release.yml` had a missing closing brace in a GitHub expression:
```yaml
# WRONG (missing closing brace):
asset_name: python-code-intelligence-mcp-${{ steps.version.outputs.version }.tar.gz

# FIXED:
asset_name: python-code-intelligence-mcp-${{ steps.version.outputs.version }}.tar.gz
```

### Impact
This syntax error was causing:
- ❌ All workflow runs to fail with 0s duration
- ❌ Tag pushes (like v0.1.0) not triggering the release workflow
- ❌ Manual workflow dispatch to fail
- ❌ Workflow showing as ".github/workflows/release.yml" instead of "Release" in API

### Solution
Added the missing closing brace `}` to complete the expression `${{ steps.version.outputs.version }}`.

### Testing
After merging this fix:
1. The release workflow will be parseable again
2. We can manually trigger it for the v0.1.0 tag
3. Future tags will automatically trigger the workflow

### Urgency
**This needs to be merged immediately** to unblock the v0.1.0 release.