### PR TITLE
fix: complete release workflow fixes for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,17 +128,27 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          # Use commitizen to generate changelog for this version
-          cz changelog --incremental --file-format md > RELEASE_NOTES.md
+          # Try to use commitizen to generate changelog for this version
+          # Note: --incremental generates from last version tag
+          cz changelog --incremental --dry-run > RELEASE_NOTES.md 2>/dev/null || true
 
-          # If cz changelog didn't generate content, create basic release notes
+          # If cz changelog didn't generate content or failed, create basic release notes
           if [ ! -s RELEASE_NOTES.md ]; then
             echo "## Release ${{ steps.version.outputs.tag }}" > RELEASE_NOTES.md
             echo "" >> RELEASE_NOTES.md
             echo "### Changes" >> RELEASE_NOTES.md
             echo "" >> RELEASE_NOTES.md
-            # Get commits since last tag
-            git log $(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")..HEAD --oneline --pretty=format:"- %s" >> RELEASE_NOTES.md || echo "- Initial release" >> RELEASE_NOTES.md
+            # Get commits since last tag or all commits if first release
+            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+            if [ -z "$LAST_TAG" ]; then
+              echo "First release - including all commits" >> RELEASE_NOTES.md
+              echo "" >> RELEASE_NOTES.md
+              git log --oneline --pretty=format:"- %s" | head -20 >> RELEASE_NOTES.md
+            else
+              echo "Changes since $LAST_TAG:" >> RELEASE_NOTES.md
+              echo "" >> RELEASE_NOTES.md
+              git log ${LAST_TAG}..HEAD --oneline --pretty=format:"- %s" >> RELEASE_NOTES.md
+            fi
           fi
 
           echo "Generated release notes:"


### PR DESCRIPTION
## Final Fix for Release Workflow

This PR completes the fixes needed for a fully working release workflow.

### Problem #3: Changelog Generation
The workflow was using an invalid commitizen flag `--file-format md` which doesn't exist.

### Solution
- Use `cz changelog --incremental --dry-run` (correct syntax)
- Redirect errors and allow failure with `|| true`
- Robust fallback to git log if commitizen fails
- Handle both first release and subsequent releases properly

### Complete List of Fixes Applied
1. **PR #159** ✅ - Fixed syntax error (missing brace)
2. **PR #160** ✅ - Fixed coverage requirement issue
3. **This PR** - Fixed changelog generation command

### Testing
After merging this, we'll move the v0.1.0 tag one final time to include all three fixes.

### The Workflow Will Now:
1. ✅ Parse correctly (syntax fixed)
2. ✅ Pass version validation (coverage fixed)
3. ✅ Generate changelog properly (this fix)
4. ✅ Create GitHub release
5. ✅ Build and upload packages
6. ✅ Bump to next dev version

### Urgency
This is the final fix needed for the v0.1.0 release to complete successfully.