### PR TITLE
Fix post-release dev version bump and set dev version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,8 +296,8 @@ jobs:
 
       - name: Verify version consistency
         run: |
-          # Run our version consistency tests
-          uv run pytest tests/test_version_consistency.py -v
+          # Run our version consistency tests (skip coverage for version-only tests)
+          uv run pytest tests/test_version_consistency.py -v --no-cov
           echo "✅ Version consistency verified"
 
       - name: Commit development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-code-intelligence-mcp"
-version = "0.2.0"
+version = "0.2.1.dev0"
 description = "Extensible Python code intelligence MCP server for semantic analysis and code navigation"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -146,7 +146,7 @@ exclude_lines = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.2.0"
+version = "0.2.1.dev0"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",

--- a/src/pycodemcp/__init__.py
+++ b/src/pycodemcp/__init__.py
@@ -3,7 +3,7 @@
 An extensible MCP server for Python code analysis and navigation.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1.dev0"
 
 from .server import mcp
 


### PR DESCRIPTION
## Summary

- Fixes the post-release dev version bump workflow that failed after v0.2.0 release
- Manually sets version to 0.2.1.dev0 to restore dev version auto-increment functionality

## Problem

The post-release step in the release workflow failed with:
```
FAIL: Required test coverage of 85% not reached. Total coverage: 16.63%
```

This happened because the version consistency test was run without `--no-cov`, causing pytest to collect coverage for only one test file.

## Solution

1. **Fix release workflow**: Add `--no-cov` flag to the pytest command in the post-release step
2. **Set dev version**: Manually update version to `0.2.1.dev0` since the automated step failed

## Changes

- `.github/workflows/release.yml`: Add `--no-cov` to version consistency test
- `pyproject.toml`: Update version from `0.2.0` to `0.2.1.dev0`
- `src/pycodemcp/__init__.py`: Update version from `0.2.0` to `0.2.1.dev0`

## Testing

- Version consistency tests pass: ✅
- Pre-commit hooks pass: ✅
- Dev version format enables auto-increment workflow: ✅

## Impact

- Future releases will successfully bump to dev version after release
- Dev version auto-increment workflow is now active for main branch commits
- No breaking changes

Fixes #207