### PR TITLE
feat(edges): imported_by as a Jedi/AST-backed expand edge (#345)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-imported-by-edge.md
+++ b/docs/superpowers/plans/2026-06-10-imported-by-edge.md
@@ -1,0 +1,190 @@
+# imported_by edge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote `imported_by` from a deferred reference-backend edge to a supported Jedi/AST-backed `expand` edge — `expand(handle, "imported_by")` returns the project modules that import a target module — with no `ExpandResult` shape change.
+
+**Architecture:** Reuse the deterministic AST import-graph reversal that already lives inside `JediAnalyzer.analyze_dependencies` (no `get_references`), by extracting it into a stable `find_importers` method and extracting `_ModuleSentinel` into a shared leaf so the `edges` resolver can build module stubs without importing `inspect`. A new module-only `resolve_imported_by` resolver plugs into the existing `expand` registry; non-module handles return the honest `not_yet_implemented` branch rather than a misleading measured-empty result.
+
+**Tech Stack:** Python, FastMCP, Jedi (local AST ops only — `file_artifact_cache.get_ast`, `get_project_files`, `_resolve_relative_import`), pytest. Reuses `pyeye.handle.Handle`, the `edges` registry / `EdgeResult` / `build_stub` / `expand` foundation from #340 (#342), and `_resolve_relative_import` from #343.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-imported-by-edge-design.md` (authoritative — contracts, the `EdgeResult | None` convention, the documented dynamic-import ceiling).
+
+**Branch / issue:** `feat/345-imported-by`, issue #345. Off `main` (which already carries #342 + #343).
+
+---
+
+## Hard constraints (apply to every task)
+
+- **No reverse symbol search.** No path for `imported_by` may call `get_references`/`find_references`. The reverse scan is a deterministic AST walk + `_resolve_relative_import` only. This is grep-verified and asserted by a spy test, exactly as `callees` is. This is the load-bearing reason the edge can be promoted at all.
+- **No `ExpandResult` / linter shape change.** `imported_by` is a normal member of the existing discriminated union — module → supported `{source, edge, stubs}`; non-module → unsupported `{…, reason: "not_yet_implemented", detail}`. No new fields. The conformance linter should need no code change (its E.* rules already cover any `edge` string and a stub-only supported result).
+- **Module-only; non-module → `not_yet_implemented`, never `[]`.** Because a symbol genuinely *can* be imported by name, a measured-empty `[]` for a non-module would be the #332 absence-vs-zero lie. The resolver signals wrong-kind with `None`; `expand` maps that to the unsupported `not_yet_implemented` branch with a kind-specific `detail`.
+- **Behavior-preserving extractions.** The `_ModuleSentinel` move and the `find_importers` extraction must not change observable behavior: the existing `inspect` tests AND the existing `analyze_dependencies` tests must pass **unmodified**. If one breaks on something other than the move, stop and reconsider — the extraction changed behavior beyond intent.
+- **Reuse, don't duplicate.** `resolve_imported_by` consumes `find_importers`; it must not reimplement the scan. The legacy `analyze_dependencies` is rewired to consume the same `find_importers` — both share one implementation. New code must not depend on the deprecated `analyze_dependencies` method directly.
+- **Canonical handles throughout.** Every importer adjacency is a canonical module `Handle`; each module stub is built from the importer's own file (via the shared sentinel), so tests/standalone scripts — which are not importable via `find_module_file` — still produce stubs.
+- **One intended observable registry change (with one intended test edit).** Moving `imported_by` from the deferred set to the implemented set flips `edge_status("imported_by")`. The existing status-matrix test that parametrizes `imported_by` under `deferred_reference_backend` (`tests/unit/mcp/operations/test_edges.py`) **must** be updated to reflect the new bucket — this is the *intended* test change, distinct from the behavior-preserving guardrails above. `imported_by` stays in the linter's `_PHASE4_UNMEASURED_EDGES` because `inspect.edge_counts.imported_by` is **not** restored in this slice.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/pyeye/_module_sentinel.py` | Create | Shared leaf home for `_ModuleSentinel` (moved from `inspect`). Pure `ast`/`Path` deps; importable by both `inspect` and `edges` without a cycle. |
+| `src/pyeye/mcp/operations/inspect.py` | Modify | Import `_ModuleSentinel` from the shared leaf under its existing private alias; remove the local class definition. No other change. |
+| `src/pyeye/analyzers/jedi_analyzer.py` | Modify | Extract the reverse-scan into a stable `find_importers` returning `(importer_module, importer_file)` pairs; rewire `analyze_dependencies` to consume it for its `imported_by` field. |
+| `src/pyeye/mcp/operations/edges.py` | Modify | Move `imported_by` from the deferred set to the implemented set; add the async `resolve_imported_by` (module → `EdgeResult`; non-module → `None`) to the resolver registry. |
+| `src/pyeye/mcp/operations/expand.py` | Modify | Await resolver results that are awaitable; treat a resolver `None` as the `not_yet_implemented` unsupported branch with a synthesized kind-specific `detail`. No change to the `members`/`callees` outcomes. |
+| `tests/unit/mcp/operations/test_edges.py` | Modify | Update the status-matrix assertion; add `resolve_imported_by` adjacency / measured-empty / non-module-`None` / no-`get_references` coverage. |
+| `tests/integration/jedi_integration/test_module_analysis.py` (and any other `analyze_dependencies` tests) | Reference | Must pass unmodified (extraction parity); add direct `find_importers` unit coverage here or alongside. |
+| `tests/unit/mcp/operations/test_expand.py` | Modify | `imported_by` supported (module) and unsupported (`not_yet_implemented`, non-module) over the operation. |
+| `tests/integration/api_redesign/test_traversal_integration.py` | Modify | `imported_by` end-to-end via the already-registered MCP `expand` tool. |
+| `tests/conformance/test_linter_adversarial_expand.py` | Modify | Dogfood real `imported_by` output (both branches) through the linter; confirm no linter code change. |
+| `tests/fixtures/resolve_project/...` | Identify/extend | A target module imported by ≥2 project modules, including a non-package (test/script-style) importer to prove coverage breadth. |
+
+---
+
+## Phase 1: Extract `_ModuleSentinel` to a shared leaf
+
+The prerequisite that lets `edges` build module stubs without importing `inspect`.
+
+### Task 1.1: Move `_ModuleSentinel` into `src/pyeye/_module_sentinel.py`
+
+- [ ] Move the `_ModuleSentinel` class out of `inspect.py` into a new shared leaf module, and have `inspect.py` import it back under its existing private name so every existing call site is unchanged — because `edges` (which must not import `inspect`) needs to construct module Names, and a shared leaf is the cycle-free home (mirroring the `_ast_targets.py` extraction from #340).
+- [ ] Confirm the existing `inspect` test suite passes **unmodified** (the move is behavior-preserving) and that the new module can be imported from `edges` without a circular import.
+- [ ] Commit.
+
+**Files:** `src/pyeye/_module_sentinel.py`, `src/pyeye/mcp/operations/inspect.py`.
+**Constraints:** The shared module must depend only on `ast`/`Path` (no `inspect`/`edges`/`expand` imports), so it stays a true leaf. Preserve the class's public surface exactly — its constructor takes the canonical handle as a **string**. Check for any `isinstance(..., _ModuleSentinel)` uses and ensure they still resolve through the re-imported name.
+**Acceptance:** Existing `inspect` tests green unmodified; `_ModuleSentinel` importable from a leaf module with no cycle.
+**Risks:** A hidden dependency on an `inspect`-internal symbol would break the leaf property — if found, that symbol must move too or be passed in, not imported back from `inspect`.
+
+---
+
+## Phase 2: Extract `find_importers`
+
+The reusable reverse-scan, lifted out of the deprecated `analyze_dependencies` so new code doesn't build on to-be-removed code.
+
+### Task 2.1: Failing tests for `find_importers`
+
+- [ ] Write tests asserting a new `find_importers` on `JediAnalyzer` returns, for a fixture target module, the importer `(module, file)` pairs for every project module that imports it (directly via `import` and via relative `from`-imports), excludes the target's own file, and dedups — because this is the deterministic adjacency the edge depends on.
+- [ ] Write a test asserting the legacy `analyze_dependencies`'s `imported_by` for the same target is unchanged once it is rewired to consume `find_importers` (extraction parity) — because the legacy method must keep its exact output.
+- [ ] Write a test asserting an importer that is a **test/script-style** file (a project file outside the importable package roots) is still reported — because coverage breadth (tests + scripts) is a guaranteed property and is exactly what the re-resolution-free approach buys.
+- [ ] Run the tests; confirm they fail (method missing).
+- [ ] Commit.
+
+**Files:** the `analyze_dependencies` test module (`tests/integration/jedi_integration/test_module_analysis.py`) or a sibling, plus a fixture importer if one is needed.
+**Constraints:** Resolution must remain a pure AST walk + `_resolve_relative_import`; the test must not assume any `get_references`. The scan operates at `scope="all"` so the importer set spans the project tree, standalone dirs, namespaces, and extra packages. Pick/extend a fixture so at least two distinct importers exist and at least one is a non-package file.
+**Acceptance:** Failing tests pin the `find_importers` adjacency, the dedup, the relative-import case, the test/script-importer case, and the legacy-parity contract.
+**Risks:** The existing scan has a heuristic source-text pre-filter (`shares_package` + textual match) before the authoritative AST check — the tests should target the AST outcome, not the pre-filter, so the refactor is free to keep or adjust the pre-filter as long as results are identical.
+
+### Task 2.2: Implement `find_importers` and rewire `analyze_dependencies`
+
+- [ ] Factor the reverse-scan block out of `analyze_dependencies` into `find_importers(module_path, target_file, scope)`, returning `(importer_module, importer_file)` pairs, and rewire `analyze_dependencies` to derive its `imported_by` field from the projected result — so the scan has a single implementation shared by the legacy method and the new edge.
+- [ ] Run the new tests and the full existing `analyze_dependencies` suite; confirm the new tests pass and the legacy tests pass **unmodified**.
+- [ ] Commit.
+
+**Files:** `src/pyeye/analyzers/jedi_analyzer.py`.
+**Constraints:** Pass the target's file in (the edge resolver already holds it via the source sentinel) to avoid re-locating the module and the not-found path. Carry over the pre-filter, the `ast.Import`/`ast.ImportFrom` matching, and `_resolve_relative_import` verbatim. Keep `find_importers` async (it uses `get_project_files`/`read_file_async`).
+**Acceptance:** `find_importers` tests pass; legacy `analyze_dependencies` tests pass unmodified; the duplication between the two is gone.
+**Risks:** If the legacy `imported_by` output shifts at all, the projection from `(module, file)` pairs back to the sorted module list isn't equivalent — reconcile before proceeding rather than editing the legacy tests.
+
+---
+
+## Phase 3: `resolve_imported_by` + registry move
+
+The edge resolver and its registration.
+
+### Task 3.1: Failing tests for the registry move and `resolve_imported_by`
+
+- [ ] Update the status-matrix test so `imported_by` is asserted as `implemented` (and removed from the `deferred_reference_backend` parametrization) — because the edge legitimately changes bucket; this is the one intended test edit.
+- [ ] Write tests asserting `resolve_imported_by` returns the correct canonical importer handles for a fixture module imported by ≥2 modules (including the test/script-style importer), returns a measured-empty result for a module nobody imports, and returns the wrong-kind `None` signal for a non-module handle — because these three outcomes are the resolver's whole contract.
+- [ ] Write a test asserting the `resolve_imported_by` path makes no `get_references`/`find_references` call (spy), mirroring the `callees` trust test — the load-bearing constraint.
+- [ ] Run the tests; confirm they fail.
+- [ ] Commit.
+
+**Files:** `tests/unit/mcp/operations/test_edges.py`.
+**Constraints:** The resolver returns `EdgeResult` for modules and `None` for non-modules (the per-kind not-supported signal the spec introduces); it must not return `EdgeResult([])` for non-modules. Importer adjacents are `(Handle, module-sentinel)` pairs so `expand` can build stubs. The resolver is async.
+**Acceptance:** Failing tests pin the new status bucket, the module adjacency, the measured-empty case, the non-module `None`, and the no-reverse-search constraint.
+**Risks:** `None`-vs-`EdgeResult([])` is the subtle correctness point — a test must distinguish "non-module → None (not_yet_implemented downstream)" from "module with no importers → EdgeResult([]) (measured none)".
+
+### Task 3.2: Implement `resolve_imported_by` and move the edge
+
+- [ ] Move `imported_by` from the deferred set to the implemented set, implement the async `resolve_imported_by` (module: resolve via `find_importers` using the source sentinel's file → build a `(Handle, module-sentinel)` per importer → dedup → `EdgeResult`; non-module: `None`), and register it in the resolver registry — reusing `find_importers` and the shared sentinel, not reimplementing either.
+- [ ] Run the Phase-3 tests and the full suite; confirm green.
+- [ ] Grep-verify no `get_references`/`find_references` on the `imported_by` path.
+- [ ] Commit.
+
+**Files:** `src/pyeye/mcp/operations/edges.py`.
+**Constraints:** Build each importer's module Name from its own file (via the shared sentinel), never by re-resolving the importer handle — re-resolution fails for tests/standalone scripts. Determinism: identical importer set and order every run. Fix the scan scope to `"all"`.
+**Acceptance:** All Phase-3 tests pass; full suite green; grep confirms no reverse search on the path.
+**Risks:** The resolver is the first async member of the registry — make sure it composes with `expand`'s call site (handled in Phase 4); a sync-only assumption there would surface here.
+
+---
+
+## Phase 4: `expand` wiring
+
+Compose the new resolver into the user-facing operation.
+
+### Task 4.1: Failing tests for `expand` over `imported_by`
+
+- [ ] Write tests asserting `expand(handle, "imported_by")` over a module returns the supported branch with module stubs built by the Phase-1 builder, and over a non-module returns the unsupported branch with `reason: "not_yet_implemented"` and a kind-specific `detail` naming the handle's kind — because this is the end-to-end contract and the empty-vs-unsupported distinction.
+- [ ] Write a test asserting the supported `imported_by` result carries no `unresolved_call_sites` (callees-only) and the module-with-no-importers case is a supported `stubs: []`, distinct from the non-module unsupported branch — to pin the #332 distinction at the operation layer.
+- [ ] Run the tests; confirm they fail.
+- [ ] Commit.
+
+**Files:** `tests/unit/mcp/operations/test_expand.py`.
+**Constraints:** The non-module `detail` is kind-specific, so it is synthesized for the resolver-`None` path rather than produced by the generic status-keyed unsupported-detail helper. The supported and unsupported branches stay mutually exclusive.
+**Acceptance:** Failing tests define both branches for `imported_by`, the kind-specific detail, and the empty-vs-unsupported distinction.
+**Risks:** The `None` (wrong-kind) path must stay distinct from the existing source-unresolvable path (which returns a graceful supported-empty for an unresolvable handle) — don't conflate the two.
+
+### Task 4.2: Implement the `expand` changes
+
+- [ ] Update `expand` to await resolver results that are awaitable (so the async `resolve_imported_by` composes with the sync `members`/`callees` resolvers) and to map a resolver `None` to the `not_yet_implemented` unsupported branch with a synthesized kind-specific `detail` — without changing the `members`/`callees` outcomes.
+- [ ] Run the Phase-4 tests and the full suite; confirm green (including the unchanged `members`/`callees` expand tests).
+- [ ] Commit.
+
+**Files:** `src/pyeye/mcp/operations/expand.py`.
+**Constraints:** `members`/`callees` remain synchronous and continue returning `EdgeResult([])` (never `None`) for wrong kinds, so their behavior — and `inspect`'s sync `len(resolve_members(...).handles)` delegation — is untouched. The awaitable bridge must not turn the whole resolver dispatch into something that breaks the sync resolvers.
+**Acceptance:** All `expand` tests pass; `members`/`callees` expand behavior unchanged; full suite green.
+**Risks:** Over-broadening the async handling could accidentally await a plain `EdgeResult` — guard precisely on awaitability.
+
+---
+
+## Phase 5: Integration + conformance
+
+Surface `imported_by` on the wire and lock its shape into conformance.
+
+### Task 5.1: Wire integration tests
+
+- [ ] Add integration tests exercising `imported_by` end-to-end through the already-registered MCP `expand` tool against a real fixture: a module call (supported, module stubs) and a non-module call (unsupported `not_yet_implemented`) — because the edge must survive the wire as a plain serialisable dict.
+- [ ] Run the integration tests and the full suite with coverage; confirm green at the threshold.
+- [ ] Commit.
+
+**Files:** `tests/integration/api_redesign/test_traversal_integration.py`.
+**Constraints:** No new tool registration is needed — `expand` is already a registered tool; `imported_by` is simply a new edge value. Assert plain-dict/serialisation safety as the existing wire tests do.
+**Acceptance:** `imported_by` discoverable and callable via the wire for both branches; full suite green at coverage threshold.
+
+### Task 5.2: Conformance dogfood
+
+- [ ] Add conformance tests that run the real `imported_by` output (supported module result and non-module `not_yet_implemented`) through the response linter and confirm it passes with **no linter code change** — because the existing structural floors already cover a stub-only supported result and the `not_yet_implemented` reason.
+- [ ] Confirm `imported_by` remains in the linter's unmeasured-edges set (inspect `edge_counts` is not touched in this slice) and run the conformance suite.
+- [ ] Commit.
+
+**Files:** `tests/conformance/test_linter_adversarial_expand.py`.
+**Constraints:** Validate only that `imported_by` ExpandResults conform; do not restore or assert any `inspect.edge_counts.imported_by` (deferred). If the linter unexpectedly needs a change, stop and reconsider — the spec's premise is that it does not.
+**Acceptance:** Linter accepts both `imported_by` branches; conformance suite green; no inspect `edge_counts` change.
+
+---
+
+## Verification gates (between phases)
+
+- [ ] Full test suite green at the coverage threshold (run with the random-order plugin disabled for a deterministic read).
+- [ ] Pre-commit hooks pass (no bypass flags).
+- [ ] No `get_references`/`find_references` introduced on the `imported_by` path (grep-verified) — the load-bearing trust constraint.
+- [ ] Existing `inspect` tests and existing `analyze_dependencies` tests pass **unmodified** (the two extraction guardrails).
+- [ ] The only intended test edit is the status-matrix bucket change for `imported_by`; `ExpandResult` and linter shapes are unchanged.
+
+## What this slice deliberately defers
+
+Symbol-level `imported_by` (the non-module `not_yet_implemented` path flips to real results later, no shape change), literal-string `importlib.import_module` detection, restoring `inspect.edge_counts.imported_by`, and the symbol-level reverse edges (`callers`/`references`) that genuinely require the Pyright backend (#333).

--- a/docs/superpowers/plans/2026-06-10-imported-by-edge.md
+++ b/docs/superpowers/plans/2026-06-10-imported-by-edge.md
@@ -4,7 +4,7 @@
 
 **Goal:** Promote `imported_by` from a deferred reference-backend edge to a supported Jedi/AST-backed `expand` edge — `expand(handle, "imported_by")` returns the project modules that import a target module — with no `ExpandResult` shape change.
 
-**Architecture:** Reuse the deterministic AST import-graph reversal that already lives inside `JediAnalyzer.analyze_dependencies` (no `get_references`), by extracting it into a stable `find_importers` method and extracting `_ModuleSentinel` into a shared leaf so the `edges` resolver can build module stubs without importing `inspect`. A new module-only `resolve_imported_by` resolver plugs into the existing `expand` registry; non-module handles return the honest `not_yet_implemented` branch rather than a misleading measured-empty result.
+**Architecture:** Reuse the deterministic AST import-graph reversal that already lives inside `JediAnalyzer.analyze_dependencies` (no `get_references`), by extracting it into a stable `find_importers` method and extracting `ModuleSentinel` into a shared leaf so the `edges` resolver can build module stubs without importing `inspect`. A new module-only `resolve_imported_by` resolver plugs into the existing `expand` registry; non-module handles return the honest `not_yet_implemented` branch rather than a misleading measured-empty result.
 
 **Tech Stack:** Python, FastMCP, Jedi (local AST ops only — `file_artifact_cache.get_ast`, `get_project_files`, `_resolve_relative_import`), pytest. Reuses `pyeye.handle.Handle`, the `edges` registry / `EdgeResult` / `build_stub` / `expand` foundation from #340 (#342), and `_resolve_relative_import` from #343.
 
@@ -19,7 +19,7 @@
 - **No reverse symbol search.** No path for `imported_by` may call `get_references`/`find_references`. The reverse scan is a deterministic AST walk + `_resolve_relative_import` only. This is grep-verified and asserted by a spy test, exactly as `callees` is. This is the load-bearing reason the edge can be promoted at all.
 - **No `ExpandResult` / linter shape change.** `imported_by` is a normal member of the existing discriminated union — module → supported `{source, edge, stubs}`; non-module → unsupported `{…, reason: "not_yet_implemented", detail}`. No new fields. The conformance linter should need no code change (its E.* rules already cover any `edge` string and a stub-only supported result).
 - **Module-only; non-module → `not_yet_implemented`, never `[]`.** Because a symbol genuinely *can* be imported by name, a measured-empty `[]` for a non-module would be the #332 absence-vs-zero lie. The resolver signals wrong-kind with `None`; `expand` maps that to the unsupported `not_yet_implemented` branch with a kind-specific `detail`.
-- **Behavior-preserving extractions.** The `_ModuleSentinel` move and the `find_importers` extraction must not change observable behavior: the existing `inspect` tests AND the existing `analyze_dependencies` tests must pass **unmodified**. If one breaks on something other than the move, stop and reconsider — the extraction changed behavior beyond intent.
+- **Behavior-preserving extractions.** The `ModuleSentinel` move and the `find_importers` extraction must not change observable behavior: the existing `inspect` tests AND the existing `analyze_dependencies` tests must pass **unmodified**. If one breaks on something other than the move, stop and reconsider — the extraction changed behavior beyond intent.
 - **Reuse, don't duplicate.** `resolve_imported_by` consumes `find_importers`; it must not reimplement the scan. The legacy `analyze_dependencies` is rewired to consume the same `find_importers` — both share one implementation. New code must not depend on the deprecated `analyze_dependencies` method directly.
 - **Canonical handles throughout.** Every importer adjacency is a canonical module `Handle`; each module stub is built from the importer's own file (via the shared sentinel), so tests/standalone scripts — which are not importable via `find_module_file` — still produce stubs.
 - **One intended observable registry change (with one intended test edit).** Moving `imported_by` from the deferred set to the implemented set flips `edge_status("imported_by")`. The existing status-matrix test that parametrizes `imported_by` under `deferred_reference_backend` (`tests/unit/mcp/operations/test_edges.py`) **must** be updated to reflect the new bucket — this is the *intended* test change, distinct from the behavior-preserving guardrails above. `imported_by` stays in the linter's `_PHASE4_UNMEASURED_EDGES` because `inspect.edge_counts.imported_by` is **not** restored in this slice.
@@ -30,8 +30,8 @@
 
 | File | Action | Responsibility |
 |------|--------|----------------|
-| `src/pyeye/_module_sentinel.py` | Create | Shared leaf home for `_ModuleSentinel` (moved from `inspect`). Pure `ast`/`Path` deps; importable by both `inspect` and `edges` without a cycle. |
-| `src/pyeye/mcp/operations/inspect.py` | Modify | Import `_ModuleSentinel` from the shared leaf under its existing private alias; remove the local class definition. No other change. |
+| `src/pyeye/_module_sentinel.py` | Create | Shared leaf home for `ModuleSentinel` (moved from `inspect`). Pure `ast`/`Path` deps; importable by both `inspect` and `edges` without a cycle. |
+| `src/pyeye/mcp/operations/inspect.py` | Modify | Import the public `ModuleSentinel` from the shared leaf; remove the local class definition. (The class was extracted under the public name `ModuleSentinel` rather than the original private `_ModuleSentinel`, so both `inspect` and `edges` import the same canonical name directly — no private alias.) |
 | `src/pyeye/analyzers/jedi_analyzer.py` | Modify | Extract the reverse-scan into a stable `find_importers` returning `(importer_module, importer_file)` pairs; rewire `analyze_dependencies` to consume it for its `imported_by` field. |
 | `src/pyeye/mcp/operations/edges.py` | Modify | Move `imported_by` from the deferred set to the implemented set; add the async `resolve_imported_by` (module → `EdgeResult`; non-module → `None`) to the resolver registry. |
 | `src/pyeye/mcp/operations/expand.py` | Modify | Await resolver results that are awaitable; treat a resolver `None` as the `not_yet_implemented` unsupported branch with a synthesized kind-specific `detail`. No change to the `members`/`callees` outcomes. |
@@ -44,19 +44,19 @@
 
 ---
 
-## Phase 1: Extract `_ModuleSentinel` to a shared leaf
+## Phase 1: Extract `ModuleSentinel` to a shared leaf
 
 The prerequisite that lets `edges` build module stubs without importing `inspect`.
 
-### Task 1.1: Move `_ModuleSentinel` into `src/pyeye/_module_sentinel.py`
+### Task 1.1: Move `ModuleSentinel` into `src/pyeye/_module_sentinel.py`
 
-- [ ] Move the `_ModuleSentinel` class out of `inspect.py` into a new shared leaf module, and have `inspect.py` import it back under its existing private name so every existing call site is unchanged — because `edges` (which must not import `inspect`) needs to construct module Names, and a shared leaf is the cycle-free home (mirroring the `_ast_targets.py` extraction from #340).
+- [ ] Move the `ModuleSentinel` class out of `inspect.py` into a new shared leaf module under the public name `ModuleSentinel`, and have both `inspect.py` and `edges.py` import it directly from the leaf — because `edges` (which must not import `inspect`) needs to construct module Names, and a shared leaf is the cycle-free home (mirroring the `_ast_targets.py` extraction from #340). (As-built: extracted public, no private alias; `inspect`'s call sites were updated to the canonical name.)
 - [ ] Confirm the existing `inspect` test suite passes **unmodified** (the move is behavior-preserving) and that the new module can be imported from `edges` without a circular import.
 - [ ] Commit.
 
 **Files:** `src/pyeye/_module_sentinel.py`, `src/pyeye/mcp/operations/inspect.py`.
-**Constraints:** The shared module must depend only on `ast`/`Path` (no `inspect`/`edges`/`expand` imports), so it stays a true leaf. Preserve the class's public surface exactly — its constructor takes the canonical handle as a **string**. Check for any `isinstance(..., _ModuleSentinel)` uses and ensure they still resolve through the re-imported name.
-**Acceptance:** Existing `inspect` tests green unmodified; `_ModuleSentinel` importable from a leaf module with no cycle.
+**Constraints:** The shared module must depend only on `ast`/`Path` (no `inspect`/`edges`/`expand` imports), so it stays a true leaf. Preserve the class's public surface exactly — its constructor takes the canonical handle as a **string**. Check for any `isinstance(..., ModuleSentinel)` uses and ensure they still resolve through the re-imported name.
+**Acceptance:** Existing `inspect` tests green unmodified; `ModuleSentinel` importable from a leaf module with no cycle.
 **Risks:** A hidden dependency on an `inspect`-internal symbol would break the leaf property — if found, that symbol must move too or be passed in, not imported back from `inspect`.
 
 ---

--- a/docs/superpowers/specs/2026-06-10-imported-by-edge-design.md
+++ b/docs/superpowers/specs/2026-06-10-imported-by-edge-design.md
@@ -82,8 +82,9 @@ that import a target **module** — reusing the existing reverse-scan logic (and
    - kind ≠ module → return `None`.
    - kind == module → `pairs = await analyzer.find_importers("pkg.mod",
      sentinel.module_path, scope="all")` → for each `(importer_module, importer_file)`:
-     `Handle(importer_module)` + `_ModuleSentinel(importer_file, handle, analyzer)` →
-     dedup by handle (keep first) → `EdgeResult(adjacents=sorted(...))`.
+     `h = Handle(importer_module)` + `_ModuleSentinel(importer_file, str(h), analyzer)`
+     (the sentinel takes the canonical handle as a **string**, matching its existing
+     `inspect` call site) → dedup by handle (keep first) → `EdgeResult(adjacents=sorted(...))`.
 4. `expand`: `None` → unsupported `not_yet_implemented`; otherwise
    `stubs = [build_stub(name, str(h), analyzer) for (h, name) in result.adjacents]` →
    `{source, edge, stubs}`.
@@ -146,6 +147,11 @@ returning `EdgeResult([])` for the wrong kind (honest measured-empty) and never 
 `None`. Only `imported_by` uses the `None` path. When the future symbol-level slice
 lands, `resolve_imported_by` stops returning `None` for symbol kinds — a clean flip with
 no shape change.
+
+Note: the wrong-kind `detail` is **kind-specific** (it names the handle's kind), so
+`expand` synthesises it on the `None` branch rather than routing through the generic
+status-keyed `_unsupported_detail` helper (which produces the fixed per-`reason` text for
+status-derived unsupported results). `reason` is still `"not_yet_implemented"`.
 
 ### 4.2 Async accommodation
 

--- a/docs/superpowers/specs/2026-06-10-imported-by-edge-design.md
+++ b/docs/superpowers/specs/2026-06-10-imported-by-edge-design.md
@@ -39,7 +39,7 @@ that import a target **module** — reusing the existing reverse-scan logic (and
   the unsupported `not_yet_implemented` branch (see §4).
 - Extract the reverse-scan into a stable `JediAnalyzer.find_importers(...)` (used by
   both the new edge and the legacy `analyze_dependencies`), and extract
-  `_ModuleSentinel` into a shared leaf module so `edges` can build module stubs without
+  `ModuleSentinel` into a shared leaf module so `edges` can build module stubs without
   importing `inspect`.
 - Conformance + unit + integration coverage mirroring the `members`/`callees` edges.
 
@@ -63,8 +63,8 @@ that import a target **module** — reusing the existing reverse-scan logic (and
 | `src/pyeye/mcp/operations/edges.py` | Modify | Move `imported_by` to the implemented set; add `resolve_imported_by` (module-only) to `EDGE_RESOLVERS`. Returns `EdgeResult` for modules, `None` for non-modules (the per-kind not-supported signal). |
 | `src/pyeye/mcp/operations/expand.py` | Modify | Treat a `None` resolver result as the `not_yet_implemented` unsupported branch; await resolver results that are awaitable (so an async resolver composes with the existing sync ones). |
 | `src/pyeye/analyzers/jedi_analyzer.py` | Modify | Extract the reverse-scan from `analyze_dependencies` into a stable `find_importers(module_path, target_file, scope) -> list[tuple[str, Path]]`; rewire the (deprecated) `analyze_dependencies` to consume it. Behaviour-preserving. |
-| `src/pyeye/_module_sentinel.py` | Create | Shared leaf home for `_ModuleSentinel` (moved out of `inspect.py`). Deps: `ast`, `Path` only. |
-| `src/pyeye/mcp/operations/inspect.py` | Modify | Import `_ModuleSentinel` from the shared module under its existing private alias (zero call-site churn). Behaviour-preserving. |
+| `src/pyeye/_module_sentinel.py` | Create | Shared leaf home for `ModuleSentinel` (moved out of `inspect.py`). Deps: `ast`, `Path` only. |
+| `src/pyeye/mcp/operations/inspect.py` | Modify | Import the public `ModuleSentinel` from the shared module directly (as-built: extracted under the public name, no private alias). Behaviour-preserving. |
 | `tests/unit/mcp/operations/test_edges.py` | Modify | `resolve_imported_by` adjacency, measured-empty, non-module → `None`, and the no-`get_references` spy. |
 | `tests/unit/.../test_jedi_analyzer*.py` | Modify | `find_importers` unit tests + `analyze_dependencies["imported_by"]` extraction-parity. |
 | `tests/integration/api_redesign/test_traversal_integration.py` | Modify | `imported_by` over the wire (module supported; non-module unsupported). |
@@ -76,13 +76,13 @@ that import a target **module** — reusing the existing reverse-scan logic (and
 `expand("pkg.mod", "imported_by", analyzer)`:
 
 1. `edge_status("imported_by")` → `"implemented"` (after the registry move).
-2. `inspect._find_jedi_name_for_handle("pkg.mod")` → `_ModuleSentinel` (kind module,
+2. `inspect._find_jedi_name_for_handle("pkg.mod")` → `ModuleSentinel` (kind module,
    carries `.module_path`).
 3. `await resolve_imported_by(sentinel, analyzer)`:
    - kind ≠ module → return `None`.
    - kind == module → `pairs = await analyzer.find_importers("pkg.mod",
      sentinel.module_path, scope="all")` → for each `(importer_module, importer_file)`:
-     `h = Handle(importer_module)` + `_ModuleSentinel(importer_file, str(h), analyzer)`
+     `h = Handle(importer_module)` + `ModuleSentinel(importer_file, str(h), analyzer)`
      (the sentinel takes the canonical handle as a **string**, matching its existing
      `inspect` call site) → dedup by handle (keep first) → `EdgeResult(adjacents=sorted(...))`.
 4. `expand`: `None` → unsupported `not_yet_implemented`; otherwise
@@ -98,7 +98,7 @@ that import a target **module** — reusing the existing reverse-scan logic (and
   (#343). It takes `target_file` (the resolver already holds it via the source
   sentinel), avoiding a re-location of the target module. `analyze_dependencies` is
   rewired to `imported_by = sorted({m for m, _ in find_importers(...)})`.
-- **`_ModuleSentinel`** moves to `src/pyeye/_module_sentinel.py` (a self-contained
+- **`ModuleSentinel`** moves to `src/pyeye/_module_sentinel.py` (a self-contained
   ~30-line class with only `ast`/`Path` deps). `edges` imports it to build a module
   Name **from the importer file it already holds** — no re-resolution. This is load-
   bearing: tests/standalone scripts are **not** importable via `find_module_file`, so a
@@ -181,7 +181,7 @@ resolvers or the inspect count path.
 
 - kind ≠ `"module"` → `None`.
 - kind == `"module"` → `find_importers(jedi_name.full_name, jedi_name.module_path,
-  scope="all")` → build `(Handle, _ModuleSentinel)` per importer → `EdgeResult(adjacents)`.
+  scope="all")` → build `(Handle, ModuleSentinel)` per importer → `EdgeResult(adjacents)`.
 
 `scope` lives at the analyzer layer (`find_importers` keeps the param, as
 `analyze_dependencies` already does); `resolve_imported_by` fixes it to `"all"`. The

--- a/docs/superpowers/specs/2026-06-10-imported-by-edge-design.md
+++ b/docs/superpowers/specs/2026-06-10-imported-by-edge-design.md
@@ -1,0 +1,250 @@
+# imported_by edge design — promote `imported_by` to a Jedi/AST-backed `expand` edge
+
+**Date:** 2026-06-10
+**Issue:** #345
+**Status:** design (pre-implementation)
+**Branch:** `feat/345-imported-by`
+
+## 1. Context & goal
+
+The redesigned pyeye API ships `expand(handle, edge)` for the outbound/structural
+edges Jedi produces reliably today — currently `members` and `callees` (#340, merged
+in #342). Inbound/reference edges (`callers`, `references`, …) are deferred to the
+Pyright reference backend (#333) because their only implementation route is
+project-wide `get_references`, which is **non-deterministically wrong** (#332).
+
+`imported_by` currently sits in `edges._DEFERRED_REFERENCE_BACKEND_EDGES` alongside
+those edges, so `expand(handle, "imported_by")` returns the unsupported branch with
+`reason: deferred_reference_backend`. **That categorisation is wrong.** `imported_by`
+is computable **statically**: `JediAnalyzer.analyze_dependencies` already produces it
+via a deterministic AST import-graph reversal with **zero `get_references`** on the
+path (now correct for relative imports after #343). That is exactly the "local
+Jedi/AST ops, no reverse search" criterion that marks an edge supported-now — the same
+reasoning the plan already uses to carve out `subclasses` (directionally inbound, but
+reliably produced by AST-walk + `goto`).
+
+**Goal:** decouple `imported_by` from #333 and promote it to a **supported**
+Jedi/AST-backed edge — `expand(handle, "imported_by")` returns the project modules
+that import a target **module** — reusing the existing reverse-scan logic (and #343's
+`_resolve_relative_import`), with **no `ExpandResult` shape change**.
+
+## 2. Scope
+
+**In:**
+
+- Move `imported_by` from `_DEFERRED_REFERENCE_BACKEND_EDGES` to `_IMPLEMENTED_EDGES`
+  in `edges.py`; register a `resolve_imported_by` resolver.
+- `resolve_imported_by` — **module handles only** in this slice: returns the canonical
+  handles of project modules that import the target module. Non-module handles return
+  the unsupported `not_yet_implemented` branch (see §4).
+- Extract the reverse-scan into a stable `JediAnalyzer.find_importers(...)` (used by
+  both the new edge and the legacy `analyze_dependencies`), and extract
+  `_ModuleSentinel` into a shared leaf module so `edges` can build module stubs without
+  importing `inspect`.
+- Conformance + unit + integration coverage mirroring the `members`/`callees` edges.
+
+**Out (deferred — additive later, no shape change):**
+
+- **Symbol-level `imported_by`** (`from mod import Symbol` → who imports the symbol).
+  This slice is module-only; non-module handles report `not_yet_implemented`.
+- **Literal-string dynamic-import detection** (`importlib.import_module("a.b.c")` with a
+  string-literal arg). A documented follow-on.
+- **Restoring `inspect.edge_counts.imported_by`** (cheap `len(resolver(...))`, but it
+  carries its own `_PHASE4_UNMEASURED_EDGES`/linter contract change — a separate slice).
+- `callers`/`references` and the symbol-level reverse edges — these genuinely require
+  the Pyright backend (#333) and stay `deferred_reference_backend`.
+
+## 3. Architecture
+
+### 3.1 Components / file map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/pyeye/mcp/operations/edges.py` | Modify | Move `imported_by` to the implemented set; add `resolve_imported_by` (module-only) to `EDGE_RESOLVERS`. Returns `EdgeResult` for modules, `None` for non-modules (the per-kind not-supported signal). |
+| `src/pyeye/mcp/operations/expand.py` | Modify | Treat a `None` resolver result as the `not_yet_implemented` unsupported branch; await resolver results that are awaitable (so an async resolver composes with the existing sync ones). |
+| `src/pyeye/analyzers/jedi_analyzer.py` | Modify | Extract the reverse-scan from `analyze_dependencies` into a stable `find_importers(module_path, target_file, scope) -> list[tuple[str, Path]]`; rewire the (deprecated) `analyze_dependencies` to consume it. Behaviour-preserving. |
+| `src/pyeye/_module_sentinel.py` | Create | Shared leaf home for `_ModuleSentinel` (moved out of `inspect.py`). Deps: `ast`, `Path` only. |
+| `src/pyeye/mcp/operations/inspect.py` | Modify | Import `_ModuleSentinel` from the shared module under its existing private alias (zero call-site churn). Behaviour-preserving. |
+| `tests/unit/mcp/operations/test_edges.py` | Modify | `resolve_imported_by` adjacency, measured-empty, non-module → `None`, and the no-`get_references` spy. |
+| `tests/unit/.../test_jedi_analyzer*.py` | Modify | `find_importers` unit tests + `analyze_dependencies["imported_by"]` extraction-parity. |
+| `tests/integration/api_redesign/test_traversal_integration.py` | Modify | `imported_by` over the wire (module supported; non-module unsupported). |
+| `tests/conformance/test_linter_adversarial_expand.py` | Modify | Dogfood real `imported_by` output (both branches) through `lint_response(..., "expand")`. |
+| `tests/fixtures/...` | Identify/extend | A module imported by ≥2 project modules incl. an importing **test/script** file. |
+
+### 3.2 Data flow
+
+`expand("pkg.mod", "imported_by", analyzer)`:
+
+1. `edge_status("imported_by")` → `"implemented"` (after the registry move).
+2. `inspect._find_jedi_name_for_handle("pkg.mod")` → `_ModuleSentinel` (kind module,
+   carries `.module_path`).
+3. `await resolve_imported_by(sentinel, analyzer)`:
+   - kind ≠ module → return `None`.
+   - kind == module → `pairs = await analyzer.find_importers("pkg.mod",
+     sentinel.module_path, scope="all")` → for each `(importer_module, importer_file)`:
+     `Handle(importer_module)` + `_ModuleSentinel(importer_file, handle, analyzer)` →
+     dedup by handle (keep first) → `EdgeResult(adjacents=sorted(...))`.
+4. `expand`: `None` → unsupported `not_yet_implemented`; otherwise
+   `stubs = [build_stub(name, str(h), analyzer) for (h, name) in result.adjacents]` →
+   `{source, edge, stubs}`.
+
+### 3.3 The two extractions (reuse, not duplication)
+
+- **`find_importers`** factors the reverse-scan block out of the **deprecated**
+  `analyze_dependencies` into a stable method so the new edge does not depend on
+  to-be-removed code. It carries over verbatim: the `read_file_async` + `shares_package`
+  pre-filter, the `ast.Import`/`ast.ImportFrom` matching, and `_resolve_relative_import`
+  (#343). It takes `target_file` (the resolver already holds it via the source
+  sentinel), avoiding a re-location of the target module. `analyze_dependencies` is
+  rewired to `imported_by = sorted({m for m, _ in find_importers(...)})`.
+- **`_ModuleSentinel`** moves to `src/pyeye/_module_sentinel.py` (a self-contained
+  ~30-line class with only `ast`/`Path` deps). `edges` imports it to build a module
+  Name **from the importer file it already holds** — no re-resolution. This is load-
+  bearing: tests/standalone scripts are **not** importable via `find_module_file`, so a
+  re-resolution path could not produce their stubs; building from the file does. Mirrors
+  the `_ast_targets.py` extraction from #340 that keeps `edges` decoupled from `inspect`
+  (the `inspect → edges` dependency forbids `edges → inspect`).
+
+**Behaviour-preserving guardrails:** the legacy `analyze_dependencies` tests and all
+existing `inspect` tests must pass **unmodified** after the extractions.
+
+## 4. Contracts
+
+`imported_by` is a normal member of the existing `ExpandResult` discriminated union
+(spec `2026-06-08-expand-core-design.md` §4.2) — **no new fields, no shape change**.
+
+**Module handle → supported:**
+
+```text
+{ "source": str, "edge": "imported_by", "stubs": [Stub, ...] }
+```
+
+- Each `Stub` is `kind: "module"`, `scope: "project"`. `stubs: []` means **measured**:
+  no project file imports the target. No `unresolved_call_sites` (callees-only).
+
+**Non-module handle → unsupported:**
+
+```text
+{ "source": str, "edge": "imported_by", "unsupported": true,
+  "reason": "not_yet_implemented",
+  "detail": "imported_by is supported for modules; '<handle>' is a <kind>. Symbol-level imported_by is not yet implemented." }
+```
+
+**Why non-module is `not_yet_implemented`, not `stubs: []`.** A symbol genuinely *can*
+be imported by name, so returning a measured-empty `[]` for a class/function would
+falsely assert "imported by nothing" — the #332 absence-vs-zero trap. `not_yet_implemented`
+is the honest signal. This differs from `members`/`callees`, where `[]` for the wrong
+kind is *true by definition* (a variable has no members; a non-function makes no calls).
+`imported_by` is therefore the first edge where wrong-kind ≠ measured-empty.
+
+### 4.1 Resolver convention: `EdgeResult | None`
+
+A resolver may return `EdgeResult | None`. `None` means "this handle's **kind** is not
+supported for this edge" → `expand` emits the `not_yet_implemented` unsupported branch
+with the kind-specific `detail`. `members`/`callees` are **unchanged** — they keep
+returning `EdgeResult([])` for the wrong kind (honest measured-empty) and never return
+`None`. Only `imported_by` uses the `None` path. When the future symbol-level slice
+lands, `resolve_imported_by` stops returning `None` for symbol kinds — a clean flip with
+no shape change.
+
+### 4.2 Async accommodation
+
+`resolve_imported_by` is **async** (the scan does file I/O via `get_project_files` /
+`read_file_async`). `members`/`callees` stay **sync**, and `inspect`'s
+`len(resolve_members(...).handles)` delegation stays sync (the #340 refactor guardrail is
+untouched). `expand` bridges both by `await`-ing the resolver result only when it is
+awaitable. This is the minimal-blast-radius choice: no async cascade into the sync
+resolvers or the inspect count path.
+
+## 5. Resolver — `find_importers` / `resolve_imported_by`
+
+`find_importers(module_path, target_file, scope="all") -> list[tuple[str, Path]]`:
+
+1. Enumerate candidate files via `get_project_files("*.py", scope)`. **`scope="all"`**
+   resolves to the project tree (which includes `tests/` and in-tree scripts), plus
+   configured standalone-script dirs (`standalone_paths`, #236), namespaces, and extra
+   packages — the most complete honest answer to "what depends on X".
+2. For each file ≠ `target_file`: the existing pre-filter (textual `module_path`
+   appearance **or** `shares_package`), then the authoritative AST check —
+   `ast.Import` (`alias.name == module_path` or `startswith(module_path + ".")`) or
+   `ast.ImportFrom` (resolve via `_resolve_relative_import`, then `== module_path` or
+   `startswith`). On a match, record `(_get_import_path_for_file(file), file)`.
+3. Dedup by importer module; deterministic order.
+
+`resolve_imported_by(jedi_name, analyzer)`:
+
+- kind ≠ `"module"` → `None`.
+- kind == `"module"` → `find_importers(jedi_name.full_name, jedi_name.module_path,
+  scope="all")` → build `(Handle, _ModuleSentinel)` per importer → `EdgeResult(adjacents)`.
+
+`scope` lives at the analyzer layer (`find_importers` keeps the param, as
+`analyze_dependencies` already does); `resolve_imported_by` fixes it to `"all"`. The
+`expand` tool signature stays `(handle, edge, project_path)` — **no `scope` param** (it
+would be inert for `members`/`callees`; additive later if a caller ever needs to narrow).
+
+## 6. Guarantees & non-guarantees
+
+**Guaranteed (firm):**
+
+- **Soundness — no false data.** Every importer is a real project file with a real
+  AST-verified `import`/`from-import` of the target. Never an invented edge; `stubs: []`
+  means *measured* none, never "couldn't measure".
+- **Determinism & locality.** A deterministic AST walk over project files +
+  `_resolve_relative_import`. **No `get_references` / project-wide reverse symbol search
+  anywhere on the path** — grep-gated and asserted by a spy test, exactly like `callees`.
+- **Coverage breadth.** `scope="all"` finds importers in package modules, tests, in-tree
+  scripts, configured standalone dirs, namespaces, and extra packages.
+
+**Explicitly NOT guaranteed (documented ceiling):**
+
+- **Runtime-dynamic imports.** `imported_by` covers static `import`/`from-import`
+  (including conditional/nested ones — an AST walk sees them regardless of nesting).
+  Imports whose target is computed at runtime — `importlib.import_module(var)`,
+  `__import__(var)` — are undetectable and out of scope. This is the **universal static
+  ceiling** of import-graph analysis (the same *class* of boundary as `callees`' dynamic
+  dispatch), **not** the #332 non-determinism. Unlike `callees`' `unresolved_call_sites`,
+  it is **not surfaced as a count**: a dynamic import in another file cannot be attributed
+  to *this* target, so a count would be project-wide noise — the boundary is documented in
+  the edge contract instead.
+
+This is categorically different from why `callers`/`references` are deferred: those rely
+on `get_references`, which is *non-deterministically wrong* — untrustworthy numbers, not
+a known static ceiling.
+
+## 7. Testing & verification
+
+- **Unit (`test_edges.py`):** `resolve_imported_by` on a fixture module imported by ≥2
+  others — correct canonical importer handles, including an importing **test/script**
+  file (proving tests/scripts are covered); a module imported by nobody → `EdgeResult([])`
+  (measured-none); a non-module handle → `None`. **Spy test:** the `imported_by` path
+  makes no `jedi.Script.get_references` call (mirrors the callees spy).
+- **Unit (analyzer):** `find_importers` directly; assert `analyze_dependencies["imported_by"]`
+  is **unchanged** (extraction parity).
+- **Integration (`test_traversal_integration.py`):** `expand` over the wire —
+  `imported_by` on a module (supported, stubs) and on a non-module (unsupported
+  `not_yet_implemented`).
+- **Conformance:** dogfood real `imported_by` output (both branches) through
+  `lint_response(result, "expand")`. **Expected: no linter code change** — the E.* rules
+  already accept any `edge` string, the supported result carries no `unresolved_call_sites`
+  (E.3 satisfied), and `not_yet_implemented` is a valid reason. `imported_by` stays in
+  `_PHASE4_UNMEASURED_EDGES` (inspect `edge_counts` unchanged — §2 Out).
+
+**Verification gates:**
+
+- Full suite green at the coverage threshold (run `-p no:randomly` for determinism).
+- Pre-commit clean (no bypass flags).
+- **Grep-verified: no `get_references`/`find_references` on the `imported_by` path.**
+- Legacy `analyze_dependencies` tests **and** existing `inspect` tests pass **unmodified**
+  (both extractions are behaviour-preserving).
+
+## 8. Relationship & sequencing
+
+- **Depends on #342** (the #340 `edges`/`EdgeResult`/`expand`/conformance-linter
+  foundation) — merged to `main`. This slice lands on `feat/345-imported-by` off `main`.
+- **Reuses #343** (`_resolve_relative_import`), already on `main`.
+- Pairs naturally with the planned `imports` (outbound) edge (currently
+  `not_yet_implemented`); `find_importers` is the reusable seam for the reverse direction.
+- Everything deferred in §2 lands additively later with **no `ExpandResult` shape change**:
+  symbol-level `imported_by` flips the non-module `not_yet_implemented` path to real
+  results; the literal-string `importlib` and `inspect.edge_counts.imported_by` work are
+  independent follow-ons.

--- a/src/pyeye/_module_sentinel.py
+++ b/src/pyeye/_module_sentinel.py
@@ -1,0 +1,94 @@
+"""Shared leaf module: lightweight module stand-in for Jedi Name objects.
+
+Exists so both :mod:`pyeye.mcp.operations.inspect` and
+:mod:`pyeye.mcp.operations.edges` can reference :class:`ModuleSentinel`
+WITHOUT either importing the other (``edges`` must not import ``inspect`` —
+circular import once ``inspect`` imports ``edges`` for edge-count helpers).
+
+This mirrors the extraction precedent in :mod:`pyeye._ast_targets`, which was
+created for the same reason: a shared AST helper needed by both ``inspect``
+and ``edges``.
+
+Runtime dependencies: :mod:`ast` and :mod:`pathlib` only.  ``JediAnalyzer``
+is imported under ``TYPE_CHECKING`` — it is *not* needed at runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+
+
+class ModuleSentinel:
+    """Lightweight stand-in for a Jedi Name when the handle *is* a module.
+
+    Stores the module file path and enough info for ``inspect`` to build the
+    location and docstring without a real ``Name`` object.
+    """
+
+    def __init__(self, mod_file: Path, handle: str, analyzer: JediAnalyzer) -> None:
+        """Initialise the sentinel from the module file and resolved handle.
+
+        Args:
+            mod_file: Absolute path to the module's source file.
+            handle: Canonical dotted handle for the module (e.g.
+                ``"pyeye.cache"``).
+            analyzer: The project's ``JediAnalyzer`` instance (stored but not
+                called at construction time; kept for future-use parity with
+                real Jedi ``Name`` objects).
+        """
+        self.mod_file = mod_file
+        self.handle = handle
+        self._analyzer = analyzer
+
+        # Populate Jedi-Name-like attributes from the module file
+        self.module_path: Path | None = mod_file
+        self.type = "module"
+        self.full_name: str = handle
+        self.name: str = handle.split(".")[-1]
+        self.line: int = 1
+        self.column: int = 0
+
+        # Read docstring from module-level AST
+        self.docstring_text: str = ""
+        try:
+            source = mod_file.read_text(encoding="utf-8", errors="replace")
+            tree = ast.parse(source)
+            ds = ast.get_docstring(tree)
+            if ds:
+                self.docstring_text = ds
+        except Exception:
+            pass
+
+    def docstring(self, **kwargs: object) -> str:
+        """Return the module-level docstring.
+
+        Args:
+            **kwargs: Accepted and ignored for Jedi ``Name.docstring()``
+                signature compatibility.
+
+        Returns:
+            The module docstring, or an empty string if none was found.
+        """
+        _ = kwargs  # accepted-and-ignored for Jedi Name.docstring() signature compat
+        return self.docstring_text
+
+    def get_signatures(self) -> list:
+        """Return an empty list (modules have no call signatures).
+
+        Returns:
+            An empty list, matching the Jedi ``Name.get_signatures()`` shape.
+        """
+        return []
+
+    def infer(self) -> list:
+        """Return an empty list (no Jedi inference for module sentinels).
+
+        Returns:
+            An empty list, matching the Jedi ``Name.infer()`` shape.
+        """
+        return []

--- a/src/pyeye/analyzers/jedi_analyzer.py
+++ b/src/pyeye/analyzers/jedi_analyzer.py
@@ -1913,6 +1913,90 @@ class JediAnalyzer:
         combined = base + suffix
         return ".".join(combined) if combined else None
 
+    async def find_importers(
+        self, module_path: str, target_file: Path, scope: Scope = "all"
+    ) -> list[tuple[str, Path]]:
+        """Find project files that import ``module_path`` (reverse import scan).
+
+        Scans every project file in *scope* for an import of the target module,
+        using a textual pre-filter followed by an authoritative AST check. This
+        is the reusable extraction of the reverse-scan formerly inlined in
+        :meth:`analyze_dependencies`; a later ``expand(handle, edge="imported_by")``
+        edge can build on it without depending on the deprecated method.
+
+        The scan is purely AST-based (no Jedi reference resolution), which is
+        what gives it breadth: standalone scripts and test files that import the
+        target are reported, even when they live outside an importable package
+        root.
+
+        Args:
+            module_path: Absolute dotted path of the target module.
+            target_file: The target module's own file, skipped during the scan
+                so a module never reports itself.
+            scope: Search scope (see :meth:`analyze_dependencies`).
+
+        Returns:
+            ``(importer_dotted_module, importer_file)`` pairs, deduped by
+            importer module (first occurrence wins) and sorted by module name.
+        """
+        target_root = module_path.split(".")[0]
+        importers: dict[str, Path] = {}
+
+        py_files = await self.get_project_files("*.py", scope)
+        for py_file in py_files:
+            if py_file == target_file:
+                continue
+
+            try:
+                importer_module = self._get_import_path_for_file(py_file)
+                # Pre-filter (avoids AST parse for unrelated files; the AST
+                # check below is authoritative).  Parse when EITHER the
+                # absolute path appears textually (absolute imports) OR the
+                # file shares the target's top-level package — a relative
+                # import (`from .x import y`) can resolve into the target
+                # without ever spelling its absolute path (#343).  Source is
+                # read but not cached or returned — a heuristic, not content.
+                source = await read_file_async(py_file)
+                shares_package = bool(
+                    importer_module and importer_module.split(".")[0] == target_root
+                )
+                if (
+                    module_path in source
+                    or module_path.replace(".", "/") in source
+                    or shares_package
+                ):
+                    importer_is_package = py_file.name == "__init__.py"
+                    # Bucket 1: AST for the precise check comes from cache.
+                    tree = file_artifact_cache.get_ast(py_file)
+                    for node in ast.walk(tree):
+                        if isinstance(node, ast.Import):
+                            if any(
+                                alias.name == module_path
+                                or alias.name.startswith(module_path + ".")
+                                for alias in node.names
+                            ):
+                                if importer_module and importer_module not in importers:
+                                    importers[importer_module] = py_file
+                                break
+                        elif isinstance(node, ast.ImportFrom):
+                            resolved = self._resolve_relative_import(
+                                node.level,
+                                node.module,
+                                importer_module or "",
+                                importer_is_package,
+                            )
+                            if resolved and (
+                                resolved == module_path or resolved.startswith(module_path + ".")
+                            ):
+                                if importer_module and importer_module not in importers:
+                                    importers[importer_module] = py_file
+                                break
+            except Exception as e:
+                logger.warning(f"Could not analyze {py_file} for imports: {e}")
+                continue
+
+        return [(module, importers[module]) for module in sorted(importers)]
+
     async def analyze_dependencies(
         self, module_path: str, scope: Scope = "all", _visited: set[str] | None = None
     ) -> dict[str, Any]:
@@ -2087,63 +2171,10 @@ class JediAnalyzer:
             result["imports"]["internal"] = sorted(set(internal_imports))
             result["imports"]["external"] = sorted(set(external_imports))
 
-            # Find what imports this module
-            target_root = module_path.split(".")[0]
-            py_files = await self.get_project_files("*.py", scope)
-            for py_file in py_files:
-                if py_file == module_file:
-                    continue
-
-                try:
-                    importer_module = self._get_import_path_for_file(py_file)
-                    # Pre-filter (avoids AST parse for unrelated files; the AST
-                    # check below is authoritative).  Parse when EITHER the
-                    # absolute path appears textually (absolute imports) OR the
-                    # file shares the target's top-level package — a relative
-                    # import (`from .x import y`) can resolve into the target
-                    # without ever spelling its absolute path (#343).  Source is
-                    # read but not cached or returned — a heuristic, not content.
-                    source = await read_file_async(py_file)
-                    shares_package = bool(
-                        importer_module and importer_module.split(".")[0] == target_root
-                    )
-                    if (
-                        module_path in source
-                        or module_path.replace(".", "/") in source
-                        or shares_package
-                    ):
-                        importer_is_package = py_file.name == "__init__.py"
-                        # Bucket 1: AST for the precise check comes from cache.
-                        tree = file_artifact_cache.get_ast(py_file)
-                        for node in ast.walk(tree):
-                            if isinstance(node, ast.Import):
-                                if any(
-                                    alias.name == module_path
-                                    or alias.name.startswith(module_path + ".")
-                                    for alias in node.names
-                                ):
-                                    if importer_module:
-                                        result["imported_by"].append(importer_module)
-                                    break
-                            elif isinstance(node, ast.ImportFrom):
-                                resolved = self._resolve_relative_import(
-                                    node.level,
-                                    node.module,
-                                    importer_module or "",
-                                    importer_is_package,
-                                )
-                                if resolved and (
-                                    resolved == module_path
-                                    or resolved.startswith(module_path + ".")
-                                ):
-                                    if importer_module:
-                                        result["imported_by"].append(importer_module)
-                                    break
-                except Exception as e:
-                    logger.warning(f"Could not analyze {py_file} for imports: {e}")
-                    continue
-
-            result["imported_by"] = sorted(set(result["imported_by"]))
+            # Find what imports this module (reverse scan extracted to
+            # find_importers so a future imported_by edge can reuse it).
+            importer_pairs = await self.find_importers(module_path, module_file, scope)
+            result["imported_by"] = sorted({module for module, _ in importer_pairs})
 
             # Check for circular dependencies
             # Use visited set to prevent infinite recursion

--- a/src/pyeye/analyzers/jedi_analyzer.py
+++ b/src/pyeye/analyzers/jedi_analyzer.py
@@ -1937,12 +1937,19 @@ class JediAnalyzer:
 
         Returns:
             ``(importer_dotted_module, importer_file)`` pairs, deduped by
-            importer module (first occurrence wins) and sorted by module name.
+            importer module (first occurrence wins, in sorted file path order)
+            and sorted by module name.  Files are iterated in POSIX-sorted
+            order so "first occurrence wins" is deterministic across runs and
+            platforms — the per-module ``Path`` selection does not depend on
+            filesystem or scan order.
         """
         target_root = module_path.split(".")[0]
         importers: dict[str, Path] = {}
 
-        py_files = await self.get_project_files("*.py", scope)
+        py_files = sorted(
+            await self.get_project_files("*.py", scope),
+            key=lambda p: p.as_posix(),
+        )
         for py_file in py_files:
             if py_file == target_file:
                 continue

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -616,7 +616,9 @@ async def resolve_imported_by(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeRes
 #: admits a sync-or-async resolver returning ``EdgeResult | None`` so ``expand``
 #: can stay edge-agnostic (awaiting awaitable results, treating ``None`` as
 #: not-yet-implemented).
-EDGE_RESOLVERS: dict[str, Callable[..., EdgeResult | None | Awaitable[EdgeResult | None]]] = {
+EDGE_RESOLVERS: dict[
+    str, Callable[[Any, JediAnalyzer], EdgeResult | None | Awaitable[EdgeResult | None]]
+] = {
     "members": resolve_members,
     "callees": resolve_callees,
     "imported_by": resolve_imported_by,

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -188,7 +188,7 @@ def resolve_members(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult:
     is fine).
 
     Args:
-        jedi_name: Resolved Jedi ``Name`` (or ``_ModuleSentinel``) for the
+        jedi_name: Resolved Jedi ``Name`` (or :class:`ModuleSentinel`) for the
             container.  Container-ness is derived from its normalised kind.
         analyzer: Active analyzer (for the Jedi project used by ``get_script``).
 
@@ -293,7 +293,7 @@ def _module_members(
     neither included nor excluded (rare in well-typed codebases).
 
     Args:
-        jedi_name: Resolved Jedi ``Name`` (or ``_ModuleSentinel``) for the
+        jedi_name: Resolved Jedi ``Name`` (or :class:`ModuleSentinel`) for the
             module — its ``module_path`` is the module file.
         handle: The module's canonical dotted-name handle.
         analyzer: Active analyzer (for the Jedi project used by ``get_script``).

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -7,23 +7,26 @@ This module is the **single source of truth** for which traversal edges
    machine-distinguishable statuses.  The status string IS the ``reason``
    string ``expand`` emits for unsupported edges.
 2. :data:`EDGE_RESOLVERS` / the resolver registry — maps *implemented* edge
-   names (``members``, ``callees``) to their resolver callables.  Each resolver
-   is synchronous and returns an :class:`EdgeResult` (adjacent canonical handles
-   plus, for ``callees`` only, the count of unresolved call sites).
+   names (``members``, ``callees``, ``imported_by``) to their resolver
+   callables.  ``members``/``callees`` are synchronous and always return an
+   :class:`EdgeResult`; ``imported_by`` is **async** (it awaits the reverse
+   import scan) and returns ``EdgeResult | None`` — ``None`` is the wrong-kind
+   signal (the handle is not a module).  An :class:`EdgeResult` carries the
+   adjacent canonical handles plus, for ``callees`` only, the count of
+   unresolved call sites.  ``expand`` awaits any awaitable resolver result.
 
 Status model (spec §4.3)
 ------------------------
 ==============================  =========================================
 status                          edges
 ==============================  =========================================
-``"implemented"``               ``members``, ``callees``
+``"implemented"``               ``members``, ``callees``, ``imported_by``
 ``"not_yet_implemented"``       ``superclasses``, ``subclasses``,
                                 ``imports``, ``enclosing_scope``
 ``"deferred_reference_backend"``  ``callers``, ``references``, ``read_by``,
                                 ``written_by``, ``passed_by``,
-                                ``imported_by``, ``overrides``,
-                                ``overridden_by``, ``decorated_by``,
-                                ``decorates``
+                                ``overrides``, ``overridden_by``,
+                                ``decorated_by``, ``decorates``
 (unrecognised name)             ``"unknown_edge"``
 ==============================  =========================================
 
@@ -47,13 +50,14 @@ from the legacy count is import exclusion (spec §3.3).
 from __future__ import annotations
 
 import ast
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pyeye import file_artifact_cache
 from pyeye._ast_targets import attr_target_position, find_function_def_at_line
+from pyeye._module_sentinel import ModuleSentinel
 from pyeye.handle import Handle
 from pyeye.mcp.operations.resolve import _normalise_kind
 
@@ -113,7 +117,7 @@ STATUS_DEFERRED_REFERENCE_BACKEND = "deferred_reference_backend"
 STATUS_UNKNOWN_EDGE = "unknown_edge"
 
 #: Edges with a working (or Phase-3-bound) resolver.
-_IMPLEMENTED_EDGES = frozenset({"members", "callees"})
+_IMPLEMENTED_EDGES = frozenset({"members", "callees", "imported_by"})
 
 #: Edges recognised by the matrix but not yet built (no reference backend needed).
 _NOT_YET_IMPLEMENTED_EDGES = frozenset({"superclasses", "subclasses", "imports", "enclosing_scope"})
@@ -126,7 +130,6 @@ _DEFERRED_REFERENCE_BACKEND_EDGES = frozenset(
         "read_by",
         "written_by",
         "passed_by",
-        "imported_by",
         "overrides",
         "overridden_by",
         "decorated_by",
@@ -533,13 +536,88 @@ def _resolve_call_target(script: Any, target: tuple[int, int]) -> tuple[Handle, 
 
 
 # ---------------------------------------------------------------------------
+# imported_by resolver (spec §5.3) — pure-AST reverse import scan
+# ---------------------------------------------------------------------------
+
+
+async def resolve_imported_by(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult | None:
+    """Return the modules that import a target module as canonical handles.
+
+    The inbound ``imported_by`` edge for a **module** handle.  Reuses
+    :meth:`JediAnalyzer.find_importers` — a pure-AST reverse import scan (no
+    ``get_references`` / ``find_references``, the same load-bearing trust
+    constraint as ``callees``).  ``find_importers`` already dedups by importer
+    module and returns a deterministic sorted order, so the adjacents are unique
+    and stable across runs and platforms without further processing here.
+
+    Each adjacent's ``Name`` is built as a :class:`ModuleSentinel` from the
+    importer's OWN FILE — never by re-resolving the importer handle.  That is
+    deliberate: a non-package importer (a standalone ``script_importer.py`` at a
+    project root) has no importable dotted path to re-resolve, so handle-based
+    re-resolution would drop it.  Constructing the sentinel from the file the
+    scan already returned keeps that breadth (#345).
+
+    Kind gate (the load-bearing #332 distinction):
+
+    - **module** → measured: ``EdgeResult`` with the importer handles (possibly
+      empty if nobody imports it — a genuine measured "none", NOT an error).
+    - **non-module** (class / function / variable / …) → ``None``.  A *symbol*
+      CAN be imported, so returning ``EdgeResult([])`` would be the "measured
+      zero" lie; ``None`` signals "this edge does not apply to this kind" and
+      becomes ``not_yet_implemented`` downstream in ``expand`` (Phase 4).  The
+      caller MUST distinguish ``None`` from ``EdgeResult([])``.
+
+    Asynchronous: ``find_importers`` reads project files asynchronously, so this
+    resolver is ``async``.  ``expand`` awaits awaitable resolver results; the
+    sync ``members``/``callees`` resolvers are unaffected.
+
+    Args:
+        jedi_name: Resolved Jedi ``Name`` (or :class:`ModuleSentinel`) for the
+            target.  Module-ness is derived from its normalised kind; the
+            ``full_name`` / ``module_path`` are the dotted handle and file.
+        analyzer: Active analyzer (provides ``find_importers``).
+
+    Returns:
+        An :class:`EdgeResult` whose ``adjacents`` are the importer
+        ``(canonical Handle, ModuleSentinel)`` pairs (kind module) for a module
+        target, or ``None`` for a non-module target.  ``unresolved_call_sites``
+        is always ``None`` — that notion is callees-only.
+    """
+    if _normalise_kind(getattr(jedi_name, "type", None)) != "module":
+        return None
+
+    module_path = getattr(jedi_name, "full_name", None)
+    target_file = getattr(jedi_name, "module_path", None)
+    if not module_path or target_file is None:
+        return EdgeResult(adjacents=[])
+
+    importer_pairs = await analyzer.find_importers(module_path, Path(target_file), scope="all")
+
+    adjacents: list[tuple[Handle, Any]] = []
+    for importer_module, importer_file in importer_pairs:
+        h = _try_handle(importer_module)
+        if h is None:
+            continue
+        # Build the Name from the importer's FILE, not by re-resolving the
+        # handle — re-resolution drops non-package scripts (see docstring).
+        name = ModuleSentinel(importer_file, str(h), analyzer)
+        adjacents.append((h, name))
+
+    return EdgeResult(adjacents=adjacents)
+
+
+# ---------------------------------------------------------------------------
 # Resolver registry
 # ---------------------------------------------------------------------------
 
-#: Maps *implemented* edge names → resolver callables.  Each resolver is
-#: synchronous and returns an :class:`EdgeResult` (uniform across edges so
-#: ``expand`` stays edge-agnostic).
-EDGE_RESOLVERS: dict[str, Callable[[Any, JediAnalyzer], EdgeResult]] = {
+#: Maps *implemented* edge names → resolver callables.  ``members``/``callees``
+#: are synchronous and always return an :class:`EdgeResult`; ``imported_by`` is
+#: async and may return ``None`` (wrong-kind signal).  The value type therefore
+#: admits a sync-or-async resolver returning ``EdgeResult | None`` so ``expand``
+#: can stay edge-agnostic (awaiting awaitable results, treating ``None`` as
+#: not-yet-implemented).
+EDGE_RESOLVERS: dict[str, Callable[..., EdgeResult | None | Awaitable[EdgeResult | None]]] = {
     "members": resolve_members,
     "callees": resolve_callees,
+    "imported_by": resolve_imported_by,
 }

--- a/src/pyeye/mcp/operations/expand.py
+++ b/src/pyeye/mcp/operations/expand.py
@@ -117,13 +117,21 @@ async def expand(handle: str, edge: str, analyzer: JediAnalyzer) -> dict[str, An
     Args:
         handle: Canonical Python dotted-name string (from resolve/resolve_at)
             for the source symbol.
-        edge: The traversal edge to walk (e.g. ``"members"``, ``"callees"``).
+        edge: The traversal edge to walk
+            (e.g. ``"members"``, ``"callees"``, ``"imported_by"``).
         analyzer: Configured ``JediAnalyzer`` for the project.
 
     Returns:
         Either the supported branch (``source``/``edge``/``stubs`` and, for
         ``callees`` only, ``unresolved_call_sites``) or the unsupported branch
-        (``unsupported``/``reason``/``detail``).  Never raises.
+        (``unsupported``/``reason``/``detail``).  The unsupported branch is
+        also returned for an *implemented* edge when its resolver returns
+        ``None`` — the wrong-kind signal meaning the edge does not apply to
+        this handle's kind (e.g. ``imported_by`` on a non-module).  That case
+        is distinct from both a source-not-found unresolvable handle (which
+        yields a graceful supported empty result) and a measured-empty
+        ``EdgeResult`` (resolver matched the kind but found no adjacents →
+        supported ``stubs: []``).  Never raises.
     """
     status = edge_status(edge)
 
@@ -178,6 +186,13 @@ async def expand(handle: str, edge: str, analyzer: JediAnalyzer) -> dict[str, An
 
     if edge_result is None:
         kind = _normalise_kind(getattr(jedi_name, "type", None))
+        # NOTE: The detail message below uses affirmative "supported for modules
+        # only" wording as required by spec §4.1 for the ``imported_by`` edge.
+        # This phrasing assumes that ``imported_by`` is the ONLY resolver that
+        # ever returns ``None`` (i.e. every wrong-kind resolver is module-only).
+        # If a future edge adds a ``None``-returning resolver for a different
+        # kind restriction, this branch must be revisited to generate an
+        # edge-specific detail rather than the hardcoded module-only hint.
         return {
             "source": source,
             "edge": edge,

--- a/src/pyeye/mcp/operations/expand.py
+++ b/src/pyeye/mcp/operations/expand.py
@@ -65,6 +65,7 @@ from pyeye.mcp.operations.edges import (
     edge_status,
 )
 from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
+from pyeye.mcp.operations.resolve import _normalise_kind
 from pyeye.mcp.operations.stubs import build_stub
 
 if TYPE_CHECKING:
@@ -164,14 +165,29 @@ async def expand(handle: str, edge: str, analyzer: JediAnalyzer) -> dict[str, An
     # ------------------------------------------------------------------
     # A resolver may be sync (members/callees → EdgeResult) or async
     # (imported_by → Awaitable[EdgeResult | None]); await any awaitable result.
-    # A ``None`` result is the wrong-kind signal — Phase 4 will surface that as a
-    # distinct discriminator; for now a missing edge_result yields the graceful
-    # supported-empty shape (no stubs), consistent with the source-not-found path.
+    # A ``None`` result is the WRONG-KIND signal: the edge genuinely does not
+    # apply to this handle's kind (e.g. ``imported_by`` on a class — a symbol
+    # CAN be imported, so claiming ``stubs: []`` would be the #332 measured-zero
+    # lie).  Surface it as the UNSUPPORTED branch with a KIND-SPECIFIC detail
+    # (synthesized inline — the generic _unsupported_detail can't name the kind).
+    # This is DISTINCT from the source-not-found path above (jedi_name is None →
+    # graceful supported-empty) and from a measured-empty EdgeResult (the
+    # resolver matched the kind but found no adjacents → supported ``stubs: []``).
     raw = EDGE_RESOLVERS[edge](jedi_name, analyzer)
     edge_result = await raw if isawaitable(raw) else raw
 
     if edge_result is None:
-        return {"source": source, "edge": edge, "stubs": []}
+        kind = _normalise_kind(getattr(jedi_name, "type", None))
+        return {
+            "source": source,
+            "edge": edge,
+            "unsupported": True,
+            "reason": STATUS_NOT_YET_IMPLEMENTED,
+            "detail": (
+                f"Edge '{edge}' does not apply to a {kind} handle; it is "
+                f"supported for modules only in this slice."
+            ),
+        }
 
     stubs = [
         build_stub(name, str(adj_handle), analyzer) for adj_handle, name in edge_result.adjacents

--- a/src/pyeye/mcp/operations/expand.py
+++ b/src/pyeye/mcp/operations/expand.py
@@ -54,6 +54,7 @@ synchronous.
 
 from __future__ import annotations
 
+from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
 from pyeye.mcp.operations.edges import (
@@ -161,7 +162,17 @@ async def expand(handle: str, edge: str, analyzer: JediAnalyzer) -> dict[str, An
     # The resolver carries the Jedi Name so builtin/stdlib callee stubs build
     # without re-resolution (the load-bearing reason EdgeResult carries Names).
     # ------------------------------------------------------------------
-    edge_result = EDGE_RESOLVERS[edge](jedi_name, analyzer)
+    # A resolver may be sync (members/callees → EdgeResult) or async
+    # (imported_by → Awaitable[EdgeResult | None]); await any awaitable result.
+    # A ``None`` result is the wrong-kind signal — Phase 4 will surface that as a
+    # distinct discriminator; for now a missing edge_result yields the graceful
+    # supported-empty shape (no stubs), consistent with the source-not-found path.
+    raw = EDGE_RESOLVERS[edge](jedi_name, analyzer)
+    edge_result = await raw if isawaitable(raw) else raw
+
+    if edge_result is None:
+        return {"source": source, "edge": edge, "stubs": []}
+
     stubs = [
         build_stub(name, str(adj_handle), analyzer) for adj_handle, name in edge_result.adjacents
     ]

--- a/src/pyeye/mcp/operations/expand.py
+++ b/src/pyeye/mcp/operations/expand.py
@@ -2,7 +2,8 @@
 
 ``expand`` is the user-facing primitive that walks ONE edge from a canonical
 source handle and returns the adjacent symbols as lightweight stubs.  It is the
-composition layer over the Phase-2/3 edge resolvers (``members``, ``callees``)
+composition layer over the Phase-2/3 edge resolvers (``members``, ``callees``,
+``imported_by``)
 and the Phase-1 stub builder — it adds NO new resolution logic of its own.
 
 Discriminated union (spec §4.2)

--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -44,7 +44,7 @@ from pyeye._ast_targets import (
     find_function_def_at_line as _find_function_def_at_line,
 )
 from pyeye._jedi_location import location_from_name
-from pyeye._module_sentinel import ModuleSentinel as _ModuleSentinel
+from pyeye._module_sentinel import ModuleSentinel
 from pyeye.canonicalization import collect_re_exports, find_module_file
 from pyeye.handle import Handle
 from pyeye.mcp.operations.edges import resolve_members
@@ -547,7 +547,7 @@ def _find_jedi_name_for_handle(handle: str, analyzer: JediAnalyzer) -> Any | Non
             # We'll return None here and handle module specially below.
         except Exception:
             pass
-        return _ModuleSentinel(mod_file, handle, analyzer)
+        return ModuleSentinel(mod_file, handle, analyzer)
 
     # Case 2: leaf symbol inside a module
     if len(parts) < 2:
@@ -707,7 +707,7 @@ async def _count_module_members(jedi_name: Any, analyzer: JediAnalyzer) -> int:
     Collapsing them into one function would break that dispatch and test seam.
 
     Args:
-        jedi_name: Jedi ``Name`` or ``_ModuleSentinel`` for the module.
+        jedi_name: Jedi ``Name`` or ``ModuleSentinel`` for the module.
         analyzer: Active analyzer.
 
     Returns:
@@ -807,7 +807,7 @@ async def _build_edge_counts(
     Args:
         handle: Canonical dotted-name string.
         kind: Normalised kind string (``"class"``, ``"function"``, etc.).
-        jedi_name: Jedi ``Name`` (or ``_ModuleSentinel``) for the symbol.
+        jedi_name: Jedi ``Name`` (or ``ModuleSentinel``) for the symbol.
         analyzer: Active analyzer.
         budget_seconds: Per-edge time budget in seconds.
 
@@ -1077,7 +1077,7 @@ def _build_module_fields(jedi_name: Any, handle: str) -> dict[str, Any]:
     ``__init__.py``) and the parent package handle.
 
     Args:
-        jedi_name: Jedi Name (or ``_ModuleSentinel``) for the module.
+        jedi_name: Jedi Name (or ``ModuleSentinel``) for the module.
         handle: Canonical dotted-name string of the module.
 
     Returns:

--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -44,6 +44,7 @@ from pyeye._ast_targets import (
     find_function_def_at_line as _find_function_def_at_line,
 )
 from pyeye._jedi_location import location_from_name
+from pyeye._module_sentinel import ModuleSentinel as _ModuleSentinel
 from pyeye.canonicalization import collect_re_exports, find_module_file
 from pyeye.handle import Handle
 from pyeye.mcp.operations.edges import resolve_members
@@ -594,48 +595,6 @@ def _find_jedi_name_for_handle(handle: str, analyzer: JediAnalyzer) -> Any | Non
         pass
 
     return None
-
-
-class _ModuleSentinel:
-    """Lightweight stand-in for a Jedi Name when the handle *is* a module.
-
-    Stores the module file path and enough info for ``inspect`` to build the
-    location and docstring without a real ``Name`` object.
-    """
-
-    def __init__(self, mod_file: Path, handle: str, analyzer: JediAnalyzer) -> None:
-        self.mod_file = mod_file
-        self.handle = handle
-        self._analyzer = analyzer
-
-        # Populate Jedi-Name-like attributes from the module file
-        self.module_path: Path | None = mod_file
-        self.type = "module"
-        self.full_name: str = handle
-        self.name: str = handle.split(".")[-1]
-        self.line: int = 1
-        self.column: int = 0
-
-        # Read docstring from module-level AST
-        self.docstring_text: str = ""
-        try:
-            source = mod_file.read_text(encoding="utf-8", errors="replace")
-            tree = ast.parse(source)
-            ds = ast.get_docstring(tree)
-            if ds:
-                self.docstring_text = ds
-        except Exception:
-            pass
-
-    def docstring(self, **kwargs: object) -> str:
-        _ = kwargs  # accepted-and-ignored for Jedi Name.docstring() signature compat
-        return self.docstring_text
-
-    def get_signatures(self) -> list:
-        return []
-
-    def infer(self) -> list:
-        return []
 
 
 # ---------------------------------------------------------------------------

--- a/src/pyeye/mcp/operations/stubs.py
+++ b/src/pyeye/mcp/operations/stubs.py
@@ -87,7 +87,7 @@ def build_stub(jedi_name: Any, handle: str, analyzer: JediAnalyzer) -> dict[str,
     or Phase-4 expand supply it).  ``build_stub`` does NOT canonicalize.
 
     Args:
-        jedi_name: A Jedi ``Name`` object (or ``_ModuleSentinel``-compatible
+        jedi_name: A Jedi ``Name`` object (or ``ModuleSentinel``-compatible
             object) for the symbol.
         handle: The already-canonical dotted-name handle for the symbol.
         analyzer: Active analyzer for scope classification.

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -501,9 +501,16 @@ async def expand(
         project symbols and stdlib/external symbols reachable via Jedi's goto.
         Dynamic calls (un-inferable parameters, ``getattr``, lambdas, etc.) are
         counted in ``unresolved_call_sites`` rather than invented.
+      - ``imported_by``  — module → the project modules that import it (module
+        Stubs), computed by static AST import-graph reversal (no reverse symbol
+        search).  Covers importers anywhere in the project including tests and
+        standalone scripts.  Non-module handles return the unsupported branch
+        with ``reason: "not_yet_implemented"`` (symbol-level ``imported_by`` is
+        not yet implemented).  Ceiling: runtime-dynamic imports
+        (``importlib``/``__import__`` with computed targets) are not detected.
 
     Unsupported edges return the unsupported branch (never raise):
-      - Inbound/reference edges (``callers``, ``references``, ``imported_by``,
+      - Inbound/reference edges (``callers``, ``references``,
         ``overrides``, …) require the Pyright reference backend (#333) and return
         ``unsupported: true, reason: "deferred_reference_backend"``.
       - Other structural edges (``superclasses``, ``subclasses``, ``imports``,

--- a/tests/conformance/test_linter_adversarial_expand.py
+++ b/tests/conformance/test_linter_adversarial_expand.py
@@ -692,3 +692,76 @@ class TestRealExpandOutputConforms:
 
         assert isinstance(result, dict), f"result must be a dict; got {type(result)!r}"
         lint_response(result, "expand")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_real_imported_by_module_output_conforms(self) -> None:
+        """Real expand(widgets module, imported_by) supported branch passes the linter.
+
+        The supported ``imported_by`` result carries ``source``/``edge``/``stubs``
+        with no ``unresolved_call_sites`` — the existing E.3 rule must accept it
+        (because E.3 only requires the field for ``edge == "callees"``).
+        """
+        from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+        from pyeye.mcp.operations.expand import expand
+
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        result = await expand("mypackage._core.widgets", "imported_by", analyzer)
+
+        assert isinstance(result, dict), f"result must be a dict; got {type(result)!r}"
+        # Supported branch — stubs present, no unsupported key.
+        assert "stubs" in result, f"expected supported branch with stubs; got {result!r}"
+        assert "unsupported" not in result
+        lint_response(result, "expand")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_real_imported_by_non_module_output_conforms(self) -> None:
+        """Real expand(Widget class, imported_by) unsupported branch passes the linter.
+
+        The ``not_yet_implemented`` reason is already in the linter's
+        ``_VALID_UNSUPPORTED_REASONS`` set — no linter change needed.
+        """
+        from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+        from pyeye.mcp.operations.expand import expand
+
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        result = await expand("mypackage._core.widgets.Widget", "imported_by", analyzer)
+
+        assert isinstance(result, dict), f"result must be a dict; got {type(result)!r}"
+        # Unsupported branch — reason=not_yet_implemented.
+        assert result.get("unsupported") is True
+        assert result.get("reason") == "not_yet_implemented"
+        lint_response(result, "expand")  # must not raise
+
+
+# ===========================================================================
+# imported_by remains in _PHASE4_UNMEASURED_EDGES (inspect edge_counts guard)
+# ===========================================================================
+
+
+class TestImportedByRemainsInUnmeasuredEdges:
+    """Read-only assertion: imported_by is still forbidden in inspect edge_counts.
+
+    ``imported_by`` is now a supported ``expand`` edge, but ``inspect`` does NOT
+    measure it in ``edge_counts`` (that would require a separate inspection pass
+    per module).  It must therefore remain in ``_PHASE4_UNMEASURED_EDGES`` so
+    that B.3 continues to reject any inspect response that fraudulently claims to
+    have measured it.
+
+    This test is a READ-ONLY assertion on the constant — it does NOT modify the
+    linter.  If this test fails it means ``imported_by`` was removed from
+    ``_PHASE4_UNMEASURED_EDGES`` without a corresponding ``inspect`` measurement
+    implementation, which would allow the B.3 false-measurement guard to be
+    silently bypassed.
+    """
+
+    def test_imported_by_is_in_phase4_unmeasured_edges(self) -> None:
+        """``imported_by`` must be in ``_PHASE4_UNMEASURED_EDGES`` (read-only assertion)."""
+        from tests.conformance.response_linter import _PHASE4_UNMEASURED_EDGES
+
+        assert "imported_by" in _PHASE4_UNMEASURED_EDGES, (
+            "'imported_by' was removed from _PHASE4_UNMEASURED_EDGES without adding "
+            "a corresponding measurement to inspect.py.  The B.3 guard would then silently "
+            "accept inspect responses that fraudulently claim a measured imported_by count. "
+            "Either restore the entry or add the inspect measurement and update the expected "
+            "edges for module/class kinds in _PHASE4_EXPECTED_EDGES."
+        )

--- a/tests/fixtures/resolve_project/mypackage/_core/direct_importer.py
+++ b/tests/fixtures/resolve_project/mypackage/_core/direct_importer.py
@@ -1,0 +1,14 @@
+"""Importer that reaches widgets via a direct ``import`` statement.
+
+Exercises the ``ast.Import`` path of ``find_importers``:
+``import mypackage._core.widgets`` matches ``alias.name == module_path``.
+"""
+
+import mypackage._core.widgets
+
+__all__ = ["build"]
+
+
+def build() -> object:
+    """Return a widget, referencing the direct import so it is used."""
+    return mypackage._core.widgets.make_widget("direct")

--- a/tests/fixtures/resolve_project/mypackage/_core/rel_importer.py
+++ b/tests/fixtures/resolve_project/mypackage/_core/rel_importer.py
@@ -1,0 +1,16 @@
+"""Importer that reaches widgets via a relative ``from`` import.
+
+Exercises the ``ast.ImportFrom`` + ``_resolve_relative_import`` path of
+``find_importers``: ``from .widgets import make_widget`` is a level-1 relative
+import that resolves to ``mypackage._core.widgets`` without ever spelling the
+absolute path textually.
+"""
+
+from .widgets import make_widget
+
+__all__ = ["build"]
+
+
+def build() -> object:
+    """Return a widget, referencing the relative import so it is used."""
+    return make_widget("rel")

--- a/tests/fixtures/resolve_project/script_importer.py
+++ b/tests/fixtures/resolve_project/script_importer.py
@@ -1,0 +1,12 @@
+"""Standalone script that imports the widgets module.
+
+Lives OUTSIDE the ``mypackage`` package (top level of the fixture tree), so
+``_get_import_path_for_file`` yields a path-derived handle (``script_importer``),
+NOT a package module. Proves ``find_importers`` reports importers from
+non-package / script-style files — the breadth the file-based scan buys.
+"""
+
+import mypackage._core.widgets
+
+if __name__ == "__main__":
+    print(mypackage._core.widgets.make_widget("script"))

--- a/tests/integration/api_redesign/test_traversal_integration.py
+++ b/tests/integration/api_redesign/test_traversal_integration.py
@@ -382,3 +382,254 @@ class TestExpandPlainDictContract:
         assert (
             type(result) is dict
         ), f"unsupported result must be exact dict; got {type(result)!r}"  # noqa: E721
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: imported_by edge — module (supported) and non-module (unsupported)
+# ---------------------------------------------------------------------------
+
+
+class TestExpandImportedByModuleEndToEnd:
+    """End-to-end tests for the ``imported_by`` edge on a MODULE handle over the wire.
+
+    ``mypackage._core.widgets`` is a module that has known importers — the result
+    must be the supported branch with non-empty stubs, each of kind ``"module"``.
+    No ``unresolved_call_sites`` (``imported_by`` is an inbound scan, not callees).
+    """
+
+    @pytest.mark.asyncio
+    async def test_imported_by_module_returns_supported_branch(self) -> None:
+        """expand(widgets module, 'imported_by') returns the supported branch (no 'unsupported')."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
+        assert "unsupported" not in result, (
+            "supported result must not carry 'unsupported'; " f"got result={result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_imported_by_module_has_required_fields(self) -> None:
+        """expand(widgets module, 'imported_by') returns source/edge/stubs."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert "source" in result, f"'source' missing from result: {result!r}"
+        assert "edge" in result, f"'edge' missing from result: {result!r}"
+        assert "stubs" in result, f"'stubs' missing from result: {result!r}"
+        assert result["edge"] == "imported_by"
+
+    @pytest.mark.asyncio
+    async def test_imported_by_module_stubs_non_empty(self) -> None:
+        """widgets has known importers — stubs must be a non-empty list."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        stubs = result["stubs"]
+        assert isinstance(stubs, list), f"stubs must be a list; got {type(stubs)!r}"
+        assert len(stubs) > 0, "widgets has known importers — stubs must be non-empty"
+
+    @pytest.mark.asyncio
+    async def test_imported_by_module_stubs_have_required_fields(self) -> None:
+        """Each stub in the imported_by result has handle/kind/scope/line_start/line_end."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        for i, stub in enumerate(result["stubs"]):
+            assert isinstance(stub, dict), f"stub[{i}] must be a plain dict; got {type(stub)!r}"
+            for field in ("handle", "kind", "scope", "line_start", "line_end"):
+                assert field in stub, f"stub[{i}] missing required field '{field}'; stub={stub!r}"
+
+    @pytest.mark.asyncio
+    async def test_imported_by_module_stubs_are_module_kind(self) -> None:
+        """Each importer stub must have kind == 'module' (importers are always modules)."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        for i, stub in enumerate(result["stubs"]):
+            assert stub["kind"] == "module", (
+                f"stub[{i}] must have kind='module'; "
+                f"got kind={stub.get('kind')!r}; stub={stub!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_imported_by_module_no_unresolved_call_sites(self) -> None:
+        """imported_by must NOT include 'unresolved_call_sites' (callees-only field)."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert "unresolved_call_sites" not in result, (
+            "'unresolved_call_sites' must be absent for imported_by edge; "
+            f"got result keys: {list(result.keys())!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_imported_by_module_result_is_json_serialisable(self) -> None:
+        """The imported_by module result round-trips through json.dumps without error."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        # Must not raise — ensures no custom types leak across the wire
+        serialised = json.dumps(result)
+        roundtripped = json.loads(serialised)
+        assert isinstance(roundtripped, dict)
+        assert isinstance(roundtripped["stubs"], list)
+
+    @pytest.mark.asyncio
+    async def test_imported_by_module_result_is_plain_dict_with_plain_stubs(self) -> None:
+        """All nested values in the supported imported_by result are plain Python primitives."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert (
+            type(result) is dict
+        ), f"result must be exact dict (not subclass); got {type(result)!r}"  # noqa: E721
+        for i, stub in enumerate(result["stubs"]):
+            assert (
+                type(stub) is dict
+            ), f"stub[{i}] must be exact dict; got {type(stub)!r}"  # noqa: E721
+
+
+class TestExpandImportedByNonModuleEndToEnd:
+    """End-to-end tests for the ``imported_by`` edge on a NON-MODULE handle over the wire.
+
+    ``mypackage._core.widgets.Widget`` is a class — ``imported_by`` does not
+    apply to non-module kinds.  The resolver returns ``None`` (the wrong-kind
+    signal); ``expand`` must surface this as the unsupported branch with
+    ``reason == "not_yet_implemented"``, not as an empty supported result
+    (which would be the #332 measured-zero lie).
+    """
+
+    @pytest.mark.asyncio
+    async def test_imported_by_non_module_returns_unsupported_branch(self) -> None:
+        """expand(Widget class, 'imported_by') returns the unsupported branch."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets.Widget",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
+        assert result.get("unsupported") is True, (
+            "'unsupported' must be True for non-module imported_by; " f"got result={result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_imported_by_non_module_reason_is_not_yet_implemented(self) -> None:
+        """Non-module imported_by reason must be 'not_yet_implemented'."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets.Widget",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert (
+            result["reason"] == "not_yet_implemented"
+        ), f"expected reason='not_yet_implemented'; got {result.get('reason')!r}"
+
+    @pytest.mark.asyncio
+    async def test_imported_by_non_module_has_non_empty_detail(self) -> None:
+        """The unsupported branch must include a non-empty 'detail' string."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets.Widget",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert "detail" in result, f"'detail' missing from unsupported result: {result!r}"
+        assert (
+            isinstance(result["detail"], str) and len(result["detail"]) > 0
+        ), f"'detail' must be a non-empty string; got {result.get('detail')!r}"
+
+    @pytest.mark.asyncio
+    async def test_imported_by_non_module_has_no_stubs(self) -> None:
+        """The unsupported branch must NOT include 'stubs'."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets.Widget",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert "stubs" not in result, (
+            "'stubs' must be absent from unsupported branch; "
+            f"got result keys: {list(result.keys())!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_imported_by_non_module_result_is_json_serialisable(self) -> None:
+        """The unsupported branch round-trips through json.dumps without error."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets.Widget",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        serialised = json.dumps(result)
+        roundtripped = json.loads(serialised)
+        assert isinstance(roundtripped, dict)
+        assert roundtripped.get("unsupported") is True
+
+    @pytest.mark.asyncio
+    async def test_imported_by_non_module_result_is_plain_dict(self) -> None:
+        """The unsupported branch result is an exact plain dict."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="mypackage._core.widgets.Widget",
+            edge="imported_by",
+            project_path=str(_FIXTURE),
+        )
+
+        assert (
+            type(result) is dict
+        ), f"unsupported result must be exact dict; got {type(result)!r}"  # noqa: E721

--- a/tests/integration/jedi_integration/test_module_analysis.py
+++ b/tests/integration/jedi_integration/test_module_analysis.py
@@ -1,5 +1,7 @@
 """Tests for module analysis functionality."""
 
+from pathlib import Path
+
 import pytest
 
 from pyeye.analyzers.jedi_analyzer import JediAnalyzer
@@ -490,3 +492,83 @@ class TestJediAnalyzerMethods:
         result = await analyzer.get_module_info("module")
         assert result["docstring"] == "Doc."
         assert len(result["functions"]) == 1
+
+
+_FIXTURE = Path(__file__).parent.parent.parent / "fixtures" / "resolve_project"
+_TARGET = "mypackage._core.widgets"
+_TARGET_FILE = _FIXTURE / "mypackage" / "_core" / "widgets.py"
+
+
+class TestFindImporters:
+    """Tests for the extracted ``find_importers`` reverse-scan method.
+
+    Uses the committed ``resolve_project`` fixture (a real directory, not a
+    tmp dir) so the file-based reverse scan exercises the same code paths the
+    legacy ``analyze_dependencies`` does.
+    """
+
+    @pytest.mark.asyncio
+    async def test_find_importers_reports_direct_and_relative_importers(self):
+        """Both a direct ``import`` and a relative ``from`` importer are found.
+
+        ``direct_importer`` reaches the target via ``import
+        mypackage._core.widgets`` (``ast.Import``); ``rel_importer`` reaches it
+        via ``from .widgets import make_widget`` (``ast.ImportFrom`` resolved
+        through ``_resolve_relative_import``). Subset assertions keep this
+        robust against fixture growth.
+        """
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        pairs = await analyzer.find_importers(_TARGET, _TARGET_FILE, scope="all")
+
+        modules = {m for m, _ in pairs}
+        # Direct ast.Import importer.
+        assert "mypackage._core.direct_importer" in modules
+        # Relative ast.ImportFrom importer.
+        assert "mypackage._core.rel_importer" in modules
+        # Existing absolute from-importers are still present.
+        assert "mypackage.usage" in modules
+
+    @pytest.mark.asyncio
+    async def test_find_importers_excludes_target_and_is_deduped(self):
+        """The target's own file is excluded and modules are deduped."""
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        pairs = await analyzer.find_importers(_TARGET, _TARGET_FILE, scope="all")
+
+        modules = [m for m, _ in pairs]
+        # Target's own module never reports itself as an importer.
+        assert _TARGET not in modules
+        # Deduped by importer module (one entry per module).
+        assert len(modules) == len(set(modules))
+        # Every pair carries the importer's file path.
+        for _module, file_path in pairs:
+            assert isinstance(file_path, Path)
+
+    @pytest.mark.asyncio
+    async def test_find_importers_reports_non_package_script(self):
+        """A standalone script outside the package is still reported.
+
+        ``script_importer.py`` lives at the fixture root, outside
+        ``mypackage/``, so its handle is the path-derived ``script_importer``
+        (not a package module). The file-based scan must still attribute it,
+        proving coverage breadth (tests + standalone scripts).
+        """
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        pairs = await analyzer.find_importers(_TARGET, _TARGET_FILE, scope="all")
+
+        modules = {m for m, _ in pairs}
+        assert "script_importer" in modules
+
+    @pytest.mark.asyncio
+    async def test_analyze_dependencies_imported_by_parity(self):
+        """``analyze_dependencies['imported_by']`` matches ``find_importers``.
+
+        Extraction parity: the legacy method's ``imported_by`` field must equal
+        the sorted, deduped module projection of ``find_importers`` output for
+        the same target. Exact equality (both sides compute the same set).
+        """
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        pairs = await analyzer.find_importers(_TARGET, _TARGET_FILE, scope="all")
+        expected = sorted({m for m, _ in pairs})
+
+        result = await analyzer.analyze_dependencies(_TARGET, scope="all")
+        assert result["imported_by"] == expected

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -45,12 +45,14 @@ from unittest.mock import Mock, patch
 import jedi
 import pytest
 
+from pyeye._module_sentinel import ModuleSentinel
 from pyeye.analyzers.jedi_analyzer import JediAnalyzer
 from pyeye.handle import Handle
 from pyeye.mcp.operations.edges import (
     EdgeResult,
     edge_status,
     resolve_callees,
+    resolve_imported_by,
     resolve_members,
 )
 from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
@@ -67,6 +69,14 @@ _MODULE_FORMS_HANDLE = "mypackage._core.module_forms"
 _CALLEES_MODULE_HANDLE = "mypackage._core.callees_fixture"
 _ORCHESTRATE_HANDLE = "mypackage._core.callees_fixture.orchestrate"
 _PROCESSOR_RUN_HANDLE = "mypackage._core.callees_fixture.Processor.run"
+
+# imported_by fixtures: ``widgets`` is imported by several mypackage modules
+# AND by the non-package ``script_importer`` (a standalone script at the
+# fixture root). ``module_forms`` is a leaf module that nobody imports.
+_SCRIPT_IMPORTER_HANDLE = "script_importer"
+_DIRECT_IMPORTER_HANDLE = "mypackage._core.direct_importer"
+_REL_IMPORTER_HANDLE = "mypackage._core.rel_importer"
+_USAGE_IMPORTER_HANDLE = "mypackage.usage"
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +134,12 @@ class TestEdgeStatusModel:
     def test_not_yet_implemented_edges(self, edge: str) -> None:
         assert edge_status(edge) == "not_yet_implemented"
 
+    def test_imported_by_is_implemented(self) -> None:
+        # imported_by moves from deferred_reference_backend to implemented in
+        # Phase 3: its resolver (resolve_imported_by) builds on the pure-AST
+        # find_importers scan — no indexed reference backend needed.
+        assert edge_status("imported_by") == "implemented"
+
     @pytest.mark.parametrize(
         "edge",
         [
@@ -132,7 +148,6 @@ class TestEdgeStatusModel:
             "read_by",
             "written_by",
             "passed_by",
-            "imported_by",
             "overrides",
             "overridden_by",
             "decorated_by",
@@ -469,4 +484,154 @@ class TestResolveCalleesNeverReverseSearch:
             result = _callees_for(_ORCHESTRATE_HANDLE, analyzer)
         # Resolver completed without touching reverse search.
         assert _MAKE_WIDGET_HANDLE in {str(h) for h in result.handles}
+        spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Task 3.1/3.2 — imported_by resolver (pure-AST reverse import scan, async)
+# ---------------------------------------------------------------------------
+
+
+async def _imported_by_for(handle: str, analyzer: JediAnalyzer) -> EdgeResult | None:
+    """Resolve *handle* to a Jedi name and await its ``imported_by`` result.
+
+    Returns the raw resolver result so tests can distinguish ``None`` (wrong
+    kind — a non-module handle) from ``EdgeResult([])`` (a module nobody
+    imports — measured none).
+    """
+    jedi_name = _find_jedi_name_for_handle(handle, analyzer)
+    assert jedi_name is not None, f"Could not find Jedi name for handle {handle!r}"
+    return await resolve_imported_by(jedi_name, analyzer)
+
+
+class TestResolveImportedByModule:
+    """``imported_by`` = the modules that import a target module (reverse scan).
+
+    Contract is "≥ these known importers" — a SUBSET assertion, not exact
+    equality — so the test stays robust as the fixture grows. The non-package
+    ``script_importer`` is pinned explicitly: it lives outside ``mypackage`` and
+    is the case that the file-based scan (not Jedi reference resolution) buys.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_edgeresult(self, analyzer: JediAnalyzer) -> None:
+        result = await _imported_by_for(_MODULE_HANDLE, analyzer)
+        assert isinstance(result, EdgeResult)
+        assert all(isinstance(h, Handle) for h in result.handles)
+
+    @pytest.mark.asyncio
+    async def test_known_importers_present(self, analyzer: JediAnalyzer) -> None:
+        result = await _imported_by_for(_MODULE_HANDLE, analyzer)
+        assert result is not None
+        importers = {str(h) for h in result.handles}
+        expected_present = {
+            _DIRECT_IMPORTER_HANDLE,
+            _REL_IMPORTER_HANDLE,
+            _USAGE_IMPORTER_HANDLE,
+        }
+        missing = expected_present - importers
+        assert not missing, f"expected importers missing: {missing}; got {importers}"
+
+    @pytest.mark.asyncio
+    async def test_non_package_script_importer_present(self, analyzer: JediAnalyzer) -> None:
+        # script_importer.py lives at the fixture root, OUTSIDE mypackage, so its
+        # handle is the path-derived ``script_importer``. Building the importer's
+        # Name from its FILE (not by re-resolving the handle) is what makes this
+        # case work — re-resolution fails for non-package scripts.
+        result = await _imported_by_for(_MODULE_HANDLE, analyzer)
+        assert result is not None
+        importers = {str(h) for h in result.handles}
+        assert (
+            _SCRIPT_IMPORTER_HANDLE in importers
+        ), f"non-package script importer missing; got {importers}"
+
+    @pytest.mark.asyncio
+    async def test_adjacents_are_handle_name_pairs_building_module_stubs(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        # Each adjacent is a (Handle, Name) pair whose Name is a module
+        # sentinel (kind == "module") built from the importer's own file.
+        result = await _imported_by_for(_MODULE_HANDLE, analyzer)
+        assert result is not None
+        assert result.adjacents, "widgets should have importers"
+        for handle, name in result.adjacents:
+            assert isinstance(handle, Handle)
+            assert isinstance(name, ModuleSentinel)
+            assert name.type == "module"
+            # The Name's handle matches the adjacent handle (built from file).
+            assert name.full_name == str(handle)
+
+    @pytest.mark.asyncio
+    async def test_unresolved_call_sites_is_none(self, analyzer: JediAnalyzer) -> None:
+        # The unresolved-call-site notion is callees-only; imported_by never
+        # reports it.
+        result = await _imported_by_for(_MODULE_HANDLE, analyzer)
+        assert result is not None
+        assert result.unresolved_call_sites is None
+
+
+class TestResolveImportedByMeasuredEmpty:
+    """A module that nobody imports → ``EdgeResult([])`` (measured none).
+
+    This is the absence-vs-zero invariant: ``module_forms`` IS a module (the
+    kind is correct, so the edge applies), but no other file imports it, so the
+    measured result is an empty adjacency — NOT the wrong-kind ``None`` signal.
+    """
+
+    @pytest.mark.asyncio
+    async def test_leaf_module_is_measured_empty(self, analyzer: JediAnalyzer) -> None:
+        result = await _imported_by_for(_MODULE_FORMS_HANDLE, analyzer)
+        assert result is not None, "module_forms is a module — must NOT be wrong-kind None"
+        assert isinstance(result, EdgeResult)
+        assert result.handles == [], f"module_forms is imported by nobody; got {result.handles}"
+
+
+class TestResolveImportedByNonModule:
+    """A non-module handle → wrong-kind ``None`` (NOT ``EdgeResult([])``).
+
+    This is the load-bearing #332 distinction: a class/function CAN be imported,
+    so returning ``[]`` would be the "measured zero" lie. ``None`` signals "this
+    edge does not apply to this kind" and becomes ``not_yet_implemented``
+    downstream in Phase 4 — it must be distinguishable from the measured-empty
+    module case above.
+    """
+
+    @pytest.mark.asyncio
+    async def test_class_handle_returns_none(self, analyzer: JediAnalyzer) -> None:
+        # Widget is a class — imported_by does not apply to a symbol kind.
+        result = await _imported_by_for(_WIDGET_HANDLE, analyzer)
+        assert result is None, f"non-module handle must return None, got {result!r}"
+
+    @pytest.mark.asyncio
+    async def test_function_handle_returns_none(self, analyzer: JediAnalyzer) -> None:
+        # make_widget is a function — also a symbol kind, also None.
+        result = await _imported_by_for(_MAKE_WIDGET_HANDLE, analyzer)
+        assert result is None, f"non-module handle must return None, got {result!r}"
+
+    @pytest.mark.asyncio
+    async def test_none_is_distinct_from_measured_empty(self, analyzer: JediAnalyzer) -> None:
+        # The two empty-looking outcomes must be machine-distinguishable.
+        wrong_kind = await _imported_by_for(_WIDGET_HANDLE, analyzer)
+        measured_empty = await _imported_by_for(_MODULE_FORMS_HANDLE, analyzer)
+        assert wrong_kind is None
+        assert measured_empty == EdgeResult(adjacents=[])
+        assert wrong_kind != measured_empty
+
+
+class TestResolveImportedByNeverReverseSearch:
+    """imported_by NEVER calls Jedi reverse search (it is pure-AST).
+
+    Mirrors ``TestResolveCalleesNeverReverseSearch``: patch ``get_references`` to
+    explode if touched, await the resolver over the fixture, then assert it
+    completed (real importers present) AND the spy was never called.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_references_not_called(self, analyzer: JediAnalyzer) -> None:
+        assert hasattr(jedi.Script, "get_references")
+        spy = Mock(side_effect=AssertionError("get_references called on imported_by path"))
+        with patch.object(jedi.Script, "get_references", spy):
+            result = await _imported_by_for(_MODULE_HANDLE, analyzer)
+        assert result is not None
+        assert _SCRIPT_IMPORTER_HANDLE in {str(h) for h in result.handles}
         spy.assert_not_called()

--- a/tests/unit/mcp/operations/test_expand.py
+++ b/tests/unit/mcp/operations/test_expand.py
@@ -52,6 +52,13 @@ _WIDGET_HANDLE = "mypackage._core.widgets.Widget"
 _MAKE_WIDGET_HANDLE = "mypackage._core.widgets.make_widget"
 _ORCHESTRATE_HANDLE = "mypackage._core.callees_fixture.orchestrate"
 
+#: imported_by fixtures (Phase 4): ``widgets`` is a module imported by several
+#: other modules (supported, non-empty); ``module_forms`` is a leaf module that
+#: nobody imports (supported, measured ``stubs: []``); ``Widget`` is a CLASS — a
+#: non-module handle for which ``imported_by`` does not apply (unsupported).
+_MODULE_WITH_IMPORTERS_HANDLE = "mypackage._core.widgets"
+_MODULE_NO_IMPORTERS_HANDLE = "mypackage._core.module_forms"
+
 #: The Phase-1 Stub keys that are ALWAYS present (spec §4.1; ``signature`` is
 #: callable-only and therefore not asserted as universally present).
 _STUB_REQUIRED_KEYS = {"handle", "kind", "scope", "line_start", "line_end"}
@@ -300,3 +307,104 @@ class TestExpandBranchesMutuallyExclusive:
         assert result["unsupported"] is True
         assert "stubs" not in result
         assert "unresolved_call_sites" not in result
+
+
+# ---------------------------------------------------------------------------
+# Task 4.1 — imported_by wiring (the three distinct paths, #345/#332)
+# ---------------------------------------------------------------------------
+
+
+class TestExpandImportedBySupported:
+    """``expand`` over ``imported_by`` for a MODULE returns the supported shape.
+
+    The resolver (Phase 3 ``resolve_imported_by``) is async and returns an
+    ``EdgeResult`` for a module handle.  ``expand`` awaits it and builds a stub
+    per importer; every importer stub is a module (``kind == "module"``).  This
+    is the callees-free supported branch — ``unresolved_call_sites`` is ABSENT
+    (the resolver carries it as ``None`` for this edge).
+    """
+
+    @pytest.mark.asyncio
+    async def test_module_imported_by_supported_shape(self, analyzer: JediAnalyzer) -> None:
+        result = await expand(_MODULE_WITH_IMPORTERS_HANDLE, "imported_by", analyzer)
+        # Supported branch — never unsupported.
+        assert "unsupported" not in result
+        assert "reason" not in result
+        assert result["edge"] == "imported_by"
+        assert isinstance(result["source"], str)
+        assert isinstance(result["stubs"], list)
+        # imported_by is an inbound edge, NOT callees — no unresolved_call_sites.
+        assert "unresolved_call_sites" not in result
+        assert "cursor" not in result
+
+    @pytest.mark.asyncio
+    async def test_module_imported_by_stubs_are_module_stubs(self, analyzer: JediAnalyzer) -> None:
+        result = await expand(_MODULE_WITH_IMPORTERS_HANDLE, "imported_by", analyzer)
+        assert result["stubs"], "widgets module has known importers → non-empty stubs"
+        for stub in result["stubs"]:
+            _assert_is_stub(stub)
+            # Each importer is itself a module.
+            assert stub["kind"] == "module", f"importer stub should be a module: {stub}"
+
+
+class TestExpandImportedByNonModuleUnsupported:
+    """A NON-MODULE handle → unsupported ``not_yet_implemented`` (NOT empty).
+
+    The resolver returns ``None`` for a non-module handle (a class/function CAN
+    be imported, so claiming ``stubs: []`` would be the #332 "measured zero"
+    lie).  ``expand`` must surface that ``None`` as the UNSUPPORTED branch with a
+    KIND-SPECIFIC ``detail`` — distinct from the source-not-found graceful-empty
+    path and from the module measured-empty path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_class_imported_by_is_unsupported(self, analyzer: JediAnalyzer) -> None:
+        result = await expand(_WIDGET_HANDLE, "imported_by", analyzer)
+        # Unsupported branch — wrong kind for this edge.
+        assert result["unsupported"] is True
+        assert result["reason"] == "not_yet_implemented"
+        assert result["edge"] == "imported_by"
+        # Mutually exclusive: an unsupported result NEVER carries stubs.
+        assert "stubs" not in result
+        assert "unresolved_call_sites" not in result
+
+    @pytest.mark.asyncio
+    async def test_class_imported_by_detail_names_kind(self, analyzer: JediAnalyzer) -> None:
+        result = await expand(_WIDGET_HANDLE, "imported_by", analyzer)
+        detail = result["detail"]
+        assert isinstance(detail, str) and detail, "detail must be a non-empty str"
+        # Kind-specific: Widget is a class, so the detail must name the kind.
+        assert "class" in detail, f"detail must name the handle's kind (class): {detail!r}"
+        assert "imported_by" in detail, f"detail should name the edge: {detail!r}"
+
+
+class TestExpandImportedByModuleNoImportersSupported:
+    """A MODULE that nobody imports → supported ``stubs: []`` (measured none).
+
+    This pins the #332 distinction at the operation layer: ``module_forms`` IS a
+    module (the edge applies), so the resolver returns ``EdgeResult([])`` — a
+    MEASURED empty — and ``expand`` returns the SUPPORTED branch with
+    ``stubs: []``.  This is DISTINCT from the non-module unsupported branch.
+    """
+
+    @pytest.mark.asyncio
+    async def test_module_no_importers_is_supported_empty(self, analyzer: JediAnalyzer) -> None:
+        result = await expand(_MODULE_NO_IMPORTERS_HANDLE, "imported_by", analyzer)
+        assert result["stubs"] == [], "module_forms is imported by nobody → measured []"
+        # Supported branch — measured-empty is NOT unsupported (the #332 line).
+        assert "unsupported" not in result
+        assert "reason" not in result
+        assert result["edge"] == "imported_by"
+        assert "unresolved_call_sites" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_importers_distinct_from_non_module(self, analyzer: JediAnalyzer) -> None:
+        # The crux of #332: module-with-no-importers (supported empty) and
+        # non-module (unsupported) must be DIFFERENT shapes.
+        empty_module = await expand(_MODULE_NO_IMPORTERS_HANDLE, "imported_by", analyzer)
+        non_module = await expand(_WIDGET_HANDLE, "imported_by", analyzer)
+        assert "unsupported" not in empty_module
+        assert non_module["unsupported"] is True
+        # And they are genuinely different shapes (stubs vs reason).
+        assert "stubs" in empty_module and "stubs" not in non_module
+        assert "reason" not in empty_module and "reason" in non_module


### PR DESCRIPTION
## Summary

Promotes `imported_by` from a deferred reference-backend edge to a **supported** Jedi/AST-backed `expand` edge, decoupled from the Pyright backend (#333). `expand(handle, "imported_by")` now returns the project modules that import a target **module**, computed by deterministic static AST import-graph reversal with **zero `get_references`** — reusing the existing `analyze_dependencies` reverse-scan and #343's relative-import resolution.

**New surface / changes**
- `edges.py` — `imported_by` moved to the implemented set; new async `resolve_imported_by` (module → `EdgeResult` of `(Handle, ModuleSentinel)` importer adjacents built from each importer's file; non-module → `None`, the wrong-kind signal).
- `analyzers/jedi_analyzer.py` — extracted `find_importers` from the deprecated `analyze_dependencies` (which now delegates to it); deterministic file ordering; pure AST, no reverse search.
- `_module_sentinel.py` — `_ModuleSentinel` extracted from `inspect.py` to a shared leaf so `edges` can build module stubs without importing `inspect` (mirrors `_ast_targets.py`).
- `expand.py` — awaits awaitable resolver results; a resolver `None` becomes the unsupported `not_yet_implemented` branch with a kind-specific `detail`.
- `server.py` — `expand` tool docstring corrected (imported_by now supported).

## Key contracts
- **Module-only this slice.** Module → supported `{source, edge, stubs}` (module-kind stubs); `stubs: []` means *measured* (nobody imports it). **Non-module → unsupported `not_yet_implemented`** — NOT supported-empty `[]`, because a symbol *can* be imported and `[]` would be the #332 absence-vs-zero lie. Symbol-level `imported_by` is a documented additive follow-on (flips the `not_yet_implemented` path to real results, no shape change).
- **No `ExpandResult` shape change**; no `unresolved_call_sites` (callees-only); the conformance linter needed **no** change.
- **Documented ceiling:** runtime-dynamic imports (`importlib`/`__import__` with computed targets) are undetectable — surfaced as a documented static boundary, not a fabricated count (distinct from `callees`' per-call-site count).
- Importers are built from their **file**, so importers in tests and standalone scripts (outside the package roots) get stubs too.

## Test plan
- [x] Full suite green deterministically: 1823 passed, 8 skipped, 86.63% coverage (`uv run pytest -p no:randomly`).
- [x] No `get_references`/`find_references` on the `imported_by` path (grep-gated + spy-tested).
- [x] Two behavior-preserving extractions: existing `inspect` tests AND existing `analyze_dependencies` tests pass **unmodified** (only intended test edit: the `imported_by` status-matrix bucket move).
- [x] The three distinct paths pinned: source-not-found vs wrong-kind-`None` vs measured-empty.
- [x] Wire integration tests (`imported_by` over the `expand` MCP tool, both branches) + conformance dogfood of the real operation output through the linter.
- [x] Pre-commit clean (black, ruff, mypy, pydocstyle, bandit, detect-secrets) — no bypass.

## Deferred (additive, no shape change)
Symbol-level `imported_by`, literal-string `importlib.import_module` detection, restoring `inspect.edge_counts.imported_by`, and the symbol-level reverse edges (`callers`/`references`) that require the Pyright backend (#333).

Spec: `docs/superpowers/specs/2026-06-10-imported-by-edge-design.md` · Plan: `docs/superpowers/plans/2026-06-10-imported-by-edge.md`

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)