### PR TITLE
test: fix failing CI test for Claude hooks documentation

### DIFF
--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -211,12 +211,14 @@ class TestDocumentation:
         assert claude_md.exists()
 
         content = claude_md.read_text(encoding="utf-8")
-        # Check for the new hooks-based approach (recommended)
+        # Check for the hooks-based approach (now active)
         assert "Claude Code Hooks Integration" in content
         assert "setup_mcp_monitoring.sh" in content
-        # Check for the alternative manual approach
-        assert "Manual Tracking Setup" in content
-        assert "setup_dogfooding.sh" in content
+        # Check that it's marked as active
+        assert "Claude Code Hooks Integration (Active)" in content
+        # Should reference the convenience commands
+        assert "mcp-report" in content
+        # Check for key sections about automatic tracking
         assert "What Happens Automatically" in content
 
     def test_all_scripts_documented(self):


### PR DESCRIPTION
## Summary
Fixes the failing CI test that was looking for deprecated dogfooding metrics documentation.

## Changes
- Updated automation test to check for current Claude hooks documentation instead of removed shell aliases system
- Test now looks for `scripts/claude_hooks/setup_mcp_monitoring.sh` which is the active monitoring system
- This resolves the CI failure on main branch caused by the test expecting documentation that was cleaned up

## Test plan
- [x] Local test passes with the updated expectations
- [x] CI should now pass as test matches current documentation structure

🤖 Generated with [Claude Code](https://claude.ai/code)