### PR TITLE
feat(analyzer): support class names in get_call_hierarchy

### DIFF
--- a/src/pyeye/analyzers/jedi_analyzer.py
+++ b/src/pyeye/analyzers/jedi_analyzer.py
@@ -1154,10 +1154,13 @@ class JediAnalyzer:
     async def get_call_hierarchy(
         self, function_name: str, file: str | None = None
     ) -> dict[str, Any]:
-        """Get the call hierarchy for a function.
+        """Get the call hierarchy for a function or class.
+
+        For functions, finds callers (who calls it) and callees (what it calls).
+        For classes, finds instantiation sites (callers) and what __init__ calls (callees).
 
         Args:
-            function_name: Name of the function
+            function_name: Name of the function or class
             file: Optional file to search in (searches whole project if not specified)
 
         Returns:
@@ -1170,17 +1173,19 @@ class JediAnalyzer:
         }
 
         try:
-            # First find the function definition
+            # First find the function or class definition
             search_results = self.project.search(function_name, all_scopes=True)
 
             function_def = None
             for res in search_results:
-                if res.type == "function" and (file is None or str(res.module_path) == file):
+                if res.type in ("function", "class") and (
+                    file is None or str(res.module_path) == file
+                ):
                     function_def = res
                     break
 
             if not function_def or not function_def.module_path:
-                return {"error": f"Function {function_name} not found"}
+                return {"error": f"Symbol {function_name} not found"}
 
             # Get the function's source
             source = await read_file_async(function_def.module_path)

--- a/tests/integration/jedi_integration/test_jedi_analyzer.py
+++ b/tests/integration/jedi_integration/test_jedi_analyzer.py
@@ -696,6 +696,58 @@ def main():
         assert "callers" in result
         assert "callees" in result
 
+    @patch("pyeye.analyzers.jedi_analyzer.jedi.Script")
+    @patch("pyeye.analyzers.jedi_analyzer.jedi.Project")
+    @pytest.mark.asyncio
+    async def test_get_call_hierarchy_with_class(
+        self, mock_project_class, mock_script_class, temp_project_dir
+    ):
+        """Test get_call_hierarchy supports class names."""
+        mock_project = Mock()
+        mock_project_class.return_value = mock_project
+
+        test_file = temp_project_dir / "test.py"
+        test_file.write_text(
+            """
+class MyClass:
+    def __init__(self):
+        self.value = 0
+
+def create():
+    obj = MyClass()
+    return obj
+"""
+        )
+
+        # Mock class definition search
+        mock_class_def = Mock()
+        mock_class_def.name = "MyClass"
+        mock_class_def.type = "class"
+        mock_class_def.module_path = test_file
+        mock_class_def.line = 2
+        mock_class_def.column = 6
+
+        mock_project.search.return_value = [mock_class_def]
+
+        # Mock references (instantiation sites)
+        mock_ref = Mock()
+        mock_ref.is_definition = Mock(return_value=False)
+        mock_ref.module_path = test_file
+        mock_ref.line = 7
+        mock_ref.column = 10
+
+        mock_script = Mock()
+        mock_script.get_references.return_value = [mock_class_def, mock_ref]
+        mock_script.get_names.return_value = []
+        mock_script_class.return_value = mock_script
+
+        analyzer = JediAnalyzer(str(temp_project_dir))
+        result = await analyzer.get_call_hierarchy("MyClass", str(test_file))
+
+        assert result["function"] == "MyClass"
+        assert len(result["callers"]) == 1
+        assert result["callers"][0]["line"] == 7
+
     @pytest.mark.asyncio
     async def test_find_subclasses_direct(self, temp_project_dir):
         """Test finding direct subclasses only."""


### PR DESCRIPTION
## Summary

- Expands `get_call_hierarchy` to accept class names in addition to functions, so passing a class name like `ProjectManager` now returns its instantiation sites as callers instead of an error
- Updated the type filter in `jedi_analyzer.py` to match both `"function"` and `"class"` types, along with docstring and error message updates
- Added integration test verifying class name support

Fixes #301

## Test plan

- [ ] Verify `get_call_hierarchy` works with class names (new integration test)
- [ ] Verify existing function-based call hierarchy tests still pass
- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] Coverage remains above 85%

🤖 Generated with [Claude Code](https://claude.com/claude-code)