### PR TITLE
hotfix: Fix documentation workflow uv install failure

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -26,8 +26,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install uv
-        uv pip install sphinx sphinx-rtd-theme sphinx-autodoc-typehints myst-parser
-        uv pip install -e .
+        uv pip install --system sphinx sphinx-rtd-theme sphinx-autodoc-typehints myst-parser
+        uv pip install --system -e .
 
     - name: Build documentation
       run: |


### PR DESCRIPTION
## Problem
Documentation deployment workflow is failing due to uv requiring --system flag in GitHub Actions.

## Solution
Add --system flag to uv pip install commands in the workflow.

## Error Fixed
```
error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
```

This is a critical hotfix to enable documentation deployment.

**Fixes workflow failure preventing issue #5 completion**