### PR TITLE
hotfix: Fix uv virtual environment for documentation build

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -26,20 +26,21 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install uv
-        uv pip install --system sphinx sphinx-rtd-theme sphinx-autodoc-typehints myst-parser
-        uv pip install --system -e .
+        uv venv
+        uv pip install sphinx sphinx-rtd-theme sphinx-autodoc-typehints myst-parser
+        uv pip install -e .
 
     - name: Build documentation
       run: |
         cd docs
-        make html
+        uv run sphinx-build -b html source build/html
 
     - name: Upload documentation artifacts (for PR previews)
       if: github.event_name == 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: documentation-preview
-        path: docs/build/
+        path: docs/build/html/
         retention-days: 7
 
     - name: Deploy to GitHub Pages
@@ -47,7 +48,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build
+        publish_dir: docs/build/html
         # Keep history for better git management
         force_orphan: false
         # Add custom domain if you have one (optional)


### PR DESCRIPTION
## Problem
Documentation build failing with "no module named pycodemcp.server" due to package installation/environment mismatch.

## Root Cause
- Installing with `--system` while `uv run` creates its own venv
- Nested `uv run` calls causing environment confusion
- Incorrect paths for build artifacts and deployment

## Solution
1. Create explicit `uv venv` and install everything in same environment
2. Use direct `uv run sphinx-build` instead of nested calls
3. Fix `publish_dir` and artifact paths to `docs/build/html/`

## Expected Result
Documentation should build and deploy successfully to GitHub Pages.

**Final fix for issue #5 documentation deployment**