### PR TITLE
fix: handle src-layout projects in find_imports, list_modules, list_packages

### DIFF
--- a/src/pyeye/analyzers/jedi_analyzer.py
+++ b/src/pyeye/analyzers/jedi_analyzer.py
@@ -1017,15 +1017,56 @@ class JediAnalyzer:
             for py_file in candidate_files:
                 try:
                     # Create ImportAnalyzer for the appropriate root
-                    # For files under project_path, use project_path
-                    # For files elsewhere (namespace packages), use a suitable parent
-                    try:
-                        py_file.relative_to(self.project_path)
-                        analyzer_root = self.project_path
-                    except ValueError:
-                        # File is not under project_path, find appropriate root
-                        analyzer_root = py_file.parent
-                        # Walk up to find a directory with __init__.py or that contains Python packages
+                    # Try source roots first (e.g., src/ layout) to ensure
+                    # modules in src/package/module.py are recognized as "package.module"
+                    # instead of "src.package.module"
+                    analyzer_root = None
+
+                    # Resolve py_file to handle symlinks (e.g., /var -> /private/var on macOS)
+                    py_file_resolved = py_file.resolve()
+
+                    # First check source roots
+                    for source_root in self.source_roots:
+                        try:
+                            # Resolve both paths for consistent comparison
+                            source_root_resolved = source_root.resolve()
+                            py_file_resolved.relative_to(source_root_resolved)
+                            analyzer_root = source_root_resolved
+                            break
+                        except ValueError:
+                            continue
+
+                    # Then try project_path
+                    if analyzer_root is None:
+                        try:
+                            project_path_resolved = self.project_path.resolve()
+                            py_file_resolved.relative_to(project_path_resolved)
+                            analyzer_root = project_path_resolved
+                        except ValueError:
+                            pass
+
+                    # Finally check namespace paths and fall back to walking up
+                    if analyzer_root is None:
+                        # Check namespace paths
+                        for ns_paths in self.namespace_paths.values():
+                            for ns_path in ns_paths:
+                                try:
+                                    ns_path_resolved = (
+                                        ns_path.resolve()
+                                        if isinstance(ns_path, Path)
+                                        else Path(ns_path).resolve()
+                                    )
+                                    py_file_resolved.relative_to(ns_path_resolved)
+                                    analyzer_root = ns_path_resolved
+                                    break
+                                except ValueError:
+                                    continue
+                            if analyzer_root:
+                                break
+
+                    # Last resort: walk up to find appropriate root
+                    if analyzer_root is None:
+                        analyzer_root = py_file_resolved.parent
                         while analyzer_root.parent != analyzer_root:
                             if (analyzer_root / "__init__.py").exists() or any(
                                 (analyzer_root / p).is_dir()
@@ -1320,17 +1361,41 @@ class JediAnalyzer:
             init_files = await self.get_project_files("__init__.py", scope)
             for path in init_files:
                 package_dir = path.parent
+                # Resolve to handle symlinks (e.g., /var -> /private/var on macOS)
+                package_dir_resolved = package_dir.resolve()
 
                 # Determine package name based on which search path this file belongs to
                 package_name = None
                 rel_path = None
 
-                # Try to make relative to main project first
-                try:
-                    rel_path = package_dir.relative_to(self.project_path)
-                    package_name = rel_path.as_posix().replace("/", ".")
-                except ValueError:
-                    # Not under main project, check if it's in a namespace
+                # Try source roots first (e.g., src/ layout)
+                # This ensures packages in src/package/ return "package"
+                # instead of "src.package"
+                for source_root in self.source_roots:
+                    try:
+                        # Resolve both paths for consistent comparison
+                        source_root_resolved = source_root.resolve()
+                        rel_path = package_dir_resolved.relative_to(source_root_resolved)
+                        if rel_path == Path("."):
+                            # Package is at the root of source_root
+                            package_name = package_dir.name
+                        else:
+                            package_name = rel_path.as_posix().replace("/", ".")
+                        break
+                    except ValueError:
+                        continue
+
+                # Try main project if not found in source roots
+                if not package_name:
+                    try:
+                        project_path_resolved = self.project_path.resolve()
+                        rel_path = package_dir_resolved.relative_to(project_path_resolved)
+                        package_name = rel_path.as_posix().replace("/", ".")
+                    except ValueError:
+                        pass
+
+                # Check namespace paths if still not found
+                if not package_name:
                     for ns_name, ns_paths in self.namespace_paths.items():
                         for ns_path in ns_paths:
                             try:
@@ -1412,24 +1477,53 @@ class JediAnalyzer:
             # Find all Python files in the project
             py_files = await self.get_project_files("*.py", scope)
             for py_file in py_files:
+                # Resolve to handle symlinks (e.g., /var -> /private/var on macOS)
+                py_file_resolved = py_file.resolve()
+
                 # Determine import path based on which search path this file belongs to
                 import_path = None
                 rel_path = None
 
-                # Try to make relative to main project first
-                try:
-                    rel_path = py_file.relative_to(self.project_path)
-                    module_parts = list(rel_path.parts[:-1])  # directories
-                    if py_file.name != "__init__.py":
-                        module_parts.append(py_file.stem)
-                    import_path = ".".join(module_parts) if module_parts else py_file.stem
-                except ValueError:
-                    # Not under main project, check if it's in a namespace
+                # Try source roots first (e.g., src/ layout)
+                # This ensures modules in src/package/module.py return "package.module"
+                # instead of "src.package.module"
+                for source_root in self.source_roots:
+                    try:
+                        # Resolve both paths for consistent comparison
+                        source_root_resolved = source_root.resolve()
+                        rel_path = py_file_resolved.relative_to(source_root_resolved)
+                        module_parts = list(rel_path.parts[:-1])  # directories
+                        if py_file.name != "__init__.py":
+                            module_parts.append(py_file.stem)
+                        import_path = ".".join(module_parts) if module_parts else py_file.stem
+                        break
+                    except ValueError:
+                        continue
+
+                # Try main project if not found in source roots
+                if not import_path:
+                    try:
+                        project_path_resolved = self.project_path.resolve()
+                        rel_path = py_file_resolved.relative_to(project_path_resolved)
+                        module_parts = list(rel_path.parts[:-1])  # directories
+                        if py_file.name != "__init__.py":
+                            module_parts.append(py_file.stem)
+                        import_path = ".".join(module_parts) if module_parts else py_file.stem
+                    except ValueError:
+                        pass
+
+                # Check namespace paths if still not found
+                if not import_path:
                     for ns_name, ns_paths in self.namespace_paths.items():
                         for ns_path in ns_paths:
                             try:
-                                if py_file.is_relative_to(ns_path):
-                                    ns_rel_path = py_file.relative_to(ns_path)
+                                ns_path_resolved = (
+                                    ns_path.resolve()
+                                    if isinstance(ns_path, Path)
+                                    else Path(ns_path).resolve()
+                                )
+                                if py_file_resolved.is_relative_to(ns_path_resolved):
+                                    ns_rel_path = py_file_resolved.relative_to(ns_path_resolved)
                                     module_parts = list(ns_rel_path.parts[:-1])
                                     if py_file.name != "__init__.py":
                                         module_parts.append(py_file.stem)

--- a/tests/integration/jedi_integration/test_src_layout.py
+++ b/tests/integration/jedi_integration/test_src_layout.py
@@ -426,3 +426,185 @@ where = ["src"]
         assert (
             "classes" in module_info or "functions" in module_info
         ), "Module info should have content"
+
+    @pytest.mark.asyncio
+    async def test_list_packages_uses_package_path_not_src(self, real_src_project: Path):
+        """Test that list_packages returns 'mypackage' not 'src.mypackage'.
+
+        This is a regression test for issue #281.
+        """
+        config = ProjectConfig(str(real_src_project))
+        analyzer = JediAnalyzer(str(real_src_project), config=config)
+
+        packages = await analyzer.list_packages()
+
+        # Find the mypackage entry
+        package_names = [p["name"] for p in packages]
+
+        # Should have 'mypackage', not 'src.mypackage' or 'src'
+        assert "mypackage" in package_names, (
+            f"Expected 'mypackage' in package names, got: {package_names}. "
+            "The 'src.' prefix should not appear."
+        )
+        assert "src.mypackage" not in package_names, (
+            f"Found 'src.mypackage' which is wrong - should be just 'mypackage'. "
+            f"Got: {package_names}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_modules_uses_package_path_not_src(self, real_src_project: Path):
+        """Test that list_modules returns 'mypackage.core' not 'src.mypackage.core'.
+
+        This is a regression test for issue #281.
+        """
+        config = ProjectConfig(str(real_src_project))
+        analyzer = JediAnalyzer(str(real_src_project), config=config)
+
+        modules = await analyzer.list_modules()
+
+        # Get all module import paths (the key is 'import_path', not 'module')
+        module_names = [m["import_path"] for m in modules]
+
+        # Should have modules like 'mypackage.core', not 'src.mypackage.core'
+        has_correct_module = any(
+            name == "mypackage.core" or name == "mypackage" for name in module_names
+        )
+        has_src_prefix = any(name.startswith("src.mypackage") for name in module_names)
+
+        assert (
+            has_correct_module
+        ), f"Expected 'mypackage' or 'mypackage.core' in module names, got: {module_names}"
+        assert (
+            not has_src_prefix
+        ), f"Found modules with 'src.mypackage' prefix which is wrong. Got: {module_names}"
+
+
+class TestSrcLayoutFindImports:
+    """Tests for find_imports with src-layout projects.
+
+    This is a regression test for issue #281 where find_imports returned empty
+    results for src-layout projects.
+    """
+
+    @pytest.fixture
+    def src_project_with_imports(self, temp_project_dir: Path) -> Path:
+        """Create a src-layout project with internal imports.
+
+        Structure:
+            temp_project_dir/
+            ├── pyproject.toml
+            └── src/
+                └── mypackage/
+                    ├── __init__.py
+                    ├── core.py  (imports mypackage.utils)
+                    └── utils.py
+        """
+        src_dir = temp_project_dir / "src"
+        src_dir.mkdir()
+
+        pkg_dir = src_dir / "mypackage"
+        pkg_dir.mkdir()
+
+        (pkg_dir / "__init__.py").write_text('"""My Package."""\n')
+        (pkg_dir / "utils.py").write_text(
+            '''"""Utility module."""
+
+
+def helper_function():
+    """A helper function."""
+    return "helping"
+
+
+class UtilityClass:
+    """A utility class."""
+    pass
+'''
+        )
+        (pkg_dir / "core.py").write_text(
+            '''"""Core module that imports utils."""
+
+from mypackage.utils import helper_function, UtilityClass
+from mypackage import utils
+
+
+def main():
+    """Main function using utilities."""
+    result = helper_function()
+    obj = UtilityClass()
+    return result, obj
+'''
+        )
+
+        # Create pyproject.toml with setuptools src layout
+        pyproject = temp_project_dir / "pyproject.toml"
+        pyproject.write_text(
+            """
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mypackage"
+version = "1.0.0"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+"""
+        )
+
+        return temp_project_dir
+
+    @pytest.mark.asyncio
+    async def test_find_imports_works_for_src_layout(self, src_project_with_imports: Path):
+        """Test that find_imports finds imports in src-layout projects.
+
+        This is the main regression test for issue #281.
+        """
+        config = ProjectConfig(str(src_project_with_imports))
+        analyzer = JediAnalyzer(str(src_project_with_imports), config=config)
+
+        # Find files that import mypackage.utils
+        results = await analyzer.find_imports("mypackage.utils")
+
+        assert len(results) > 0, (
+            "find_imports should find core.py which imports mypackage.utils. "
+            "This was broken for src-layout projects (issue #281)."
+        )
+
+        # Verify the found file is core.py
+        found_files = [r["file"] for r in results]
+        assert any(
+            "core.py" in f for f in found_files
+        ), f"Expected to find core.py importing mypackage.utils, got: {found_files}"
+
+    @pytest.mark.asyncio
+    async def test_find_imports_with_from_import(self, src_project_with_imports: Path):
+        """Test that find_imports finds 'from module import' style imports."""
+        config = ProjectConfig(str(src_project_with_imports))
+        analyzer = JediAnalyzer(str(src_project_with_imports), config=config)
+
+        # Find files that import from mypackage.utils
+        results = await analyzer.find_imports("mypackage.utils")
+
+        # Should find the 'from mypackage.utils import helper_function' in core.py
+        import_statements = [r.get("import_statement", "") for r in results]
+
+        has_from_import = any("from mypackage.utils" in stmt for stmt in import_statements)
+        assert has_from_import, (
+            f"Expected to find 'from mypackage.utils import ...' statement. "
+            f"Got: {import_statements}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_find_imports_returns_correct_file_paths(self, src_project_with_imports: Path):
+        """Test that find_imports returns correct file paths (not src-prefixed)."""
+        config = ProjectConfig(str(src_project_with_imports))
+        analyzer = JediAnalyzer(str(src_project_with_imports), config=config)
+
+        results = await analyzer.find_imports("mypackage.utils")
+
+        # All file paths should be valid and point to real files
+        for result in results:
+            file_path = Path(result["file"])
+            assert file_path.exists(), f"File should exist: {file_path}"
+            assert file_path.suffix == ".py", f"Should be Python file: {file_path}"


### PR DESCRIPTION
## Summary
- Fixed `find_imports` to check `source_roots` first when determining ImportAnalyzer root
- Fixed `list_modules` to check `source_roots` first when computing module import paths
- Fixed `list_packages` to check `source_roots` first when computing package names
- Added path resolution using `.resolve()` to handle macOS symlinks (`/var` -> `/private/var`)
- Added comprehensive tests for all three functions in src-layout projects

## Context
This completes the src-layout fix that was started in #277 - these are the remaining functions that were missed in that PR.

## Test plan
- [x] New integration tests for `find_imports`, `list_modules`, `list_packages` with src-layout
- [x] All existing tests pass
- [x] Coverage maintained above 85%

Fixes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)