### PR TITLE
hotfix: Fix Sphinx build failure in documentation

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -57,31 +57,10 @@ Analysis Tools
 Framework-Specific Tools
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Pydantic Tools
-..............
+Framework-specific tools are available via MCP when the respective frameworks are detected in your project:
 
-.. autosummary::
-   :toctree: generated
+* **Pydantic**: find_models, get_model_schema, find_validators, etc.
+* **Django**: find_django_models, find_django_views, etc.
+* **Flask**: find_routes, find_blueprints, find_views, etc.
 
-   pycodemcp.plugins.pydantic.find_models
-   pycodemcp.plugins.pydantic.get_model_schema
-   pycodemcp.plugins.pydantic.find_validators
-
-Django Tools
-............
-
-.. autosummary::
-   :toctree: generated
-
-   pycodemcp.plugins.django.find_django_models
-   pycodemcp.plugins.django.find_django_views
-
-Flask Tools
-...........
-
-.. autosummary::
-   :toctree: generated
-
-   pycodemcp.plugins.flask.find_routes
-   pycodemcp.plugins.flask.find_blueprints
-   pycodemcp.plugins.flask.find_views
+These tools are dynamically provided by the MCP server plugins and detailed in the main API documentation.


### PR DESCRIPTION
## Problem
Documentation build is failing due to Sphinx trying to import non-existent plugin modules.

## Root Cause
The autosummary directive was trying to import:
- `pycodemcp.plugins.django.find_django_models`
- `pycodemcp.plugins.pydantic.find_models` 
- `pycodemcp.plugins.flask.find_routes`

These are MCP server functions, not importable Python modules.

## Solution
Remove problematic autosummary entries and replace with descriptive text explaining that framework-specific tools are dynamically provided by the MCP server.

## Error Fixed
```
sphinx.errors.ExtensionError: Handler for event 'builder-inited' threw an exception (exception: no module named pycodemcp.plugins.django)
```

**Critical fix to enable documentation deployment**