### PR TITLE
🚨 URGENT: Fix release workflow coverage issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,9 @@ jobs:
 
       - name: Validate version consistency
         run: |
-          # Run our new version consistency tests
-          pytest tests/test_version_consistency.py -v
+          # Run our version consistency tests WITHOUT coverage requirements
+          # (These tests only check version files, not the full codebase)
+          pytest tests/test_version_consistency.py -v --no-cov
           echo "✅ Version consistency validated"
 
       - name: Extract version from tag


### PR DESCRIPTION
## 🚨 Another Critical Fix for Release Workflow

This fixes the second issue preventing the v0.1.0 release.

### The Problem
The release workflow is failing at the version consistency validation step because:
- The tests run with default pytest settings which include coverage requirements
- Only 3 test files run (version consistency tests)
- This results in 17% coverage, failing the 85% threshold

### The Solution
Add `--no-cov` flag to the version consistency test command, matching what we already did in the dev version workflow.

### Change
```yaml
# Before:
pytest tests/test_version_consistency.py -v

# After:
pytest tests/test_version_consistency.py -v --no-cov
```

### Impact
Without this fix:
- ❌ Release workflow fails at validation step
- ❌ v0.1.0 release cannot proceed
- ❌ All future releases blocked

### Testing
After merging, we'll need to move the v0.1.0 tag again to include this fix.

### Urgency
**This needs immediate merge to complete the v0.1.0 release.**