### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,8 +185,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: dist/python_code_intelligence_mcp-${{ steps.version.outputs.version }}-py3-none-any.whl
-          asset_name: python_code_intelligence_mcp-${{ steps.version.outputs.version }}-py3-none-any.whl
+          asset_path: dist/pyeye_mcp-${{ steps.version.outputs.version }}-py3-none-any.whl
+          asset_name: pyeye_mcp-${{ steps.version.outputs.version }}-py3-none-any.whl
           asset_content_type: application/octet-stream
 
       - name: Upload source distribution to release
@@ -195,8 +195,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: dist/python_code_intelligence_mcp-${{ steps.version.outputs.version }}.tar.gz
-          asset_name: python_code_intelligence_mcp-${{ steps.version.outputs.version }}.tar.gz
+          asset_path: dist/pyeye_mcp-${{ steps.version.outputs.version }}.tar.gz
+          asset_name: pyeye_mcp-${{ steps.version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 
   # Notify about the release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2025-10-04
 
 ### BREAKING CHANGES
 
@@ -49,6 +49,7 @@ This is a breaking change that requires migration steps:
 - Fixed Sphinx documentation paths for `pyeye.mcp.server` module structure
 - Fixed test mocking conflicts with new module structure
 - Restored `_version.pyi` type stub file for proper type checking
+- Updated release workflow package names from `python_code_intelligence_mcp` to `pyeye_mcp`
 
 ## [0.3.0] - 2025-08-27
 


### PR DESCRIPTION
## Summary

Prepares the v1.0.0 release with finalized CHANGELOG and corrected release workflow.

## Changes

1. **CHANGELOG.md**: 
   - Changed `[Unreleased]` → `[1.0.0] - 2025-10-04`
   - Documented complete PyEye rebrand as BREAKING CHANGE
   - Added migration instructions for users

2. **Release workflow**:
   - Updated artifact names: `python_code_intelligence_mcp` → `pyeye_mcp`
   - Corrects package names to match actual build output (PEP 503 normalization)

## Release Process After Merge

```bash
# 1. Update main worktree
cd /home/mark/GitHub/python-code-intelligence-mcp
git pull origin main

# 2. Create and push release tag
git tag -a v1.0.0 -m "Release v1.0.0: PyEye rebrand"
git push origin v1.0.0
```

The release workflow will automatically:
- Run all validation (tests, type checking, security)
- Build packages: `pyeye_mcp-1.0.0-py3-none-any.whl` and `.tar.gz`
- Create GitHub release with changelog
- Upload distribution artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)