### PR TITLE
feat(trace): bounded multi-hop BFS traversal primitive + scope filter + truncation causes (#349, #351, #352)

### DIFF
--- a/docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md
+++ b/docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md
@@ -322,6 +322,17 @@ Used for refactor closures, call chains, bug-tracing — anywhere the agent need
 
 **Aggregate edges in `follow`.** When `follow` includes an aggregate edge (currently only `references`), trace expands it to the underlying specific edges (`read_by`, `written_by`, `passed_by`) at traversal time. Returned `Subgraph.edges` always carry specific (non-aggregate) `kind` values — never `references`. This means trace's edge metadata always tells the agent the precise relationship, and `Subgraph` nodes never need a subkind field (the kind is on the edge, not the node).
 
+> **Implementation status (2026-06): `trace` traverses the supported edges only.**
+> `trace` composes the same edge registry as `expand`. It walks the edges that
+> are implemented today — `members`, `callees`, `imported_by` (#345) — and any
+> other edge named in `follow` (deferred reference edges requiring the Pyright
+> backend, not-yet-implemented structural edges, or unknown names) is reported in
+> an additive `Subgraph.unsupported_edges: [{edge, reason, detail}]` list rather
+> than silently dropped — silently omitting it would falsely read as "no such
+> neighbours" (the same absence-vs-zero guard as `edge_counts`). As more edges
+> become supported (e.g. `subclasses`, #348), `trace` picks them up automatically
+> with no shape change. See issues #332/#333 for the reference-backend edges.
+
 ## Return Shape: The Typed Property Graph
 
 Pyeye returns nodes from a typed property graph. The schema:

--- a/docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md
+++ b/docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md
@@ -303,9 +303,12 @@ type Subgraph = {
   nodes: Map<Handle, Stub>
   edges: { from: Handle, to: Handle, kind: EdgeType }[]
   truncated: boolean   // true if max_depth or max_nodes was hit before natural termination
+  truncation_reasons: ("max_depth" | "max_nodes")[]   // WHICH cap(s) fired (#352); [] when not truncated
+  unsupported_edges: { edge: string, reason: string, detail: string }[]   // deferred/unknown edges in `follow` (#349); never silently dropped
 }
 
 type StopPredicate = {
+  exclude_external?: boolean  // stop at external (stdlib/site-packages) nodes (#351)
   module_pattern?: string  // stop when entering matching module
   exclude_tests?: boolean
   // ... extensible

--- a/src/pyeye/mcp/operations/trace.py
+++ b/src/pyeye/mcp/operations/trace.py
@@ -1,0 +1,121 @@
+"""trace(start, follow) — bounded multi-hop BFS returning a Subgraph.
+
+``trace`` is the progressive-disclosure traversal primitive that composes the
+single-hop edge registry (``members``, ``callees``, ``imported_by``) across
+multiple hops.  It is a pure *consumer* of the edge registry in
+:mod:`pyeye.mcp.operations.edges` — it adds traversal/bookkeeping (dedup, cycle
+handling, caps) but NO new edge-resolution logic, and it MUST NOT modify the
+registry.
+
+Return shape — ``Subgraph`` (spec §``trace``)::
+
+    { "nodes": { handle: Stub, ... },               # deduped by handle
+      "edges": [ {"from": h, "to": h, "kind": edge}, ... ],  # NOT deduped across kinds
+      "truncated": bool }                            # caps hit before natural termination
+
+Termination: each handle is visited (expanded) at most once; edges *to* an
+already-visited handle are still recorded so cycles stay visible to the agent,
+but do not trigger re-expansion.  This guarantees termination on cyclic graphs.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from inspect import isawaitable
+from typing import TYPE_CHECKING, Any
+
+from pyeye.mcp.operations.edges import EDGE_RESOLVERS, STATUS_IMPLEMENTED, edge_status
+from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
+from pyeye.mcp.operations.stubs import build_stub
+
+if TYPE_CHECKING:
+    from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+
+
+async def _single_hop(jedi_name: Any, edge: str, analyzer: JediAnalyzer) -> list[tuple[str, Any]]:
+    """Resolve ONE edge from *jedi_name*, returning ``(handle_str, jedi_name)`` pairs.
+
+    Pure registry consumption: consults :func:`edge_status` and runs the
+    registered resolver (awaiting async resolvers like ``imported_by``).  An
+    unsupported edge or a wrong-kind (``None``) resolver result yields no
+    adjacents — honest no-op handling for the traversal layer.
+
+    Args:
+        jedi_name: Resolved Jedi ``Name`` (or sentinel) for the source handle.
+        edge: The edge to walk.
+        analyzer: Active analyzer.
+
+    Returns:
+        A list of ``(canonical_handle_string, adjacent_jedi_name)`` pairs — the
+        adjacent name is carried so the caller can build a stub without a
+        re-resolution (the load-bearing reason ``EdgeResult`` carries Names).
+    """
+    if edge_status(edge) != STATUS_IMPLEMENTED:
+        return []
+    raw = EDGE_RESOLVERS[edge](jedi_name, analyzer)
+    edge_result = await raw if isawaitable(raw) else raw
+    if edge_result is None:
+        return []
+    return [(str(adj_handle), name) for adj_handle, name in edge_result.adjacents]
+
+
+async def trace(
+    start: str | list[str],
+    follow: list[str],
+    analyzer: JediAnalyzer,
+    max_depth: int = 3,
+) -> dict[str, Any]:
+    """Walk *follow* edges from *start* via bounded BFS, returning a ``Subgraph``.
+
+    The spec signature also carries ``max_nodes`` and ``stop_when``; those land
+    in their own TDD cycles (a node cap and a traversal-boundary predicate) and
+    are deliberately omitted here until a test drives each one.
+
+    Args:
+        start: One canonical handle or a list of them (the BFS roots).
+        follow: Edge names to traverse at every hop.
+        analyzer: Configured ``JediAnalyzer`` for the project.
+        max_depth: Maximum hop distance from a root before a node becomes a
+            non-expanded frontier leaf (default 3).
+
+    Returns:
+        A ``Subgraph`` dict: ``nodes`` (handle → Stub), ``edges`` (``from``/``to``/
+        ``kind``), and ``truncated``.  Never raises; an unresolvable root simply
+        contributes no node.
+    """
+    starts = [start] if isinstance(start, str) else list(start)
+
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, str]] = []
+    truncated = False
+
+    # (handle, jedi_name, depth); visited == "already enqueued for expansion".
+    queue: deque[tuple[str, Any, int]] = deque()
+    visited: set[str] = set()
+
+    for root in starts:
+        jedi_name = _find_jedi_name_for_handle(root, analyzer)
+        if jedi_name is None:
+            continue
+        canonical = getattr(jedi_name, "full_name", None) or root
+        if canonical not in nodes:
+            nodes[canonical] = build_stub(jedi_name, canonical, analyzer)
+        if canonical not in visited:
+            visited.add(canonical)
+            queue.append((canonical, jedi_name, 0))
+
+    while queue:
+        handle, jedi_name, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+        for edge in follow:
+            for adj_handle, adj_name in await _single_hop(jedi_name, edge, analyzer):
+                if adj_handle not in nodes:
+                    nodes[adj_handle] = build_stub(adj_name, adj_handle, analyzer)
+                # Record the edge even to an already-visited target (cycle visibility).
+                edges.append({"from": handle, "to": adj_handle, "kind": edge})
+                if adj_handle not in visited:
+                    visited.add(adj_handle)
+                    queue.append((adj_handle, adj_name, depth + 1))
+
+    return {"nodes": nodes, "edges": edges, "truncated": truncated}

--- a/src/pyeye/mcp/operations/trace.py
+++ b/src/pyeye/mcp/operations/trace.py
@@ -68,27 +68,35 @@ async def _single_hop(jedi_name: Any, edge: str, analyzer: JediAnalyzer) -> list
     return [(str(adj_handle), name) for adj_handle, name in edge_result.adjacents]
 
 
-def _stops_at(handle: str, stop_when: dict[str, Any] | None) -> bool:
-    """Return True if *handle* is a traversal boundary under *stop_when*.
+def _stops_at(handle: str, scope: str, stop_when: dict[str, Any] | None) -> bool:
+    """Return True if an adjacent is a traversal boundary under *stop_when*.
 
     Honoured ``StopPredicate`` keys (spec §``trace``):
 
+    - ``exclude_external``: stop at external (stdlib / site-packages) nodes —
+      keeps a trace inside the project and frees the ``max_nodes`` budget for
+      project nodes (#351).
     - ``module_pattern``: stop when the pattern appears in the handle (substring).
     - ``exclude_tests``: stop at test modules — any dotted segment equal to
       ``tests`` or beginning ``test_``.
 
-    A missing/empty predicate never stops.  The predicate is kind-agnostic: it
-    matches on the handle string alone, so it composes with any edge.
+    A missing/empty predicate never stops.  ``module_pattern`` / ``exclude_tests``
+    match on the handle string; ``exclude_external`` matches on *scope* (which is
+    NOT derivable from the handle), so the caller passes the adjacent's resolved
+    scope.
 
     Args:
         handle: Canonical handle of a candidate adjacent.
+        scope: The adjacent's resolved scope (``"project"`` / ``"external"``).
         stop_when: The predicate dict, or ``None``.
 
     Returns:
-        ``True`` if traversal should treat *handle* as a boundary (prune it).
+        ``True`` if traversal should treat the adjacent as a boundary (prune it).
     """
     if not stop_when:
         return False
+    if stop_when.get("exclude_external") and scope == "external":
+        return True
     pattern = stop_when.get("module_pattern")
     if pattern and pattern in handle:
         return True
@@ -117,9 +125,11 @@ async def trace(
             non-expanded frontier leaf (default 3).
         max_nodes: Maximum number of distinct nodes in the subgraph; reaching it
             stops adding new nodes and sets ``truncated`` (default 50).
-        stop_when: Optional ``StopPredicate`` (``module_pattern`` /
-            ``exclude_tests``).  An adjacent matching it is a boundary — pruned
-            (never added, edged, or expanded).  Roots are never pruned.
+        stop_when: Optional ``StopPredicate`` (``exclude_external`` /
+            ``module_pattern`` / ``exclude_tests``).  An adjacent matching it is a
+            boundary — pruned (never added, edged, expanded, or counted against
+            ``max_nodes``).  Roots are never pruned.  ``exclude_external`` keeps a
+            trace inside the project (the common ``callees`` case).
 
     Returns:
         A ``Subgraph`` dict: ``nodes`` (handle → Stub), ``edges`` (``from``/``to``/
@@ -169,25 +179,32 @@ async def trace(
         can_expand = depth < max_depth
         for edge in supported_follow:
             for adj_handle, adj_name in await _single_hop(jedi_name, edge, analyzer):
-                if _stops_at(adj_handle, stop_when):
-                    # Boundary: prune entirely — no node, no edge, no expansion.
-                    continue
                 if adj_handle in nodes:
                     # Already in the closure: record the (possibly cyclic) edge so
                     # it stays visible, but never re-expand — this bounds the walk.
                     edges.append({"from": handle, "to": adj_handle, "kind": edge})
-                elif can_expand:
-                    if len(nodes) >= max_nodes:
-                        # Node budget exhausted: this reachable handle is cut off.
-                        truncated = True
-                        continue
-                    nodes[adj_handle] = build_stub(adj_name, adj_handle, analyzer)
-                    edges.append({"from": handle, "to": adj_handle, "kind": edge})
-                    queue.append((adj_handle, adj_name, depth + 1))
-                else:
+                    continue
+                # New adjacent — build its stub once.  The stub carries the
+                # resolved ``scope`` that the boundary predicate needs, and is
+                # reused as the node value when the adjacent is kept.
+                stub = build_stub(adj_name, adj_handle, analyzer)
+                if _stops_at(adj_handle, stub["scope"], stop_when):
+                    # Boundary: prune entirely — no node, no edge, no expansion.
+                    # NOT truncation: a deliberately-excluded handle (e.g. an
+                    # external node) is not a cap cutoff, so it never sets
+                    # ``truncated`` and never consumes the ``max_nodes`` budget.
+                    continue
+                if not can_expand:
                     # A reachable handle one hop past the depth frontier: cut off.
-                    # Don't add a node or a dangling edge — just flag truncation.
                     truncated = True
+                    continue
+                if len(nodes) >= max_nodes:
+                    # Node budget exhausted: this reachable handle is cut off.
+                    truncated = True
+                    continue
+                nodes[adj_handle] = stub
+                edges.append({"from": handle, "to": adj_handle, "kind": edge})
+                queue.append((adj_handle, adj_name, depth + 1))
 
     return {
         "nodes": nodes,

--- a/src/pyeye/mcp/operations/trace.py
+++ b/src/pyeye/mcp/operations/trace.py
@@ -12,7 +12,14 @@ Return shape — ``Subgraph`` (spec §``trace``)::
     { "nodes": { handle: Stub, ... },               # deduped by handle
       "edges": [ {"from": h, "to": h, "kind": edge}, ... ],  # NOT deduped across kinds
       "truncated": bool,                             # caps hit before natural termination
+      "truncation_reasons": ["max_depth"? , "max_nodes"?],  # WHICH cap(s) fired
       "unsupported_edges": [ {"edge", "reason", "detail"}, ... ] }
+
+``truncation_reasons`` (#352) distinguishes the two causes so the agent knows
+which cap to raise: ``"max_depth"`` (a reachable node was cut at the depth
+frontier) and/or ``"max_nodes"`` (the node budget filled).  Both can fire in one
+walk.  ``truncated`` is derived — true iff ``truncation_reasons`` is non-empty —
+and kept for back-compat.
 
 ``unsupported_edges`` is an additive honesty field (beyond the spec's bare
 ``Subgraph`` triple): any edge in ``follow`` that is not an implemented edge
@@ -140,7 +147,10 @@ async def trace(
 
     nodes: dict[str, dict[str, Any]] = {}
     edges: list[dict[str, str]] = []
-    truncated = False
+    # Distinct truncation causes accumulate here (#352): "max_depth" when the
+    # depth frontier cuts a reachable node, "max_nodes" when the node budget
+    # fills.  ``truncated`` is derived (true iff any cause fired).
+    truncation_reasons: set[str] = set()
 
     # Partition the requested edges: traverse only the implemented ones.  Every
     # other edge (deferred reference-backend, not-yet-implemented, unknown) is
@@ -196,11 +206,11 @@ async def trace(
                     continue
                 if not can_expand:
                     # A reachable handle one hop past the depth frontier: cut off.
-                    truncated = True
+                    truncation_reasons.add("max_depth")
                     continue
                 if len(nodes) >= max_nodes:
                     # Node budget exhausted: this reachable handle is cut off.
-                    truncated = True
+                    truncation_reasons.add("max_nodes")
                     continue
                 nodes[adj_handle] = stub
                 edges.append({"from": handle, "to": adj_handle, "kind": edge})
@@ -209,6 +219,7 @@ async def trace(
     return {
         "nodes": nodes,
         "edges": edges,
-        "truncated": truncated,
+        "truncated": bool(truncation_reasons),
+        "truncation_reasons": sorted(truncation_reasons),
         "unsupported_edges": unsupported_edges,
     }

--- a/src/pyeye/mcp/operations/trace.py
+++ b/src/pyeye/mcp/operations/trace.py
@@ -11,7 +11,15 @@ Return shape — ``Subgraph`` (spec §``trace``)::
 
     { "nodes": { handle: Stub, ... },               # deduped by handle
       "edges": [ {"from": h, "to": h, "kind": edge}, ... ],  # NOT deduped across kinds
-      "truncated": bool }                            # caps hit before natural termination
+      "truncated": bool,                             # caps hit before natural termination
+      "unsupported_edges": [ {"edge", "reason", "detail"}, ... ] }
+
+``unsupported_edges`` is an additive honesty field (beyond the spec's bare
+``Subgraph`` triple): any edge in ``follow`` that is not an implemented edge
+(deferred reference-backend, not-yet-implemented, or unknown) is listed here
+rather than silently dropped from the walk — silently omitting it would falsely
+read as "no such neighbours" (the #332 absence-vs-zero trap).  It is ``[]`` when
+every requested edge is supported.
 
 Termination: each handle is visited (expanded) at most once; edges *to* an
 already-visited handle are still recorded so cycles stay visible to the agent,
@@ -25,6 +33,7 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
 from pyeye.mcp.operations.edges import EDGE_RESOLVERS, STATUS_IMPLEMENTED, edge_status
+from pyeye.mcp.operations.expand import _unsupported_detail
 from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
 from pyeye.mcp.operations.stubs import build_stub
 
@@ -64,12 +73,13 @@ async def trace(
     follow: list[str],
     analyzer: JediAnalyzer,
     max_depth: int = 3,
+    max_nodes: int = 50,
 ) -> dict[str, Any]:
     """Walk *follow* edges from *start* via bounded BFS, returning a ``Subgraph``.
 
-    The spec signature also carries ``max_nodes`` and ``stop_when``; those land
-    in their own TDD cycles (a node cap and a traversal-boundary predicate) and
-    are deliberately omitted here until a test drives each one.
+    The spec signature also carries ``stop_when``; that lands in its own TDD
+    cycle (a traversal-boundary predicate) and is deliberately omitted here
+    until a test drives it.
 
     Args:
         start: One canonical handle or a list of them (the BFS roots).
@@ -77,6 +87,8 @@ async def trace(
         analyzer: Configured ``JediAnalyzer`` for the project.
         max_depth: Maximum hop distance from a root before a node becomes a
             non-expanded frontier leaf (default 3).
+        max_nodes: Maximum number of distinct nodes in the subgraph; reaching it
+            stops adding new nodes and sets ``truncated`` (default 50).
 
     Returns:
         A ``Subgraph`` dict: ``nodes`` (handle → Stub), ``edges`` (``from``/``to``/
@@ -89,9 +101,25 @@ async def trace(
     edges: list[dict[str, str]] = []
     truncated = False
 
-    # (handle, jedi_name, depth); visited == "already enqueued for expansion".
+    # Partition the requested edges: traverse only the implemented ones.  Every
+    # other edge (deferred reference-backend, not-yet-implemented, unknown) is
+    # surfaced in ``unsupported_edges`` rather than silently dropped — a silent
+    # drop would falsely read as "this symbol has no such neighbours" (the #332
+    # absence-vs-zero trap the whole surface guards against).
+    supported_follow: list[str] = []
+    unsupported_edges: list[dict[str, str]] = []
+    for edge in follow:
+        status = edge_status(edge)
+        if status == STATUS_IMPLEMENTED:
+            supported_follow.append(edge)
+        else:
+            unsupported_edges.append(
+                {"edge": edge, "reason": status, "detail": _unsupported_detail(edge, status)}
+            )
+
+    # ``nodes`` doubles as the visited set: a handle is added to ``nodes`` and
+    # enqueued together, so membership in ``nodes`` means "already discovered".
     queue: deque[tuple[str, Any, int]] = deque()
-    visited: set[str] = set()
 
     for root in starts:
         jedi_name = _find_jedi_name_for_handle(root, analyzer)
@@ -100,22 +128,36 @@ async def trace(
         canonical = getattr(jedi_name, "full_name", None) or root
         if canonical not in nodes:
             nodes[canonical] = build_stub(jedi_name, canonical, analyzer)
-        if canonical not in visited:
-            visited.add(canonical)
             queue.append((canonical, jedi_name, 0))
 
     while queue:
         handle, jedi_name, depth = queue.popleft()
-        if depth >= max_depth:
-            continue
-        for edge in follow:
+        # Resolve a node's edges even at the depth frontier — peeking one hop past
+        # the frontier is how truncation is detected (a reachable-but-unvisited
+        # neighbour) and how cycle edges back into the closure stay visible.
+        can_expand = depth < max_depth
+        for edge in supported_follow:
             for adj_handle, adj_name in await _single_hop(jedi_name, edge, analyzer):
-                if adj_handle not in nodes:
+                if adj_handle in nodes:
+                    # Already in the closure: record the (possibly cyclic) edge so
+                    # it stays visible, but never re-expand — this bounds the walk.
+                    edges.append({"from": handle, "to": adj_handle, "kind": edge})
+                elif can_expand:
+                    if len(nodes) >= max_nodes:
+                        # Node budget exhausted: this reachable handle is cut off.
+                        truncated = True
+                        continue
                     nodes[adj_handle] = build_stub(adj_name, adj_handle, analyzer)
-                # Record the edge even to an already-visited target (cycle visibility).
-                edges.append({"from": handle, "to": adj_handle, "kind": edge})
-                if adj_handle not in visited:
-                    visited.add(adj_handle)
+                    edges.append({"from": handle, "to": adj_handle, "kind": edge})
                     queue.append((adj_handle, adj_name, depth + 1))
+                else:
+                    # A reachable handle one hop past the depth frontier: cut off.
+                    # Don't add a node or a dangling edge — just flag truncation.
+                    truncated = True
 
-    return {"nodes": nodes, "edges": edges, "truncated": truncated}
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "truncated": truncated,
+        "unsupported_edges": unsupported_edges,
+    }

--- a/src/pyeye/mcp/operations/trace.py
+++ b/src/pyeye/mcp/operations/trace.py
@@ -68,18 +68,46 @@ async def _single_hop(jedi_name: Any, edge: str, analyzer: JediAnalyzer) -> list
     return [(str(adj_handle), name) for adj_handle, name in edge_result.adjacents]
 
 
+def _stops_at(handle: str, stop_when: dict[str, Any] | None) -> bool:
+    """Return True if *handle* is a traversal boundary under *stop_when*.
+
+    Honoured ``StopPredicate`` keys (spec §``trace``):
+
+    - ``module_pattern``: stop when the pattern appears in the handle (substring).
+    - ``exclude_tests``: stop at test modules — any dotted segment equal to
+      ``tests`` or beginning ``test_``.
+
+    A missing/empty predicate never stops.  The predicate is kind-agnostic: it
+    matches on the handle string alone, so it composes with any edge.
+
+    Args:
+        handle: Canonical handle of a candidate adjacent.
+        stop_when: The predicate dict, or ``None``.
+
+    Returns:
+        ``True`` if traversal should treat *handle* as a boundary (prune it).
+    """
+    if not stop_when:
+        return False
+    pattern = stop_when.get("module_pattern")
+    if pattern and pattern in handle:
+        return True
+    if stop_when.get("exclude_tests"):
+        segments = handle.split(".")
+        if any(seg == "tests" or seg.startswith("test_") for seg in segments):
+            return True
+    return False
+
+
 async def trace(
     start: str | list[str],
     follow: list[str],
     analyzer: JediAnalyzer,
     max_depth: int = 3,
     max_nodes: int = 50,
+    stop_when: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Walk *follow* edges from *start* via bounded BFS, returning a ``Subgraph``.
-
-    The spec signature also carries ``stop_when``; that lands in its own TDD
-    cycle (a traversal-boundary predicate) and is deliberately omitted here
-    until a test drives it.
 
     Args:
         start: One canonical handle or a list of them (the BFS roots).
@@ -89,6 +117,9 @@ async def trace(
             non-expanded frontier leaf (default 3).
         max_nodes: Maximum number of distinct nodes in the subgraph; reaching it
             stops adding new nodes and sets ``truncated`` (default 50).
+        stop_when: Optional ``StopPredicate`` (``module_pattern`` /
+            ``exclude_tests``).  An adjacent matching it is a boundary — pruned
+            (never added, edged, or expanded).  Roots are never pruned.
 
     Returns:
         A ``Subgraph`` dict: ``nodes`` (handle → Stub), ``edges`` (``from``/``to``/
@@ -138,6 +169,9 @@ async def trace(
         can_expand = depth < max_depth
         for edge in supported_follow:
             for adj_handle, adj_name in await _single_hop(jedi_name, edge, analyzer):
+                if _stops_at(adj_handle, stop_when):
+                    # Boundary: prune entirely — no node, no edge, no expansion.
+                    continue
                 if adj_handle in nodes:
                     # Already in the closure: record the (possibly cyclic) edge so
                     # it stays visible, but never re-expand — this bounds the walk.

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -612,8 +612,11 @@ async def trace(
             non-expanded frontier leaf (default 3).
         max_nodes: Maximum number of distinct nodes in the subgraph; reaching it
             sets ``truncated`` (default 50).
-        stop_when: Optional StopPredicate (``module_pattern`` / ``exclude_tests``);
-            a matching adjacent is a pruned boundary.  Roots are never pruned.
+        stop_when: Optional StopPredicate (``exclude_external`` /
+            ``module_pattern`` / ``exclude_tests``); a matching adjacent is a
+            pruned boundary.  Roots are never pruned.  ``exclude_external`` stops
+            at stdlib/site-packages nodes — keeps a trace inside the project (the
+            common ``callees`` case).
 
     Returns:
         A ``Subgraph`` dict (plain, JSON-serialisable).  Never raises; an

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -594,6 +594,7 @@ async def trace(
         { "nodes": { handle: Stub, ... },        # deduped by canonical handle
           "edges": [ {"from": h, "to": h, "kind": edge}, ... ],
           "truncated": bool,                     # a cap cut off reachable nodes
+          "truncation_reasons": ["max_depth"?, "max_nodes"?],  # which cap(s) fired
           "unsupported_edges": [ {"edge", "reason", "detail"}, ... ] }
 
     Edges are NOT deduped across kinds; edges to already-visited handles are

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -57,6 +57,7 @@ from .operations.resolve import (
     resolve as _resolve_impl,
     resolve_at as _resolve_at_impl,
 )
+from .operations.trace import trace as _trace_impl
 
 # Logger — configured by __main__.py or caller; fallback to basic stderr.
 logger = logging.getLogger(__name__)
@@ -560,6 +561,75 @@ async def expand(
     analyzer = get_analyzer(project_path)
     # dict(...) widens the operation's return to plain dict[str, Any] for the wire.
     return dict(await _expand_impl(handle, edge, analyzer))
+
+
+@mcp.tool()
+@validate_mcp_inputs
+@metrics.measure("trace")
+@track_mcp_operation("trace")
+async def trace(
+    start: str | list[str],
+    follow: list[str],
+    project_path: str = ".",
+    max_depth: int = 3,
+    max_nodes: int = 50,
+    stop_when: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Python: Bounded multi-hop BFS traversal — returns a typed Subgraph.
+
+    The composition primitive: it walks the ``follow`` edges outward from
+    ``start`` across multiple hops, deduping by canonical handle, and returns a
+    ``Subgraph`` of the reachable structure.  Use resolve()/inspect() to obtain
+    canonical handles first, then trace() to see structure across hops (call
+    chains, reverse-import closures, member trees).
+
+    Composes the same edge registry as ``expand``; only the implemented edges
+    (``members``, ``callees``, ``imported_by``) are traversed.  Any other edge
+    named in ``follow`` (deferred reference edges, not-yet-implemented structural
+    edges, unknown names) is reported in ``unsupported_edges`` rather than
+    silently dropped — a silent drop would falsely read as "no such neighbours".
+
+    Response shape — ``Subgraph``::
+
+        { "nodes": { handle: Stub, ... },        # deduped by canonical handle
+          "edges": [ {"from": h, "to": h, "kind": edge}, ... ],
+          "truncated": bool,                     # a cap cut off reachable nodes
+          "unsupported_edges": [ {"edge", "reason", "detail"}, ... ] }
+
+    Edges are NOT deduped across kinds; edges to already-visited handles are
+    recorded (so cycles stay visible) but never re-expanded, guaranteeing
+    termination on cyclic graphs.  ``truncated`` is true ONLY when ``max_depth``
+    or ``max_nodes`` cut off reachable handles before natural termination — not
+    merely because a cap was set.
+
+    Args:
+        start: One canonical handle, or a list of them, as BFS roots.
+        follow: Edge names to traverse at every hop (e.g. ``["members"]``,
+            ``["callees"]``, ``["imported_by"]``).
+        project_path: Project root path (default: current directory).
+        max_depth: Maximum hop distance from a root before a node becomes a
+            non-expanded frontier leaf (default 3).
+        max_nodes: Maximum number of distinct nodes in the subgraph; reaching it
+            sets ``truncated`` (default 50).
+        stop_when: Optional StopPredicate (``module_pattern`` / ``exclude_tests``);
+            a matching adjacent is a pruned boundary.  Roots are never pruned.
+
+    Returns:
+        A ``Subgraph`` dict (plain, JSON-serialisable).  Never raises; an
+        unresolvable root simply contributes no node.
+    """
+    analyzer = get_analyzer(project_path)
+    # dict(...) widens the operation's return to plain dict[str, Any] for the wire.
+    return dict(
+        await _trace_impl(
+            start,
+            follow,
+            analyzer,
+            max_depth=max_depth,
+            max_nodes=max_nodes,
+            stop_when=stop_when,
+        )
+    )
 
 
 # NOTE: superseded by future expand(handle, edge="references"); kept until Phase B migration.

--- a/tests/conformance/response_linter.py
+++ b/tests/conformance/response_linter.py
@@ -74,6 +74,8 @@ T.2 Each node value passes the Stub floor (S.*); the node KEY equals the stub's
 T.3 Each edge is ``{from, to, kind}`` of single-line strs.
 T.4 Each ``unsupported_edges`` entry is ``{edge, reason, detail}`` with ``reason``
     ∈ the valid unsupported reasons and a non-empty ``detail`` (mirrors E.2).
+T.5 ``truncation_reasons`` is a list of valid causes (``max_depth`` / ``max_nodes``)
+    and is consistent with ``truncated`` (true iff the list is non-empty).
 
 Usage
 -----
@@ -638,6 +640,9 @@ _VALID_UNSUPPORTED_REASONS: frozenset[str] = frozenset(
 # S.1 — Valid scope values for a Stub.
 _VALID_STUB_SCOPES: frozenset[str] = frozenset({"project", "external"})
 
+# T.1 — Valid trace truncation-cause values.
+_VALID_TRUNCATION_REASONS: frozenset[str] = frozenset({"max_depth", "max_nodes"})
+
 # ---------------------------------------------------------------------------
 # Check S — Stub structural-floor helpers
 # ---------------------------------------------------------------------------
@@ -1071,13 +1076,44 @@ def _check_trace_structural_floor(
             _check_trace_edge(edge, f"edges[{idx}]", violations)
 
     # T.1 — truncated: required bool (exactly bool, not truthy)
+    truncated = response.get("truncated")
     if "truncated" not in response:
         violations.append("[T.1 trace required key] 'truncated' is missing.")
-    elif type(response.get("truncated")) is not bool:
+    elif type(truncated) is not bool:
         violations.append(
             f"[T.1 trace field type] 'truncated' must be a bool; "
-            f"got {type(response.get('truncated')).__name__!r}."
+            f"got {type(truncated).__name__!r}."
         )
+
+    # T.5 — truncation_reasons: required list of valid causes; must be consistent
+    # with the derived ``truncated`` boolean (true iff reasons non-empty).
+    reasons = response.get("truncation_reasons")
+    if "truncation_reasons" not in response:
+        violations.append(
+            "[T.5 trace required key] 'truncation_reasons' is missing. It is [] when "
+            "the trace terminated naturally, or lists the cap(s) that fired "
+            f"({sorted(_VALID_TRUNCATION_REASONS)})."
+        )
+    elif not isinstance(reasons, list):
+        violations.append(
+            f"[T.5 trace field type] 'truncation_reasons' must be a list; "
+            f"got {type(reasons).__name__!r}."
+        )
+    else:
+        for idx, item in enumerate(reasons):
+            if item not in _VALID_TRUNCATION_REASONS:
+                violations.append(
+                    f"[T.5 trace truncation_reasons value] truncation_reasons[{idx}]: "
+                    f"value {item!r} is not recognised; must be one of "
+                    f"{sorted(_VALID_TRUNCATION_REASONS)}."
+                )
+        # Consistency with the back-compat boolean.
+        if type(truncated) is bool and truncated != bool(reasons):
+            violations.append(
+                f"[T.5 trace truncation consistency] 'truncated' is {truncated} but "
+                f"'truncation_reasons' is {_truncate(reasons)}; 'truncated' must be "
+                "true iff 'truncation_reasons' is non-empty."
+            )
 
     # T.1 / T.4 — unsupported_edges
     unsupported = response.get("unsupported_edges")

--- a/tests/conformance/response_linter.py
+++ b/tests/conformance/response_linter.py
@@ -64,6 +64,17 @@ S.2 ``signature`` is optional; when present it must be a single-line str
     (no ``\\n`` characters).
 S.3 No source-content keys (reuses A.2 / A.1 / A.4 layering checks).
 
+Check T — trace Subgraph structural floors (operation == "trace")
+-----------------------------------------------------------------
+T.1 Required keys with correct types: ``nodes`` (dict Map<Handle, Stub>),
+    ``edges`` (list), ``truncated`` (bool, not truthy), ``unsupported_edges``
+    (list).
+T.2 Each node value passes the Stub floor (S.*); the node KEY equals the stub's
+    ``handle`` (the dedup-by-handle invariant).
+T.3 Each edge is ``{from, to, kind}`` of single-line strs.
+T.4 Each ``unsupported_edges`` entry is ``{edge, reason, detail}`` with ``reason``
+    ∈ the valid unsupported reasons and a non-empty ``detail`` (mirrors E.2).
+
 Usage
 -----
 ::
@@ -72,6 +83,7 @@ Usage
 
     lint_response(result, "inspect")  # raises ConformanceViolation on failure
     lint_response(result, "expand")   # raises ConformanceViolation on failure
+    lint_response(result, "trace")    # raises ConformanceViolation on failure
     lint_response(stub,   "stub")     # raises ConformanceViolation on failure
 """
 
@@ -927,6 +939,164 @@ def _check_expand_structural_floor(
 
 
 # ---------------------------------------------------------------------------
+# Check T — trace Subgraph structural-floor helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_trace_edge(edge: Any, path: str, violations: list[str]) -> None:
+    """T.3 — Validate one Subgraph edge: ``{from, to, kind}`` single-line strs."""
+    if not isinstance(edge, dict):
+        violations.append(
+            f"[T.3 trace edge type] {path}: expected a dict; got {type(edge).__name__!r}."
+        )
+        return
+    for field in ("from", "to", "kind"):
+        if field not in edge:
+            violations.append(
+                f"[T.3 trace edge required key] {path}: missing required key {field!r}."
+            )
+            continue
+        value = edge[field]
+        if not isinstance(value, str):
+            violations.append(
+                f"[T.3 trace edge field type] {path}.{field}: expected str; "
+                f"got {type(value).__name__!r} ({_truncate(value)})."
+            )
+        elif "\n" in value:
+            violations.append(
+                f"[T.3 trace edge single-line] {path}.{field}: must be single-line; "
+                f"value={_truncate(value)}."
+            )
+
+
+def _check_trace_unsupported_edge(item: Any, path: str, violations: list[str]) -> None:
+    """T.4 — Validate one ``unsupported_edges`` entry: ``{edge, reason, detail}``.
+
+    Mirrors the ExpandResult unsupported branch: ``reason`` must be one of
+    :data:`_VALID_UNSUPPORTED_REASONS`, and ``detail`` must be a non-empty str.
+    """
+    if not isinstance(item, dict):
+        violations.append(
+            f"[T.4 trace unsupported_edge type] {path}: expected a dict; "
+            f"got {type(item).__name__!r}."
+        )
+        return
+
+    if "edge" not in item:
+        violations.append(f"[T.4 trace unsupported_edge required key] {path}: missing 'edge'.")
+    elif not isinstance(item["edge"], str):
+        violations.append(
+            f"[T.4 trace unsupported_edge field type] {path}.edge: expected str; "
+            f"got {type(item['edge']).__name__!r}."
+        )
+
+    reason = item.get("reason")
+    if "reason" not in item:
+        violations.append(f"[T.4 trace unsupported_edge required key] {path}: missing 'reason'.")
+    elif not isinstance(reason, str):
+        violations.append(
+            f"[T.4 trace unsupported_edge field type] {path}.reason: expected str; "
+            f"got {type(reason).__name__!r}."
+        )
+    elif reason not in _VALID_UNSUPPORTED_REASONS:
+        violations.append(
+            f"[T.4 trace unsupported_edge unknown reason] {path}.reason: value {reason!r} "
+            f"is not recognised; must be one of {sorted(_VALID_UNSUPPORTED_REASONS)}."
+        )
+
+    detail = item.get("detail")
+    if "detail" not in item:
+        violations.append(f"[T.4 trace unsupported_edge required key] {path}: missing 'detail'.")
+    elif not isinstance(detail, str) or not detail:
+        violations.append(
+            f"[T.4 trace unsupported_edge detail] {path}.detail: must be a non-empty str; "
+            f"got {_truncate(detail)} (type={type(detail).__name__!r})."
+        )
+
+
+def _check_trace_structural_floor(
+    response: dict[str, Any],
+    violations: list[str],
+) -> None:
+    """T.1–T.4 — Validate the structural floor of a trace ``Subgraph`` dict.
+
+    Layering (A.*) is run separately by ``_check_layering``.
+
+    T.1 ``nodes`` (dict), ``edges`` (list), ``truncated`` (bool, not truthy), and
+        ``unsupported_edges`` (list) are present with correct types.
+    T.2 Each node value passes the Stub floor (S.*), and the node KEY equals the
+        stub's ``handle`` (the dedup-by-handle invariant).
+    T.3 Each edge is ``{from, to, kind}`` of single-line strs.
+    T.4 Each ``unsupported_edges`` entry is ``{edge, reason ∈ valid, detail}``.
+    """
+    # T.1 / T.2 — nodes
+    nodes = response.get("nodes")
+    if "nodes" not in response:
+        violations.append(
+            "[T.1 trace required key] 'nodes' is missing. A Subgraph must carry "
+            "'nodes', 'edges', 'truncated', and 'unsupported_edges'."
+        )
+    elif not isinstance(nodes, dict):
+        violations.append(
+            f"[T.1 trace field type] 'nodes' must be a dict (Map<Handle, Stub>); "
+            f"got {type(nodes).__name__!r}."
+        )
+    else:
+        for key, stub in nodes.items():
+            node_path = f"nodes[{key!r}]"
+            if not isinstance(key, str):
+                violations.append(
+                    f"[T.2 trace node key] {node_path}: node key must be a str handle; "
+                    f"got {type(key).__name__!r}."
+                )
+            _check_stub_structural_floor(stub, node_path, violations)
+            if isinstance(key, str) and isinstance(stub, dict):
+                handle = stub.get("handle")
+                if isinstance(handle, str) and handle != key:
+                    violations.append(
+                        f"[T.2 trace node key/handle] {node_path}.handle is {handle!r}; "
+                        "the node key must equal the stub handle (dedup-by-handle)."
+                    )
+
+    # T.1 / T.3 — edges
+    edges = response.get("edges")
+    if "edges" not in response:
+        violations.append("[T.1 trace required key] 'edges' is missing.")
+    elif not isinstance(edges, list):
+        violations.append(
+            f"[T.1 trace field type] 'edges' must be a list; got {type(edges).__name__!r}."
+        )
+    else:
+        for idx, edge in enumerate(edges):
+            _check_trace_edge(edge, f"edges[{idx}]", violations)
+
+    # T.1 — truncated: required bool (exactly bool, not truthy)
+    if "truncated" not in response:
+        violations.append("[T.1 trace required key] 'truncated' is missing.")
+    elif type(response.get("truncated")) is not bool:
+        violations.append(
+            f"[T.1 trace field type] 'truncated' must be a bool; "
+            f"got {type(response.get('truncated')).__name__!r}."
+        )
+
+    # T.1 / T.4 — unsupported_edges
+    unsupported = response.get("unsupported_edges")
+    if "unsupported_edges" not in response:
+        violations.append(
+            "[T.1 trace required key] 'unsupported_edges' is missing. Use [] when every "
+            "edge in 'follow' is supported."
+        )
+    elif not isinstance(unsupported, list):
+        violations.append(
+            f"[T.1 trace field type] 'unsupported_edges' must be a list; "
+            f"got {type(unsupported).__name__!r}."
+        )
+    else:
+        for idx, item in enumerate(unsupported):
+            _check_trace_unsupported_edge(item, f"unsupported_edges[{idx}]", violations)
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -941,10 +1111,11 @@ def lint_response(response: dict[str, Any], operation: str) -> None:
         response: The dict returned by resolve / resolve_at / inspect / expand,
             or a standalone Stub dict.
         operation: One of ``"resolve"``, ``"resolve_at"``, ``"inspect"``,
-            ``"expand"``, ``"stub"`` — used in error messages and for
+            ``"expand"``, ``"trace"``, ``"stub"`` — used in error messages and for
             operation-specific contract checks:
             - ``inspect``  gets B.3 Phase 4 cross-check
             - ``expand``   gets E.1–E.4 structural-floor + top-level source exemption
+            - ``trace``    gets T.1–T.4 Subgraph structural-floor
             - ``stub``     gets S.1–S.2 structural-floor
             - others don't get operation-specific checks
 
@@ -958,6 +1129,8 @@ def lint_response(response: dict[str, Any], operation: str) -> None:
 
     if operation == "expand":
         _check_expand_structural_floor(response, violations)
+    elif operation == "trace":
+        _check_trace_structural_floor(response, violations)
     elif operation == "stub":
         _check_stub_structural_floor(response, "", violations)
     else:

--- a/tests/conformance/test_linter_adversarial_trace.py
+++ b/tests/conformance/test_linter_adversarial_trace.py
@@ -51,6 +51,7 @@ _VALID_SUBGRAPH: dict = {
         },
     ],
     "truncated": False,
+    "truncation_reasons": [],
     "unsupported_edges": [],
 }
 
@@ -105,6 +106,33 @@ class TestTraceStructuralFloor:
         del sg["unsupported_edges"]
         with pytest.raises(ConformanceViolation, match="unsupported_edges"):
             lint_response(sg, "trace")
+
+    def test_missing_truncation_reasons_rejected(self) -> None:
+        sg = _clone()
+        del sg["truncation_reasons"]
+        with pytest.raises(ConformanceViolation, match="truncation_reasons"):
+            lint_response(sg, "trace")
+
+    def test_unknown_truncation_reason_rejected(self) -> None:
+        sg = _clone()
+        sg["truncated"] = True
+        sg["truncation_reasons"] = ["max_galaxies"]
+        with pytest.raises(ConformanceViolation, match="truncation_reasons"):
+            lint_response(sg, "trace")
+
+    def test_truncated_inconsistent_with_reasons_rejected(self) -> None:
+        # truncated True but no reasons listed — the back-compat invariant breaks.
+        sg = _clone()
+        sg["truncated"] = True
+        sg["truncation_reasons"] = []
+        with pytest.raises(ConformanceViolation, match="consistency"):
+            lint_response(sg, "trace")
+
+    def test_valid_truncated_with_reason_passes(self) -> None:
+        sg = _clone()
+        sg["truncated"] = True
+        sg["truncation_reasons"] = ["max_depth"]
+        lint_response(sg, "trace")  # must not raise
 
     def test_node_key_must_match_stub_handle(self) -> None:
         sg = _clone()

--- a/tests/conformance/test_linter_adversarial_trace.py
+++ b/tests/conformance/test_linter_adversarial_trace.py
@@ -1,0 +1,181 @@
+"""Adversarial test suite for the conformance linter — trace ``Subgraph`` shape.
+
+Each test targets one structural-floor (Check T) or layering (Check A) violation
+for the ``trace`` operation, plus a dogfood test that runs REAL ``trace`` output
+through the linter.
+
+Rule tags enforced here:
+    T.1  nodes/edges/truncated/unsupported_edges present with correct types
+    T.2  Each node value passes the Stub floor (S.*); node key == stub handle
+    T.3  Each edge is {from, to, kind} single-line strs
+    T.4  Each unsupported_edges entry is {edge, reason ∈ valid, detail non-empty}
+    A.*  No source content anywhere in the Subgraph (layering)
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from tests.conformance.response_linter import ConformanceViolation, lint_response
+
+_FIXTURE = Path(__file__).parent.parent / "fixtures" / "resolve_project"
+
+# A well-formed Subgraph (two nodes, one members edge, no unsupported edges).
+_VALID_SUBGRAPH: dict = {
+    "nodes": {
+        "mypackage._core.widgets.Widget": {
+            "handle": "mypackage._core.widgets.Widget",
+            "kind": "class",
+            "scope": "project",
+            "signature": "Widget(name: str)",
+            "line_start": 10,
+            "line_end": 50,
+        },
+        "mypackage._core.widgets.Widget.render": {
+            "handle": "mypackage._core.widgets.Widget.render",
+            "kind": "method",
+            "scope": "project",
+            "signature": "render(self) -> str",
+            "line_start": 20,
+            "line_end": 25,
+        },
+    },
+    "edges": [
+        {
+            "from": "mypackage._core.widgets.Widget",
+            "to": "mypackage._core.widgets.Widget.render",
+            "kind": "members",
+        },
+    ],
+    "truncated": False,
+    "unsupported_edges": [],
+}
+
+
+def _clone() -> dict:
+    return copy.deepcopy(_VALID_SUBGRAPH)
+
+
+class TestTraceAcceptsValid:
+    def test_valid_subgraph_passes(self) -> None:
+        lint_response(_clone(), "trace")  # must not raise
+
+    def test_unsupported_edges_entry_passes(self) -> None:
+        sg = _clone()
+        sg["unsupported_edges"] = [
+            {
+                "edge": "callers",
+                "reason": "deferred_reference_backend",
+                "detail": "Edge 'callers' requires the reference backend (#333).",
+            }
+        ]
+        lint_response(sg, "trace")  # must not raise
+
+
+class TestTraceStructuralFloor:
+    def test_missing_nodes_rejected(self) -> None:
+        sg = _clone()
+        del sg["nodes"]
+        with pytest.raises(ConformanceViolation, match="nodes"):
+            lint_response(sg, "trace")
+
+    def test_nodes_must_be_dict(self) -> None:
+        sg = _clone()
+        sg["nodes"] = []
+        with pytest.raises(ConformanceViolation, match="nodes"):
+            lint_response(sg, "trace")
+
+    def test_missing_edges_rejected(self) -> None:
+        sg = _clone()
+        del sg["edges"]
+        with pytest.raises(ConformanceViolation, match="edges"):
+            lint_response(sg, "trace")
+
+    def test_truncated_must_be_bool(self) -> None:
+        sg = _clone()
+        sg["truncated"] = "false"  # string, not bool
+        with pytest.raises(ConformanceViolation, match="truncated"):
+            lint_response(sg, "trace")
+
+    def test_missing_unsupported_edges_rejected(self) -> None:
+        sg = _clone()
+        del sg["unsupported_edges"]
+        with pytest.raises(ConformanceViolation, match="unsupported_edges"):
+            lint_response(sg, "trace")
+
+    def test_node_key_must_match_stub_handle(self) -> None:
+        sg = _clone()
+        # Corrupt the dedup-by-handle invariant: key != stub.handle.
+        node = sg["nodes"]["mypackage._core.widgets.Widget"]
+        node["handle"] = "mypackage._core.widgets.SomethingElse"
+        with pytest.raises(ConformanceViolation, match="handle"):
+            lint_response(sg, "trace")
+
+    def test_node_failing_stub_floor_rejected(self) -> None:
+        sg = _clone()
+        # Drop a required Stub key from a node value.
+        del sg["nodes"]["mypackage._core.widgets.Widget.render"]["scope"]
+        with pytest.raises(ConformanceViolation, match="scope"):
+            lint_response(sg, "trace")
+
+    def test_edge_missing_kind_rejected(self) -> None:
+        sg = _clone()
+        del sg["edges"][0]["kind"]
+        with pytest.raises(ConformanceViolation, match="kind"):
+            lint_response(sg, "trace")
+
+    def test_edge_endpoint_must_be_str(self) -> None:
+        sg = _clone()
+        sg["edges"][0]["to"] = 123
+        with pytest.raises(ConformanceViolation):
+            lint_response(sg, "trace")
+
+    def test_unsupported_edge_bad_reason_rejected(self) -> None:
+        sg = _clone()
+        sg["unsupported_edges"] = [{"edge": "callers", "reason": "made_up_reason", "detail": "x"}]
+        with pytest.raises(ConformanceViolation, match="reason"):
+            lint_response(sg, "trace")
+
+    def test_unsupported_edge_empty_detail_rejected(self) -> None:
+        sg = _clone()
+        sg["unsupported_edges"] = [
+            {"edge": "callers", "reason": "deferred_reference_backend", "detail": ""}
+        ]
+        with pytest.raises(ConformanceViolation, match="detail"):
+            lint_response(sg, "trace")
+
+
+class TestTraceLayering:
+    def test_source_content_in_node_stub_rejected(self) -> None:
+        sg = _clone()
+        # Smuggle source content into a node stub — layering (A.*) must reject it.
+        sg["nodes"]["mypackage._core.widgets.Widget"]["body"] = "def render(self):\n    ..."
+        with pytest.raises(ConformanceViolation):
+            lint_response(sg, "trace")
+
+
+class TestRealTraceOutputConforms:
+    """Dogfood: real trace output passes the linter with no linter change needed."""
+
+    @pytest.mark.asyncio
+    async def test_real_members_trace_conforms(self) -> None:
+        from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+        from pyeye.mcp.operations.trace import trace
+
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        result = await trace("mypackage._core.widgets.Widget", ["members"], analyzer, max_depth=2)
+        lint_response(result, "trace")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_real_trace_with_deferred_edge_conforms(self) -> None:
+        from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+        from pyeye.mcp.operations.trace import trace
+
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        result = await trace(
+            "mypackage._core.widgets.Widget", ["members", "callers"], analyzer, max_depth=1
+        )
+        lint_response(result, "trace")  # must not raise

--- a/tests/integration/api_redesign/test_traversal_integration.py
+++ b/tests/integration/api_redesign/test_traversal_integration.py
@@ -633,3 +633,83 @@ class TestExpandImportedByNonModuleEndToEnd:
         assert (
             type(result) is dict
         ), f"unsupported result must be exact dict; got {type(result)!r}"  # noqa: E721
+
+
+# ---------------------------------------------------------------------------
+# trace tool — registration + end-to-end over the wire
+# ---------------------------------------------------------------------------
+
+
+class TestTraceToolRegistered:
+    """Verify trace is importable from pyeye.mcp.server and is an async callable."""
+
+    def test_trace_is_importable(self) -> None:
+        from pyeye.mcp.server import trace  # noqa: F401
+
+    def test_trace_is_callable(self) -> None:
+        from pyeye.mcp.server import trace
+
+        assert callable(trace)
+
+    def test_trace_is_async(self) -> None:
+        from pyeye.mcp.server import trace
+
+        assert _inspect_stdlib.iscoroutinefunction(trace)
+
+
+class TestTraceEndToEnd:
+    """End-to-end Subgraph contract for the trace tool over the wire."""
+
+    @pytest.mark.asyncio
+    async def test_members_trace_returns_subgraph(self) -> None:
+        from pyeye.mcp.server import trace
+
+        result = await trace(
+            start="mypackage._core.widgets.Widget",
+            follow=["members"],
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+        assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
+        # Subgraph quad.
+        for key in ("nodes", "edges", "truncated", "unsupported_edges"):
+            assert key in result, f"'{key}' missing from Subgraph: {result!r}"
+        assert isinstance(result["nodes"], dict)
+        assert isinstance(result["edges"], list)
+        assert isinstance(result["truncated"], bool)
+        # The start is a node and its members produced edges.
+        assert "mypackage._core.widgets.Widget" in result["nodes"]
+        assert any(e["kind"] == "members" for e in result["edges"])
+        assert result["unsupported_edges"] == []
+
+    @pytest.mark.asyncio
+    async def test_deferred_edge_in_follow_surfaced_over_wire(self) -> None:
+        from pyeye.mcp.server import trace
+
+        result = await trace(
+            start="mypackage._core.widgets.Widget",
+            follow=["members", "callers"],
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+        # The supported edge still traverses; the deferred edge is surfaced.
+        assert any(e["kind"] == "members" for e in result["edges"])
+        callers = next((u for u in result["unsupported_edges"] if u["edge"] == "callers"), None)
+        assert callers is not None, f"'callers' not surfaced: {result['unsupported_edges']}"
+        assert callers["reason"] == "deferred_reference_backend"
+
+    @pytest.mark.asyncio
+    async def test_trace_result_is_json_serialisable(self) -> None:
+        from pyeye.mcp.server import trace
+
+        result = await trace(
+            start="mypackage._core.widgets",
+            follow=["imported_by"],
+            project_path=str(_FIXTURE),
+            max_depth=2,
+        )
+        # Plain dict, fully JSON round-trippable — no custom types leak the wire.
+        assert (
+            type(result) is dict
+        ), f"result must be exact dict; got {type(result)!r}"  # noqa: E721
+        json.loads(json.dumps(result))

--- a/tests/integration/api_redesign/test_traversal_integration.py
+++ b/tests/integration/api_redesign/test_traversal_integration.py
@@ -671,8 +671,8 @@ class TestTraceEndToEnd:
             max_depth=1,
         )
         assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
-        # Subgraph quad.
-        for key in ("nodes", "edges", "truncated", "unsupported_edges"):
+        # Subgraph keys.
+        for key in ("nodes", "edges", "truncated", "truncation_reasons", "unsupported_edges"):
             assert key in result, f"'{key}' missing from Subgraph: {result!r}"
         assert isinstance(result["nodes"], dict)
         assert isinstance(result["edges"], list)

--- a/tests/unit/mcp/operations/test_trace.py
+++ b/tests/unit/mcp/operations/test_trace.py
@@ -151,6 +151,44 @@ class TestTraceMaxNodes:
         assert result["truncated"] is False
 
 
+class TestTraceTruncationReasons:
+    """``truncation_reasons`` distinguishes the depth frontier from the node
+    budget so the agent knows which cap to raise (#352)."""
+
+    @pytest.mark.asyncio
+    async def test_depth_cut_reports_max_depth(self, analyzer: JediAnalyzer) -> None:
+        # Module members at depth 1: Widget's methods are cut by depth, not budget.
+        result = await trace(_WIDGETS_MODULE_HANDLE, ["members"], analyzer, max_depth=1)
+        assert result["truncated"] is True
+        assert result["truncation_reasons"] == ["max_depth"]
+
+    @pytest.mark.asyncio
+    async def test_node_budget_cut_reports_max_nodes(self, analyzer: JediAnalyzer) -> None:
+        # Generous depth, tight node budget: only the budget fires.
+        result = await trace(
+            _WIDGETS_MODULE_HANDLE, ["members"], analyzer, max_depth=5, max_nodes=2
+        )
+        assert result["truncated"] is True
+        assert result["truncation_reasons"] == ["max_nodes"]
+
+    @pytest.mark.asyncio
+    async def test_both_caps_report_both(self, analyzer: JediAnalyzer) -> None:
+        # Shallow depth AND a tight budget on the multi-path imported_by graph:
+        # the budget fills during root expansion, and frontier nodes still have
+        # unvisited importers cut by depth — both causes fire.
+        result = await trace(
+            _WIDGETS_MODULE_HANDLE, ["imported_by"], analyzer, max_depth=1, max_nodes=3
+        )
+        assert result["truncated"] is True
+        assert set(result["truncation_reasons"]) == {"max_depth", "max_nodes"}
+
+    @pytest.mark.asyncio
+    async def test_no_truncation_empty_reasons(self, analyzer: JediAnalyzer) -> None:
+        result = await trace(_WIDGET_HANDLE, ["members"], analyzer, max_depth=5)
+        assert result["truncated"] is False
+        assert result["truncation_reasons"] == []
+
+
 class TestTraceDeferredEdgeInFollow:
     """A deferred/unsupported edge in ``follow`` is surfaced explicitly — never
     silently dropped (which would falsely imply "no such neighbours")."""

--- a/tests/unit/mcp/operations/test_trace.py
+++ b/tests/unit/mcp/operations/test_trace.py
@@ -1,0 +1,85 @@
+"""Tests for the ``trace(start, follow, ...)`` operation — Phase 4 (Task 4.1+4.2).
+
+``trace`` is the bounded multi-hop BFS primitive.  It composes the single-hop
+edge registry (``members``, ``callees``, ``imported_by``) across hops and returns
+a ``Subgraph`` (spec §``trace``)::
+
+    type Subgraph = {
+      nodes: Map<Handle, Stub>                       # deduped by handle
+      edges: { from: Handle, to: Handle, kind }[]    # NOT deduped across kinds
+      truncated: boolean    # max_depth/max_nodes hit BEFORE natural termination
+    }
+
+Termination: dedup by handle (visit once); edges *to* already-visited handles are
+recorded (cycles stay visible) but do not trigger re-expansion — so cyclic graphs
+terminate even at unbounded depth.
+
+Fixture facts (``tests/fixtures/resolve_project``):
+- ``mypackage._core.widgets.Widget`` — a class WITH members (members happy path).
+- ``mypackage._core.widgets`` — a module imported by several other modules.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+from pyeye.mcp.operations.trace import trace
+
+_FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
+
+_WIDGET_HANDLE = "mypackage._core.widgets.Widget"
+
+#: Stub keys always present (spec §4.1; ``signature`` is callable-only).
+_STUB_REQUIRED_KEYS = {"handle", "kind", "scope", "line_start", "line_end"}
+
+
+@pytest.fixture
+def analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at the resolve_project fixture."""
+    return JediAnalyzer(str(_FIXTURE))
+
+
+def _assert_is_stub(stub: dict) -> None:
+    """Assert *stub* conforms to the Phase-1 §4.1 Stub shape (no source content)."""
+    assert isinstance(stub, dict), f"stub must be a dict, got {type(stub)}"
+    missing = _STUB_REQUIRED_KEYS - set(stub)
+    assert not missing, f"stub missing required keys {missing}: {stub}"
+    for forbidden in ("body", "source", "code", "snippet", "text"):
+        assert forbidden not in stub, f"stub leaked source content via {forbidden!r}: {stub}"
+
+
+class TestTraceMembersOneHop:
+    """The core happy path: a single-edge, single-hop trace over ``members``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_subgraph_shape(self, analyzer: JediAnalyzer) -> None:
+        result = await trace(_WIDGET_HANDLE, ["members"], analyzer, max_depth=1)
+        # Subgraph triple.
+        assert set(result) >= {"nodes", "edges", "truncated"}
+        assert isinstance(result["nodes"], dict)
+        assert isinstance(result["edges"], list)
+        assert isinstance(result["truncated"], bool)
+
+    @pytest.mark.asyncio
+    async def test_start_and_members_are_nodes(self, analyzer: JediAnalyzer) -> None:
+        result = await trace(_WIDGET_HANDLE, ["members"], analyzer, max_depth=1)
+        # The start handle is the root node of the subgraph.
+        assert _WIDGET_HANDLE in result["nodes"]
+        # Widget has members, so the closure has more than just the root.
+        assert len(result["nodes"]) > 1, "expected the start plus its member nodes"
+        # Every node value is a well-formed stub.
+        for stub in result["nodes"].values():
+            _assert_is_stub(stub)
+
+    @pytest.mark.asyncio
+    async def test_records_members_edges_from_start(self, analyzer: JediAnalyzer) -> None:
+        result = await trace(_WIDGET_HANDLE, ["members"], analyzer, max_depth=1)
+        member_edges = [
+            e for e in result["edges"] if e["from"] == _WIDGET_HANDLE and e["kind"] == "members"
+        ]
+        assert member_edges, "expected members edges from the start handle"
+        # Every edge endpoint must itself be a node (the graph is closed).
+        for edge in result["edges"]:
+            assert edge["from"] in result["nodes"], f"edge from-handle not a node: {edge}"
+            assert edge["to"] in result["nodes"], f"edge to-handle not a node: {edge}"

--- a/tests/unit/mcp/operations/test_trace.py
+++ b/tests/unit/mcp/operations/test_trace.py
@@ -19,12 +19,13 @@ Fixture facts (``tests/fixtures/resolve_project``):
 - ``mypackage._core.widgets`` — a module imported by several other modules.
 """
 
+from collections import Counter
 from pathlib import Path
 
 import pytest
 
 from pyeye.analyzers.jedi_analyzer import JediAnalyzer
-from pyeye.mcp.operations.trace import trace
+from pyeye.mcp.operations.trace import _stops_at, trace
 
 _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
 
@@ -181,3 +182,103 @@ class TestTraceDeferredEdgeInFollow:
     ) -> None:
         result = await trace(_WIDGET_HANDLE, ["members"], analyzer, max_depth=1)
         assert result["unsupported_edges"] == []
+
+
+class TestStopsAtPredicate:
+    """Unit tests for the ``_stops_at`` boundary predicate (kind-agnostic)."""
+
+    def test_module_pattern_substring_match(self) -> None:
+        assert _stops_at("mypackage._core.widgets", {"module_pattern": "_core"}) is True
+        assert _stops_at("mypackage.usage", {"module_pattern": "_core"}) is False
+
+    def test_exclude_tests_matches_test_modules(self) -> None:
+        assert _stops_at("tests.unit.test_thing", {"exclude_tests": True}) is True
+        assert _stops_at("pkg.test_helpers", {"exclude_tests": True}) is True
+        assert _stops_at("mypackage.usage", {"exclude_tests": True}) is False
+
+    def test_no_predicate_never_stops(self) -> None:
+        assert _stops_at("anything.at.all", None) is False
+        assert _stops_at("anything.at.all", {}) is False
+
+
+class TestTraceStopWhen:
+    """``stop_when`` prunes the traversal at the predicate boundary."""
+
+    @pytest.mark.asyncio
+    async def test_module_pattern_prunes_matching_adjacents(self, analyzer: JediAnalyzer) -> None:
+        # Baseline: importers of widgets include several ``_core.*`` modules.
+        full = await trace(_WIDGETS_MODULE_HANDLE, ["imported_by"], analyzer, max_depth=1)
+        core_importers = [h for h in full["nodes"] if "_core" in h and h != _WIDGETS_MODULE_HANDLE]
+        assert core_importers, "fixture should have _core importers to prune"
+
+        # With module_pattern '_core', those adjacents are pruned at the boundary;
+        # the start (itself a _core module) is a root and is never pruned.
+        pruned = await trace(
+            _WIDGETS_MODULE_HANDLE,
+            ["imported_by"],
+            analyzer,
+            max_depth=1,
+            stop_when={"module_pattern": "_core"},
+        )
+        leaked = [h for h in pruned["nodes"] if "_core" in h and h != _WIDGETS_MODULE_HANDLE]
+        assert leaked == [], f"module_pattern did not prune _core adjacents: {leaked}"
+        # Non-matching importers survive (e.g. mypackage.usage / use_widget).
+        assert any(h.startswith("mypackage.") and "_core" not in h for h in pruned["nodes"])
+        # The graph stays closed — no edge points at a pruned (absent) node.
+        for edge in pruned["edges"]:
+            assert edge["from"] in pruned["nodes"], f"edge from-handle not a node: {edge}"
+            assert edge["to"] in pruned["nodes"], f"edge to-handle not a node: {edge}"
+
+
+class TestTraceMultiHopAndMultiEdge:
+    """Regression locks for multi-hop depth and multi-edge ``follow``."""
+
+    @pytest.mark.asyncio
+    async def test_two_hop_members_reaches_second_level(self, analyzer: JediAnalyzer) -> None:
+        result = await trace(_WIDGETS_MODULE_HANDLE, ["members"], analyzer, max_depth=2)
+        # Widget is a depth-1 member of the module...
+        assert _WIDGET_HANDLE in result["nodes"]
+        # ...and the 2nd hop expanded it: members edges originate FROM Widget.
+        second_hop = [
+            e for e in result["edges"] if e["from"] == _WIDGET_HANDLE and e["kind"] == "members"
+        ]
+        assert second_hop, "expected 2nd-hop members edges from Widget"
+        for edge in second_hop:
+            assert edge["to"] in result["nodes"], f"2nd-hop target not a node: {edge}"
+
+    @pytest.mark.asyncio
+    async def test_multi_edge_follow_labels_each_kind(self, analyzer: JediAnalyzer) -> None:
+        result = await trace(
+            _WIDGETS_MODULE_HANDLE, ["members", "imported_by"], analyzer, max_depth=1
+        )
+        kinds = {e["kind"] for e in result["edges"]}
+        # Both edge types are present and correctly labelled (not deduped across kinds).
+        assert "members" in kinds
+        assert "imported_by" in kinds
+        assert result["unsupported_edges"] == []
+        for edge in result["edges"]:
+            assert edge["from"] in result["nodes"], f"edge from-handle not a node: {edge}"
+            assert edge["to"] in result["nodes"], f"edge to-handle not a node: {edge}"
+
+
+class TestTraceCycleSafe:
+    """Cycle-safe termination + dedup on a fan-in / multi-path graph."""
+
+    @pytest.mark.asyncio
+    async def test_terminates_dedups_and_records_fanin_edges(self, analyzer: JediAnalyzer) -> None:
+        # The imported_by closure is a multi-path graph (more edges than a tree).
+        result = await trace(_WIDGETS_MODULE_HANDLE, ["imported_by"], analyzer, max_depth=10)
+        # Natural termination despite the cyclic/multi-path structure.
+        assert result["truncated"] is False
+        # Fan-in: more edges than a spanning tree (nodes - 1) would have.
+        assert len(result["edges"]) > len(result["nodes"]) - 1
+        # A fan-in target is reached by multiple edges but appears as ONE node
+        # (dedup), and every edge endpoint is a node (cycle edges stay visible).
+        incoming = Counter(e["to"] for e in result["edges"])
+        fan_in = [target for target, count in incoming.items() if count > 1]
+        assert fan_in, "expected at least one fan-in target"
+        for target in fan_in:
+            assert target in result["nodes"], "fan-in target must be a single deduped node"
+        for edge in result["edges"]:
+            assert edge["from"] in result["nodes"], f"edge from-handle not a node: {edge}"
+            assert edge["to"] in result["nodes"], f"edge to-handle not a node: {edge}"

--- a/tests/unit/mcp/operations/test_trace.py
+++ b/tests/unit/mcp/operations/test_trace.py
@@ -33,6 +33,9 @@ _WIDGET_HANDLE = "mypackage._core.widgets.Widget"
 #: A MODULE whose members include the ``Widget`` class, which itself has members
 #: (methods) — a genuine two-level ``members`` tree for depth/truncation tests.
 _WIDGETS_MODULE_HANDLE = "mypackage._core.widgets"
+#: A function whose ``callees`` mix project (``make_widget``) and external
+#: (``math.sqrt``, ``builtins.float``) nodes — for scope-filter tests (#351).
+_ORCHESTRATE_HANDLE = "mypackage._core.callees_fixture.orchestrate"
 
 #: Stub keys always present (spec §4.1; ``signature`` is callable-only).
 _STUB_REQUIRED_KEYS = {"handle", "kind", "scope", "line_start", "line_end"}
@@ -185,20 +188,81 @@ class TestTraceDeferredEdgeInFollow:
 
 
 class TestStopsAtPredicate:
-    """Unit tests for the ``_stops_at`` boundary predicate (kind-agnostic)."""
+    """Unit tests for the ``_stops_at`` boundary predicate.
+
+    Signature is ``_stops_at(handle, scope, stop_when)`` — scope is needed for the
+    ``exclude_external`` key (scope is not derivable from the handle string).
+    """
 
     def test_module_pattern_substring_match(self) -> None:
-        assert _stops_at("mypackage._core.widgets", {"module_pattern": "_core"}) is True
-        assert _stops_at("mypackage.usage", {"module_pattern": "_core"}) is False
+        assert _stops_at("mypackage._core.widgets", "project", {"module_pattern": "_core"}) is True
+        assert _stops_at("mypackage.usage", "project", {"module_pattern": "_core"}) is False
 
     def test_exclude_tests_matches_test_modules(self) -> None:
-        assert _stops_at("tests.unit.test_thing", {"exclude_tests": True}) is True
-        assert _stops_at("pkg.test_helpers", {"exclude_tests": True}) is True
-        assert _stops_at("mypackage.usage", {"exclude_tests": True}) is False
+        assert _stops_at("tests.unit.test_thing", "project", {"exclude_tests": True}) is True
+        assert _stops_at("pkg.test_helpers", "project", {"exclude_tests": True}) is True
+        assert _stops_at("mypackage.usage", "project", {"exclude_tests": True}) is False
+
+    def test_exclude_external_matches_external_scope(self) -> None:
+        # scope-aware: external adjacents are a boundary; project ones are not.
+        assert _stops_at("math.sqrt", "external", {"exclude_external": True}) is True
+        assert _stops_at("builtins.float", "external", {"exclude_external": True}) is True
+        assert _stops_at("mypackage.usage", "project", {"exclude_external": True}) is False
 
     def test_no_predicate_never_stops(self) -> None:
-        assert _stops_at("anything.at.all", None) is False
-        assert _stops_at("anything.at.all", {}) is False
+        assert _stops_at("anything.at.all", "external", None) is False
+        assert _stops_at("anything.at.all", "external", {}) is False
+
+
+class TestTraceExcludeExternal:
+    """``stop_when={'exclude_external': True}`` prunes external nodes and frees
+    the node budget for project nodes (#351)."""
+
+    @pytest.mark.asyncio
+    async def test_drops_external_nodes(self, analyzer: JediAnalyzer) -> None:
+        # Baseline: orchestrate's callees include external nodes.
+        full = await trace(_ORCHESTRATE_HANDLE, ["callees"], analyzer, max_depth=1)
+        assert any(
+            n["scope"] == "external" for n in full["nodes"].values()
+        ), "fixture must have external callees to prune"
+
+        pruned = await trace(
+            _ORCHESTRATE_HANDLE,
+            ["callees"],
+            analyzer,
+            max_depth=1,
+            stop_when={"exclude_external": True},
+        )
+        externals = [h for h, n in pruned["nodes"].items() if n["scope"] == "external"]
+        assert externals == [], f"exclude_external left external nodes: {externals}"
+        # Project callees still present; graph stays closed.
+        assert any(n["scope"] == "project" for n in pruned["nodes"].values())
+        for edge in pruned["edges"]:
+            assert edge["from"] in pruned["nodes"], f"edge from-handle not a node: {edge}"
+            assert edge["to"] in pruned["nodes"], f"edge to-handle not a node: {edge}"
+
+    @pytest.mark.asyncio
+    async def test_external_nodes_do_not_consume_budget(self, analyzer: JediAnalyzer) -> None:
+        # The budget-starvation fix: pruned externals never count against
+        # max_nodes, so the whole cap is spent on project nodes.
+        cap = 3
+        without = await trace(
+            _ORCHESTRATE_HANDLE, ["callees"], analyzer, max_depth=2, max_nodes=cap
+        )
+        with_excl = await trace(
+            _ORCHESTRATE_HANDLE,
+            ["callees"],
+            analyzer,
+            max_depth=2,
+            max_nodes=cap,
+            stop_when={"exclude_external": True},
+        )
+        proj_without = sum(1 for n in without["nodes"].values() if n["scope"] == "project")
+        proj_with = sum(1 for n in with_excl["nodes"].values() if n["scope"] == "project")
+        # Freeing externals can only help project nodes fit under the cap.
+        assert proj_with >= proj_without
+        # And the cap is now spent entirely on project nodes.
+        assert all(n["scope"] == "project" for n in with_excl["nodes"].values())
 
 
 class TestTraceStopWhen:

--- a/tests/unit/mcp/operations/test_trace.py
+++ b/tests/unit/mcp/operations/test_trace.py
@@ -29,6 +29,9 @@ from pyeye.mcp.operations.trace import trace
 _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
 
 _WIDGET_HANDLE = "mypackage._core.widgets.Widget"
+#: A MODULE whose members include the ``Widget`` class, which itself has members
+#: (methods) — a genuine two-level ``members`` tree for depth/truncation tests.
+_WIDGETS_MODULE_HANDLE = "mypackage._core.widgets"
 
 #: Stub keys always present (spec §4.1; ``signature`` is callable-only).
 _STUB_REQUIRED_KEYS = {"handle", "kind", "scope", "line_start", "line_end"}
@@ -83,3 +86,98 @@ class TestTraceMembersOneHop:
         for edge in result["edges"]:
             assert edge["from"] in result["nodes"], f"edge from-handle not a node: {edge}"
             assert edge["to"] in result["nodes"], f"edge to-handle not a node: {edge}"
+
+
+class TestTraceTruncated:
+    """``truncated`` is True ONLY when a cap cut off reachable nodes before
+    natural termination — never merely because a cap was set."""
+
+    @pytest.mark.asyncio
+    async def test_truncated_true_when_depth_cuts_off_reachable_nodes(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        # The module's members include ``Widget``, a class that ITSELF has
+        # members (methods).  At max_depth=1 those grandchildren are reachable
+        # but not visited → truncated.
+        result = await trace(_WIDGETS_MODULE_HANDLE, ["members"], analyzer, max_depth=1)
+        assert result["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_truncated_false_when_fully_explored(self, analyzer: JediAnalyzer) -> None:
+        # Tracing the Widget class with ample depth: Widget → methods, and
+        # methods have no further members → the whole closure is returned.
+        result = await trace(_WIDGET_HANDLE, ["members"], analyzer, max_depth=5)
+        assert result["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_cutoff_does_not_leak_beyond_depth_nodes_or_edges(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        # Truncation must not smuggle beyond-depth handles in: the graph stays
+        # closed (every edge endpoint is a node) even when truncated.
+        result = await trace(_WIDGETS_MODULE_HANDLE, ["members"], analyzer, max_depth=1)
+        assert result["truncated"] is True
+        for edge in result["edges"]:
+            assert edge["from"] in result["nodes"], f"edge from-handle not a node: {edge}"
+            assert edge["to"] in result["nodes"], f"edge to-handle not a node: {edge}"
+
+
+class TestTraceMaxNodes:
+    """``max_nodes`` bounds the node count; hitting it sets ``truncated``."""
+
+    @pytest.mark.asyncio
+    async def test_max_nodes_caps_node_count_and_truncates(self, analyzer: JediAnalyzer) -> None:
+        # A deep-enough trace of the module would yield well over two nodes;
+        # max_nodes=2 must cap the closure and report truncation.
+        result = await trace(
+            _WIDGETS_MODULE_HANDLE, ["members"], analyzer, max_depth=3, max_nodes=2
+        )
+        assert len(result["nodes"]) <= 2
+        assert result["truncated"] is True
+        # The graph stays closed even when the node cap cut the walk short.
+        for edge in result["edges"]:
+            assert edge["from"] in result["nodes"], f"edge from-handle not a node: {edge}"
+            assert edge["to"] in result["nodes"], f"edge to-handle not a node: {edge}"
+
+    @pytest.mark.asyncio
+    async def test_under_cap_is_not_truncated(self, analyzer: JediAnalyzer) -> None:
+        # A generous cap on a small closure leaves truncated False.
+        result = await trace(_WIDGET_HANDLE, ["members"], analyzer, max_depth=5, max_nodes=100)
+        assert len(result["nodes"]) < 100
+        assert result["truncated"] is False
+
+
+class TestTraceDeferredEdgeInFollow:
+    """A deferred/unsupported edge in ``follow`` is surfaced explicitly — never
+    silently dropped (which would falsely imply "no such neighbours")."""
+
+    @pytest.mark.asyncio
+    async def test_deferred_edge_surfaced_while_supported_edge_traversed(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        result = await trace(_WIDGET_HANDLE, ["members", "callers"], analyzer, max_depth=1)
+        # The supported edge is still traversed (partial value is preserved).
+        assert any(e["kind"] == "members" for e in result["edges"])
+        # The deferred edge is reported, not silently omitted.
+        unsupported = result["unsupported_edges"]
+        callers = next((u for u in unsupported if u["edge"] == "callers"), None)
+        assert callers is not None, f"'callers' not surfaced: {unsupported}"
+        assert callers["reason"] == "deferred_reference_backend"
+        # No edge in the graph carries the unsupported kind.
+        assert not any(e["kind"] == "callers" for e in result["edges"])
+
+    @pytest.mark.asyncio
+    async def test_unknown_edge_surfaced(self, analyzer: JediAnalyzer) -> None:
+        result = await trace(_WIDGET_HANDLE, ["definitely_not_an_edge"], analyzer, max_depth=1)
+        unsupported = result["unsupported_edges"]
+        assert any(
+            u["edge"] == "definitely_not_an_edge" and u["reason"] == "unknown_edge"
+            for u in unsupported
+        ), unsupported
+
+    @pytest.mark.asyncio
+    async def test_all_supported_follow_reports_empty_unsupported(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        result = await trace(_WIDGET_HANDLE, ["members"], analyzer, max_depth=1)
+        assert result["unsupported_edges"] == []


### PR DESCRIPTION
## Summary

Implements **`trace`** — the bounded multi-hop BFS traversal primitive — completing the progressive-disclosure flow (`resolve` → `inspect` → `expand` → **`trace`**), and folds in two follow-ups found while dogfooding this branch so trace lands in a genuinely good state rather than a known-suboptimal one.

`trace(start, follow, …)` composes the existing edge registry across hops and returns a `Subgraph`. It's a pure **consumer** of `edges.py` (never writes it), so it stays conflict-free with the parallel #348 `subclasses` work and picks up new edges automatically.

## Response — `Subgraph`
```
{ "nodes": { handle: Stub, ... },           # deduped by canonical handle
  "edges": [ {"from","to","kind"}, ... ],    # NOT deduped across kinds
  "truncated": bool,                          # derived; kept for back-compat
  "truncation_reasons": ["max_depth"?, "max_nodes"?],   # WHICH cap(s) fired (#352)
  "unsupported_edges": [ {"edge","reason","detail"}, ... ] }   # deferred/unknown edges (#349)
```

## What's included (each test-first, RED→GREEN)

**#349 — the primitive**
- Multi-hop BFS over `members` / `callees` / `imported_by`, deduped by handle
- Cycle-safe termination (edges to visited handles recorded, never re-expanded)
- Honest `truncated` (only when a cap cut off reachable nodes; peeks one hop past the frontier; graph stays closed)
- `max_nodes` cap; `stop_when` predicate; `unsupported_edges` honesty (deferred edge in `follow` surfaced, never silently dropped — #332 guard)
- Registered as an `@mcp.tool` mirroring `expand`; plain-dict, JSON-serialisable
- Conformance **Check T** locks the Subgraph shape (adversarial + real-output dogfood)

**#351 — `exclude_external` scope filter** (`stop_when`)
- `_stops_at` is now scope-aware; `exclude_external: true` prunes stdlib/site-packages nodes
- Crucially, pruned externals **never consume the `max_nodes` budget** — fixes budget-starvation where a `callees` trace exploded into `builtins`/`jedi`/stdlib and crowded out project nodes
- Keeps trace a pure registry consumer (no `edges.py`/`stubs.py` change)

**#352 — `truncation_reasons`**
- Distinguishes the depth frontier (`max_depth`) from the node budget (`max_nodes`) so the agent knows which cap to raise; both can fire; `truncated` derived + kept for back-compat
- Conformance Check **T.5** validates the values + the `truncated`-consistency invariant

## Test plan
- [x] 25 unit (`test_trace.py`), trace integration (`test_traversal_integration.py`), conformance (`test_linter_adversarial_trace.py`)
- [x] Full suite: 1873 passed, **86.76% coverage** (>85%). Only failure is the pre-existing `test_cache_hit_performance` perf flake under `--cov`, confirmed passing without coverage — unrelated to this change
- [x] ruff / black / mypy clean; pre-commit green on every commit (no bypass)
- [x] No `get_references` introduced — trace only composes the registry's reliable edges

## Notes
- Pairs with #348 (`subclasses`): once it lands, `trace` follows `subclasses` with no shape change
- Inbound/reference edges (`callers`/`references`) stay deferred behind #333, surfaced via `unsupported_edges`
- #353 (imported-vs-defined member marking) is a separate Stub/members-layer change (`edges.py`) — intentionally NOT bundled here to avoid colliding with #348

Closes #349
Closes #351
Closes #352