### PR TITLE
docs: add explicit uv run instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,23 @@ For personal development settings (worktrees, local paths, etc.):
 - **Working Directory**: /home/mark/GitHub/python-code-intelligence-mcp
 - **Python Environment**: uv managed
 
+### ⚠️ CRITICAL: This Project Uses `uv` Package Manager
+
+**ALWAYS prefix Python commands with `uv run`:**
+
+- ❌ **WRONG**: `pytest tests/test_file.py`
+- ✅ **RIGHT**: `uv run pytest tests/test_file.py`
+
+This applies to ALL Python tools:
+
+- `uv run pytest` - Run tests
+- `uv run black` - Format code
+- `uv run ruff` - Lint code
+- `uv run mypy` - Type checking
+- `uv run python` - Run Python scripts
+
+**Why**: Dependencies are installed in the uv-managed virtual environment, not globally.
+
 ## 🚨 MANDATORY REQUIREMENTS
 
 ### ⚠️ CRITICAL: Worktree Safety Rules
@@ -112,7 +129,7 @@ When implementing ANY feature or fix:
 
    ```bash
    # IMPORTANT: Run ALL tests, not just your new tests!
-   pytest --cov=src/pycodemcp --cov-fail-under=85
+   uv run pytest --cov=src/pycodemcp --cov-fail-under=85
    ```
 
 4. **Fix any failing tests or coverage issues**
@@ -131,7 +148,7 @@ Always run these validation commands:
 
 ```bash
 # MANDATORY: Run ALL tests with coverage (not just your new tests!)
-pytest --cov=src/pycodemcp --cov-fail-under=85
+uv run pytest --cov=src/pycodemcp --cov-fail-under=85
 
 # Note: Linting/type checks are handled by pre-commit hooks automatically
 ```


### PR DESCRIPTION
## Summary

Adds explicit `uv run` prefixes to all development commands in CLAUDE.md to prevent "command not found" errors during Claude sessions.

## Problem

When Claude tries to run commands like `pytest` or `mypy` directly, it fails with "command not found" because these tools are only available through `uv run` in our project setup. This was causing confusion and failed validation attempts.

## Changes

- Updated all command examples in CLAUDE.md to use `uv run` prefix
- Added clear instructions about uv-managed environment
- Ensures Claude sessions use the correct command format

## Impact

- Prevents command not found errors in Claude sessions
- Ensures validation commands work correctly
- Improves developer experience when following documentation

This is a documentation fix that makes our development workflow more reliable.

🤖 Generated with [Claude Code](https://claude.ai/code)