### PR TITLE
fix(plugin): use correct url key in marketplace source config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,8 +28,8 @@
       "name": "pyeye",
       "repository": "https://github.com/okeefeco/pyeye-mcp",
       "source": {
-        "repo": "https://github.com/okeefeco/pyeye-mcp.git",
-        "source": "url"
+        "source": "url",
+        "url": "https://github.com/okeefeco/pyeye-mcp.git"
       },
       "version": "1.0.0"
     }


### PR DESCRIPTION
## Summary

- Fixes the `source` object in `.claude-plugin/marketplace.json` where the clone URL was incorrectly assigned to a `repo` key instead of the required `url` key when using `"source": "url"` type
- Reorders fields so `source` type comes before the URL value for clarity

## Details

The marketplace source config expects `{ "source": "url", "url": "..." }` but had `{ "repo": "...", "source": "url" }`. This would prevent plugin installation tools from finding the repository URL.

## Test plan

- [ ] Verify marketplace.json parses correctly with plugin discovery tools
- [ ] Confirm `url` key is recognized by Claude plugin installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)