### PR TITLE
Fix: Handle variable version tuple length from setuptools_scm

### DIFF
--- a/src/pycodemcp/__init__.py
+++ b/src/pycodemcp/__init__.py
@@ -5,6 +5,10 @@ An extensible MCP server for Python code analysis and navigation.
 
 try:
     from ._version import __version__, __version_tuple__
+
+    # Type annotation to handle both release and dev version tuples
+    # setuptools_scm generates 3-tuple for releases, 5-tuple for dev versions
+    __version_tuple__: tuple[int, int, int] | tuple[int, int, int, str, str] = __version_tuple__
 except ImportError:
     # Package not installed or _version.py not generated yet
     __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Fix for v0.3.0 Release Failure

The v0.3.0 release failed due to a type checking error. setuptools_scm generates different tuple lengths depending on the version type.

### Problem
- Release versions (e.g., v0.3.0): 3-tuple (major, minor, patch)
- Dev versions: 5-tuple (major, minor, patch, pre, local)
- Type annotation was not flexible enough to handle both

### Solution
Added proper type annotation to handle both tuple lengths using Python 3.10+ union syntax.

### Testing
- Verified with mypy that type checking passes
- Confirmed both release and dev versions work correctly

This fix will allow the v0.3.0 release to complete successfully once merged.