### PR TITLE
feat(edges): promote subclasses to a supported expand edge (#348)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-subclasses-edge.md
+++ b/docs/superpowers/plans/2026-06-13-subclasses-edge.md
@@ -1,0 +1,160 @@
+# subclasses edge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote `subclasses` from a `not_yet_implemented` edge to a supported Jedi/AST-backed `expand` edge — `expand(class_handle, "subclasses")` returns the project classes that subclass the target as canonical class stubs — with no `ExpandResult` shape change and no `expand.py` change.
+
+**Architecture:** `subclasses` is the plan's deliberate "directionally-inbound but reliably-static" exception: it is produced by an AST class-graph walk + forward `goto`/`resolve_canonical` (no `get_references` / reverse symbol search), so it belongs with `members`/`callees`/`imported_by`. A new synchronous-wrapping resolver `resolve_subclasses` **reuses the existing `JediAnalyzer.find_subclasses`** (`jedi_analyzer.py:3070`) verbatim — same call shape `_count_subclasses` already uses (`scope="main"`, `include_indirect=True`) so the expanded list stays consistent with `inspect.edge_counts.subclasses`. Wrong-kind handles return a measured-empty `EdgeResult([])` (mirroring `members`/`callees`), because only a class *can* be subclassed — `[]` for a non-class is true by definition, not the #332 absence-vs-zero lie. This keeps the slice strictly additive: `edges.py` registry + one resolver, no `None` path, no `expand.py` edit.
+
+**Tech Stack:** Python, FastMCP, Jedi (forward ops only — `find_subclasses`, `file_artifact_cache.get_script`/`get_ast`, `goto`, `resolve_canonical`), pytest. Reuses `pyeye.handle.Handle`, the `edges` registry / `EdgeResult` / `build_stub` / `expand` foundation from #340 (#342), and the existing `find_subclasses` analyzer method.
+
+**Spec / precedent:** This slice has no dedicated spec doc. Its template is the merged `imported_by` promotion — design `docs/superpowers/specs/2026-06-10-imported-by-edge-design.md`, plan `docs/superpowers/plans/2026-06-10-imported-by-edge.md` (PR #346). Where this plan diverges from that template, the divergence is called out explicitly below.
+
+**Branch / issue:** `feat/348-subclasses-edge`, issue #348. Off `main` (which carries #342 + #345/#346).
+
+> **Note on the issue's cited reference.** Issue #348 cites `docs/superpowers/plans/2026-06-02-outline-expand-trace.md` (Task 1.3/1.4) for the "reliably-static" justification. **That file does not exist in this tree.** The justification is nonetheless verified directly against the code (see Phase 0) and against the `imported_by` design doc, which states the same `subclasses` carve-out reasoning. Do not block on the missing doc.
+
+---
+
+## Key design decisions (locked before implementation)
+
+1. **Wrong-kind → measured-empty, NOT `None`/`not_yet_implemented`.** (User-confirmed.) `resolve_subclasses` returns `EdgeResult([])` for a non-class handle. Rationale: nothing but a class can be subclassed, so `subclasses: []` for a function/variable/module is *true by definition* — exactly the `members`/`callees` case (`[] for the wrong kind is true by definition`), **not** the `imported_by` case (a symbol genuinely *can* be imported, so `[]` there would be a lie). Consequence: `resolve_subclasses` **never returns `None`**, so `expand.py` is **untouched** — its hardcoded "supported for modules only" `None`-branch detail stays correct (only `imported_by` uses `None`). This is the single biggest simplification versus the `imported_by` template.
+
+2. **Reuse `find_subclasses` directly — no extraction.** Unlike `imported_by` (whose scan was buried inside the deprecated `analyze_dependencies`, forcing a `find_importers` extraction), `find_subclasses` is already a standalone public `JediAnalyzer` method. `resolve_subclasses` calls it as-is. **No analyzer refactor, no `find_importers`-style extraction, no `ModuleSentinel`-style new leaf.**
+
+3. **Call shape mirrors `_count_subclasses` exactly: `scope="main"`, `include_indirect=True`, `show_hierarchy=False`.** This is load-bearing for the progressive-disclosure contract: `inspect.edge_counts.subclasses` is computed with that exact shape (`inspect.py:757-763`), so `len(expand(C,"subclasses").stubs)` must equal `inspect(C).edge_counts.subclasses`. `scope="main"` (project-internal only, excludes stdlib/third-party/namespaces) also matches the issue's "project classes that subclass the target". `include_indirect=True` means this single-hop edge intentionally returns the full project subclass closure (direct + indirect) — a deliberate divergence from `members`/`callees` direct-only semantics, justified by count/list consistency. **Constraint:** if a later slice changes either `_count_subclasses` or this resolver's call shape, it must change both together.
+
+---
+
+## Hard constraints (apply to every task)
+
+- **No reverse symbol search.** No path for `subclasses` may call `get_references` / `find_references`. `find_subclasses` resolves bases via AST walk + forward `goto(follow_imports=True)` + `resolve_canonical` only (verified in Phase 0). This is grep-verified and asserted by a spy test, exactly as `callees`/`imported_by` are. This is the load-bearing reason the edge can be promoted at all.
+- **No `ExpandResult` / linter shape change.** `subclasses` is a normal member of the existing discriminated union — class → supported `{source, edge, stubs}`; non-class → supported `{source, edge, stubs: []}` (measured-none). No new fields, no `unresolved_call_sites` (callees-only), no `None` path. The conformance linter must need no code change.
+- **`expand.py` is not modified.** If implementing `subclasses` appears to require an `expand.py` change, stop — it means the `None` path crept back in, contradicting decision (1).
+- **Behavior-preserving reuse.** `resolve_subclasses` wraps `find_subclasses`; it must not reimplement the subclass search and must not modify `find_subclasses`. The legacy `find_subclasses` tool and all its existing tests must pass **unmodified**. The existing `inspect.edge_counts.subclasses` tests must also pass unmodified.
+- **Canonical class stubs, with breadth.** Each adjacency is a canonical class `Handle`; each stub is built from a Jedi `Name` obtained by **forward enumeration over the subclass's own file** — copy the pattern from `_class_members` (`edges.py:233-274`): `get_script(subclass_file).get_names(...)` filtered to the entry whose `full_name` equals the subclass's `full_name` from the `find_subclasses` dict — **not** by dotted-handle re-resolution. Re-resolution by handle drops subclasses defined in non-importable files (e.g. a `class Impl(Base)` in a `tests/` file — which `scope="main"` *does* find) and is fragile on macOS symlinked temp dirs; file-based resolution preserves both breadth and correctness.
+- **One intended observable registry change (with one intended test edit).** Moving `subclasses` from `_NOT_YET_IMPLEMENTED_EDGES` to `_IMPLEMENTED_EDGES` flips `edge_status("subclasses")`. The status-matrix test (`tests/unit/mcp/operations/test_edges.py:130-141`) parametrizes `subclasses` under `not_yet_implemented`; it **must** be updated (drop it from that param list; add a `test_subclasses_is_implemented` mirroring `test_imported_by_is_implemented`). This is the *intended* test edit, distinct from the behavior-preserving guardrails.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/pyeye/mcp/operations/edges.py` | Modify | Move `subclasses` from `_NOT_YET_IMPLEMENTED_EDGES` to `_IMPLEMENTED_EDGES`; add the (async) `resolve_subclasses` resolver (class → `EdgeResult` of canonical class `(Handle, Name)` pairs; non-class → `EdgeResult([])`); register it in `EDGE_RESOLVERS`. Update the module docstring's status table + the `EDGE_RESOLVERS` comment to list `subclasses`. |
+| `src/pyeye/mcp/operations/expand.py` | **Unchanged** | Already awaits awaitable resolver results and already builds stubs per `(handle, Name)`. No edit (decision 1). Listed here only to assert "no change". |
+| `src/pyeye/analyzers/jedi_analyzer.py` | **Unchanged** | `find_subclasses` reused as-is. No edit. |
+| `tests/unit/mcp/operations/test_edges.py` | Modify | Update the status-matrix assertion (the one intended edit). Add `resolve_subclasses` coverage: class with ≥2 subclasses incl. an indirect one and a test/script-file subclass → correct canonical class handles; class with no subclasses → `EdgeResult([])` (measured-none); non-class handle → `EdgeResult([])` (measured-none, NOT `None`); the no-`get_references` spy. |
+| `tests/unit/mcp/operations/test_expand.py` | Modify | `expand(class, "subclasses")` → supported with class stubs; `expand(non_class, "subclasses")` → supported `stubs: []` (NOT the unsupported branch); supported result carries no `unresolved_call_sites`; **count/list consistency** assertion against `inspect(...).edge_counts.subclasses`. |
+| `tests/integration/api_redesign/test_traversal_integration.py` | Modify | `subclasses` end-to-end via the already-registered MCP `expand` tool — class (supported, stubs) and non-class (supported, `stubs: []`) — as plain serialisable dicts. |
+| `tests/conformance/test_linter_adversarial_expand.py` | Modify | Dogfood real `subclasses` output (class result + non-class measured-empty) through `lint_response(result, "expand")`; confirm **no linter code change**. |
+| `tests/fixtures/...` | Identify/extend | A base class with ≥2 project subclasses including (a) an indirect/grandchild subclass and (b) a subclass defined in a non-importable file (e.g. a test/script-style module) to prove breadth. Reuse an existing `find_subclasses` fixture if one already covers this. |
+
+---
+
+## Phase 0: Verify the load-bearing precondition
+
+Confirm the "reliably-static" claim before building on it, since the cited plan doc is missing.
+
+### Task 0.1: Confirm `find_subclasses` never reaches `get_references`
+
+- [ ] Trace the `find_subclasses` call tree (`_resolve_direct_subclass_fqns`, `_resolve_aliased_bases`, `_canonical_cached`/`resolve_canonical`, `get_project_files`, the AST helpers) and confirm none calls `get_references`/`find_references` — because the entire promotion depends on the edge being forward-only. Grep is sufficient; the known `get_references` call sites in `jedi_analyzer.py` are all on `find_references`-family paths, not the subclass path.
+- [ ] Confirm `inspect.edge_counts.subclasses` is computed via `find_subclasses(scope="main", include_indirect=True, show_hierarchy=False)` (`inspect.py:_count_subclasses`) so the resolver's call shape can match it.
+
+**Files:** none modified (investigation).
+**Acceptance:** Documented confirmation (in the task's notes / commit message of Phase 1) that the subclass path is forward-only and the count call shape is known.
+**Risks:** If any helper *does* reach `get_references`, the promotion premise is false — stop and escalate; the edge would belong with the deferred reference edges, not this slice.
+
+---
+
+## Phase 1: `resolve_subclasses` + registry move
+
+The whole edge: resolver, registration, and the status flip. (No extraction phases are needed — contrast the `imported_by` plan's Phases 1–2.)
+
+### Task 1.1: Failing tests for the registry move and `resolve_subclasses`
+
+- [ ] Update the status-matrix test so `subclasses` is asserted `implemented` (drop it from the `not_yet_implemented` parametrize at `test_edges.py:132`; add a `test_subclasses_is_implemented` mirroring the existing `test_imported_by_is_implemented`) — the one intended test edit.
+- [ ] Write tests asserting `resolve_subclasses` returns the correct canonical **class** handles for a fixture base class with ≥2 project subclasses — including at least one **indirect** (grandchild) subclass and one subclass defined in a **non-importable file** (proving `scope="main"` breadth + file-based stub construction) — because the canonical class adjacency (direct + indirect) is the resolver's whole job.
+- [ ] Write a test asserting a class with **no** project subclasses yields `EdgeResult([])` (measured-none).
+- [ ] Write a test asserting a **non-class** handle (function / variable / module) yields `EdgeResult([])` — the measured-empty wrong-kind result — and explicitly **not** `None`, because that distinction (decision 1) is what keeps `expand.py` untouched.
+- [ ] Write a spy test asserting the `resolve_subclasses` path makes no `jedi.Script.get_references` call, mirroring the `callees`/`imported_by` spies — the load-bearing trust constraint.
+- [ ] Run the tests; confirm they fail (resolver missing / status still `not_yet_implemented`).
+- [ ] Commit.
+
+**Files:** `tests/unit/mcp/operations/test_edges.py`; fixtures as needed.
+**Constraints:** Each adjacency is a `(canonical class Handle, Jedi Name)` pair so `expand` can build a class stub (with signature) without re-resolving. The resolver returns `EdgeResult` for every kind — `EdgeResult(adjacents)` for a class, `EdgeResult([])` for everything else — and never `None`. Tests must pin the canonical handles (dotted FQNs), the direct+indirect closure, and the no-reverse-search constraint. Use **real fixture directories**, not symlinked temp dirs, for any Jedi-backed resolution (Jedi `goto`/`resolve_canonical` degrade on macOS `/var`→`/private/var` symlinks).
+**Acceptance:** Failing tests pin the new status bucket, the class adjacency (incl. indirect + non-importable-file subclass), the measured-empty no-subclass case, the non-class measured-empty case, and the no-`get_references` spy.
+**Risks:** `find_subclasses` returns a discriminated union (`{"ambiguous": False, "subclasses": [...]}` vs `{"ambiguous": True, "candidates": [...]}`). With an FQN input it never returns the ambiguous variant (as `_count_subclasses` asserts at `inspect.py:765-767`) — the resolver should carry the **same defensive `assert not result.get("ambiguous")`** for its canonical-handle input rather than handle a `candidates` branch, so a future regression surfaces loudly instead of silently yielding an empty list.
+
+### Task 1.2: Implement `resolve_subclasses` and move the edge
+
+- [ ] Move `subclasses` from `_NOT_YET_IMPLEMENTED_EDGES` to `_IMPLEMENTED_EDGES`, implement `resolve_subclasses` (class kind: `await find_subclasses(handle, scope="main", include_indirect=True, show_hierarchy=False)` → for each returned subclass, build a canonical class `Handle` from its FQN and a `build_stub`-compatible Jedi `Name` via forward enumeration over the subclass's own file → dedup by handle string, deterministic order → `EdgeResult`; non-class kind: `EdgeResult([])`), and register it in `EDGE_RESOLVERS` — reusing `find_subclasses`, not reimplementing it.
+- [ ] Update the `edges.py` module-docstring status table and the `EDGE_RESOLVERS` comment so `subclasses` is listed under implemented (keeping the file as the single source of truth, per its own docstring).
+- [ ] Run the Phase-1 tests and the full suite; confirm green.
+- [ ] Grep-verify no `get_references`/`find_references` on the `subclasses` path.
+- [ ] Commit.
+
+**Files:** `src/pyeye/mcp/operations/edges.py`.
+**Constraints:** Build each subclass's Jedi `Name` from its own file (the `find_subclasses` result carries `file`/`line`/`full_name`), mirroring `_class_members`' `get_names`-filtered-by-`full_name` approach — never by dotted-handle re-resolution (breadth + symlink robustness). Determinism: identical subclass set and order every run (sort or first-seen-dedup, not set iteration order). Fix `scope="main"`, `include_indirect=True` to match `_count_subclasses`. The resolver is `async` (it awaits `find_subclasses`); `expand` already awaits awaitable results.
+**Acceptance:** All Phase-1 tests pass; full suite green; `find_subclasses` and `inspect.edge_counts.subclasses` tests pass unmodified; grep confirms no reverse search on the path; `expand.py` unchanged.
+**Risks:** (1) Name production is the only genuinely new logic — if forward file-enumeration cannot produce a `Name` for some subclass (e.g. a transient cache miss), drop that adjacency rather than invent a partial stub, and prefer a path that keeps `len(stubs)` equal to the edge_count (see Phase 2 consistency test); investigate any divergence rather than masking it. (2) `find_subclasses` is `async` — the resolver is the second async member of the registry after `imported_by`; `expand`'s `isawaitable` bridge already handles this, but confirm via the Phase-2 tests.
+
+---
+
+## Phase 2: `expand` operation-layer behavior
+
+Confirm the edge composes correctly through `expand` — **with no `expand.py` change**.
+
+### Task 2.1: Tests for `expand` over `subclasses`
+
+- [ ] Write tests asserting `expand(class_handle, "subclasses")` returns the supported branch with canonical class stubs (built by the existing stub builder), and `expand(non_class_handle, "subclasses")` returns the **supported** branch with `stubs: []` (measured-none) — explicitly **not** the unsupported `not_yet_implemented` branch — because the measured-empty wrong-kind contract (decision 1) is the defining behavior of this slice.
+- [ ] Write a test asserting the supported `subclasses` result carries **no** `unresolved_call_sites` key (callees-only).
+- [ ] Write a **count/list consistency** test: `len(expand(C, "subclasses")["stubs"]) == inspect(C)…edge_counts.subclasses` for a fixture class — the progressive-disclosure contract that justifies the shared `scope="main"`/`include_indirect=True` call shape.
+- [ ] Run the tests; confirm they pass against the Phase-1 implementation (this phase should require **no `expand.py` edit** — if a test forces one, the `None` path regressed; stop).
+- [ ] Commit.
+
+**Files:** `tests/unit/mcp/operations/test_expand.py`.
+**Constraints:** The non-class case must land on the *supported* branch (`stubs: []`), never the unsupported branch — this is the observable proof that `subclasses` took the `members`/`callees` measured-empty route, not the `imported_by` `None` route. Do not assert a kind-specific unsupported detail (there is none for this edge).
+**Acceptance:** All `subclasses` `expand` tests pass; `members`/`callees`/`imported_by` `expand` behavior unchanged; `expand.py` unmodified; the count==len consistency holds.
+**Risks:** If a fixture class's `edge_counts.subclasses` and `len(stubs)` diverge, the resolver's enumeration or dedup differs from `find_subclasses`' result list — reconcile (likely a Name-production drop or a dedup-key mismatch) rather than relaxing the assertion.
+
+---
+
+## Phase 3: Integration + conformance
+
+Surface `subclasses` on the wire and lock its shape into conformance.
+
+### Task 3.1: Wire integration tests
+
+- [ ] Add integration tests exercising `subclasses` end-to-end through the already-registered MCP `expand` tool against a real fixture: a class call (supported, class stubs) and a non-class call (supported, `stubs: []`) — because the edge must survive the wire as a plain serialisable dict.
+- [ ] Run the integration tests and the full suite with coverage; confirm green at the threshold.
+- [ ] Commit.
+
+**Files:** `tests/integration/api_redesign/test_traversal_integration.py`.
+**Constraints:** No new tool registration — `expand` is already registered; `subclasses` is simply a new edge value. Assert plain-dict/serialisation safety as the existing wire tests do. Use a real fixture project (no symlinked temp dirs) so Jedi base-resolution inside `find_subclasses` is reliable.
+**Acceptance:** `subclasses` discoverable and callable via the wire for both branches; full suite green at coverage threshold.
+
+### Task 3.2: Conformance dogfood
+
+- [ ] Add conformance tests that run the real `subclasses` output (a class result with stubs and a non-class measured-empty result) through the response linter and confirm it passes with **no linter code change** — because the existing structural floors already accept any `edge` string and a stub-only supported result.
+- [ ] Run the conformance suite.
+- [ ] Commit.
+
+**Files:** `tests/conformance/test_linter_adversarial_expand.py`.
+**Constraints:** Validate only that `subclasses` `ExpandResult`s conform. `subclasses` is a class-only edge in `edge_counts`, so it is already measured there (not in the linter's unmeasured-edges set, unlike `imported_by`) — do **not** alter the linter's measured/unmeasured edge sets. If the linter unexpectedly needs a change, stop and reconsider — the premise is that it does not.
+**Acceptance:** Linter accepts both `subclasses` branches; conformance suite green; no linter code change.
+
+---
+
+## Verification gates (between phases)
+
+- [ ] Full test suite green at the coverage threshold (run with the random-order plugin disabled, `-p no:randomly`, for a deterministic read).
+- [ ] Pre-commit hooks pass (no bypass flags).
+- [ ] No `get_references`/`find_references` introduced on the `subclasses` path (grep-verified) — the load-bearing trust constraint.
+- [ ] `find_subclasses` legacy tests **and** existing `inspect.edge_counts.subclasses` tests pass **unmodified** (behavior-preserving reuse).
+- [ ] `expand.py` and `jedi_analyzer.py` are unchanged; the only production edit is `edges.py`.
+- [ ] The only intended test edit beyond new tests is the status-matrix bucket change for `subclasses`; `ExpandResult` and linter shapes are unchanged.
+
+## What this slice deliberately defers (issue #348 "Out")
+
+`superclasses`, `imports`, and `enclosing_scope` (the other `not_yet_implemented` edges — separate slices); any reference-backend work (`callers`/`references`, deferred on #333); restoring/altering symbol-level reverse edges. The `trace` primitive is parallelizable — it consumes the `EDGE_RESOLVERS` registry and auto-gains `subclasses`-follow once both land; this slice is the single writer to `edges.py` for `subclasses`.

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -7,22 +7,28 @@ This module is the **single source of truth** for which traversal edges
    machine-distinguishable statuses.  The status string IS the ``reason``
    string ``expand`` emits for unsupported edges.
 2. :data:`EDGE_RESOLVERS` / the resolver registry — maps *implemented* edge
-   names (``members``, ``callees``, ``imported_by``) to their resolver
-   callables.  ``members``/``callees`` are synchronous and always return an
-   :class:`EdgeResult`; ``imported_by`` is **async** (it awaits the reverse
-   import scan) and returns ``EdgeResult | None`` — ``None`` is the wrong-kind
-   signal (the handle is not a module).  An :class:`EdgeResult` carries the
-   adjacent canonical handles plus, for ``callees`` only, the count of
-   unresolved call sites.  ``expand`` awaits any awaitable resolver result.
+   names (``members``, ``callees``, ``imported_by``, ``subclasses``) to their
+   resolver callables.  ``members``/``callees`` are synchronous and always
+   return an :class:`EdgeResult`; ``imported_by`` and ``subclasses`` are
+   **async**.  ``imported_by`` returns ``EdgeResult | None`` — ``None`` is its
+   wrong-kind signal (the handle is not a module).  ``subclasses`` ALWAYS
+   returns an :class:`EdgeResult` (never ``None``): a non-class handle yields
+   ``EdgeResult([])`` because only a class CAN be subclassed, so ``[]`` for the
+   wrong kind is true by definition (the ``members``/``callees`` case), not the
+   absence-vs-zero lie that forces ``imported_by``'s ``None`` path.  An
+   :class:`EdgeResult` carries the adjacent canonical handles plus, for
+   ``callees`` only, the count of unresolved call sites.  ``expand`` awaits any
+   awaitable resolver result.
 
 Status model (spec §4.3)
 ------------------------
 ==============================  =========================================
 status                          edges
 ==============================  =========================================
-``"implemented"``               ``members``, ``callees``, ``imported_by``
-``"not_yet_implemented"``       ``superclasses``, ``subclasses``,
-                                ``imports``, ``enclosing_scope``
+``"implemented"``               ``members``, ``callees``, ``imported_by``,
+                                ``subclasses``
+``"not_yet_implemented"``       ``superclasses``, ``imports``,
+                                ``enclosing_scope``
 ``"deferred_reference_backend"``  ``callers``, ``references``, ``read_by``,
                                 ``written_by``, ``passed_by``,
                                 ``overrides``, ``overridden_by``,
@@ -117,10 +123,10 @@ STATUS_DEFERRED_REFERENCE_BACKEND = "deferred_reference_backend"
 STATUS_UNKNOWN_EDGE = "unknown_edge"
 
 #: Edges with a working (or Phase-3-bound) resolver.
-_IMPLEMENTED_EDGES = frozenset({"members", "callees", "imported_by"})
+_IMPLEMENTED_EDGES = frozenset({"members", "callees", "imported_by", "subclasses"})
 
 #: Edges recognised by the matrix but not yet built (no reference backend needed).
-_NOT_YET_IMPLEMENTED_EDGES = frozenset({"superclasses", "subclasses", "imports", "enclosing_scope"})
+_NOT_YET_IMPLEMENTED_EDGES = frozenset({"superclasses", "imports", "enclosing_scope"})
 
 #: Inbound / reference edges deferred until an indexed reference backend lands.
 _DEFERRED_REFERENCE_BACKEND_EDGES = frozenset(
@@ -607,14 +613,149 @@ async def resolve_imported_by(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeRes
 
 
 # ---------------------------------------------------------------------------
+# subclasses resolver (#348) — forward AST class-graph walk, async
+# ---------------------------------------------------------------------------
+
+
+def _subclass_name_from_file(
+    subclass_file: str, subclass_fqn: str, analyzer: JediAnalyzer
+) -> Any | None:
+    """Produce a Jedi ``Name`` for *subclass_fqn* by enumerating its OWN file.
+
+    Mirrors :func:`_class_members`' approach: enumerate the file's definitions
+    via Jedi ``get_names`` and return the one whose ``full_name`` matches the
+    subclass's AST-derived FQN.  This is deliberately NOT a dotted-handle
+    re-resolution — re-resolution drops subclasses defined in non-importable
+    files (a root-level ``script.py`` has no importable dotted path) and is
+    fragile on macOS symlinked temp dirs.  Building the ``Name`` from the file
+    the AST scan already located preserves that breadth and is path-independent.
+
+    Args:
+        subclass_file: Posix path to the file declaring the subclass (from the
+            ``find_subclasses`` result dict).
+        subclass_fqn: The subclass's AST-derived ``full_name`` (the canonical
+            handle string to match against Jedi's ``full_name``).
+        analyzer: Active analyzer (for the Jedi project used by ``get_script``).
+
+    Returns:
+        The matching Jedi ``Name``, or ``None`` if the file cannot be scanned or
+        no enumerated definition's ``full_name`` matches (the caller drops the
+        adjacency rather than inventing a partial stub).
+    """
+    try:
+        script = file_artifact_cache.get_script(Path(subclass_file), analyzer.project)
+        names = script.get_names(all_scopes=True, definitions=True, references=False)
+    except Exception:
+        return None
+
+    for name in names:
+        if (name.full_name or "") == subclass_fqn:
+            return name
+    return None
+
+
+async def resolve_subclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult:
+    """Return the project classes that subclass a class as canonical handles.
+
+    The outbound-but-reliably-static ``subclasses`` edge for a **class** handle.
+    Reuses :meth:`JediAnalyzer.find_subclasses` — an AST class-graph walk +
+    forward ``goto``/``resolve_canonical`` (NO ``get_references`` /
+    ``find_references``, the same load-bearing trust constraint as ``callees`` /
+    ``imported_by``).  The call shape (``scope="main"``, ``include_indirect=True``,
+    ``show_hierarchy=False``) is IDENTICAL to ``inspect._count_subclasses`` so
+    ``len(adjacents) == inspect(handle).edge_counts.subclasses``.  As a
+    single-hop edge it intentionally returns the full project subclass closure
+    (direct + indirect), a deliberate divergence from ``members``/``callees``
+    direct-only semantics justified by that count/list consistency.
+
+    Each adjacent's ``Name`` is built from the subclass's OWN FILE (via
+    :func:`_subclass_name_from_file`) — never by re-resolving the dotted handle —
+    so a subclass defined in a non-importable root-level script is preserved and
+    resolution stays path-independent (#335 macOS symlink robustness).
+
+    Kind gate (the slice's defining decision):
+
+    - **class** → measured: ``EdgeResult`` with the subclass handles (possibly
+      empty if the class has no project subclasses — a genuine measured "none").
+    - **non-class** (function / variable / module / …) → ``EdgeResult([])``,
+      NEVER ``None``.  Only a class CAN be subclassed, so ``[]`` for the wrong
+      kind is true by definition (exactly the ``members``/``callees`` case) —
+      NOT the absence-vs-zero lie that forces ``imported_by``'s ``None`` path.
+      Because this resolver never returns ``None``, ``expand`` needs no change.
+
+    Asynchronous: ``find_subclasses`` reads project files asynchronously, so
+    this resolver is ``async``.  ``expand`` awaits awaitable resolver results.
+
+    Args:
+        jedi_name: Resolved Jedi ``Name`` for the target.  Class-ness is derived
+            from its normalised kind; ``full_name`` is the dotted handle.
+        analyzer: Active analyzer (provides ``find_subclasses``).
+
+    Returns:
+        An :class:`EdgeResult` whose ``adjacents`` are the subclass
+        ``(canonical Handle, Jedi Name)`` pairs (kind class) for a class target,
+        or ``EdgeResult([])`` for any non-class target.  ``unresolved_call_sites``
+        is always ``None`` — that notion is callees-only.
+    """
+    if _normalise_kind(getattr(jedi_name, "type", None)) != "class":
+        return EdgeResult(adjacents=[])
+
+    handle = getattr(jedi_name, "full_name", None)
+    if not handle:
+        return EdgeResult(adjacents=[])
+
+    # Identical call shape to inspect._count_subclasses so len(stubs) == the
+    # measured edge_counts.subclasses (the progressive-disclosure contract).
+    result = await analyzer.find_subclasses(
+        handle,
+        scope="main",
+        include_indirect=True,
+        show_hierarchy=False,
+    )
+    # An FQN input never triggers the ambiguous variant (as _count_subclasses
+    # asserts).  Carry the same defensive assert so a future regression surfaces
+    # loudly instead of silently yielding an empty list.
+    assert not result.get(
+        "ambiguous", False
+    ), f"FQN input to find_subclasses returned ambiguous variant: {handle!r}"
+
+    adjacents: list[tuple[Handle, Any]] = []
+    seen: set[str] = set()
+    for subclass in result.get("subclasses", []):
+        fqn = subclass.get("full_name")
+        subclass_file = subclass.get("file")
+        if not fqn or not subclass_file:
+            continue
+        h = _try_handle(fqn)
+        if h is None:
+            continue
+        key = str(h)
+        if key in seen:
+            continue
+        # Build the Name from the subclass's FILE, not by re-resolving the
+        # handle — re-resolution drops non-package scripts (see helper docstring).
+        name = _subclass_name_from_file(subclass_file, fqn, analyzer)
+        if name is None:
+            # No Jedi Name for this subclass — drop the adjacency rather than
+            # invent a partial stub (keeps len(stubs) honest).
+            continue
+        seen.add(key)
+        adjacents.append((h, name))
+
+    return EdgeResult(adjacents=adjacents)
+
+
+# ---------------------------------------------------------------------------
 # Resolver registry
 # ---------------------------------------------------------------------------
 
 #: Maps *implemented* edge names → resolver callables.  ``members``/``callees``
-#: are synchronous and always return an :class:`EdgeResult`; ``imported_by`` is
-#: async and may return ``None`` (wrong-kind signal).  The value type therefore
-#: admits a sync-or-async resolver returning ``EdgeResult | None`` so ``expand``
-#: can stay edge-agnostic (awaiting awaitable results, treating ``None`` as
+#: are synchronous and always return an :class:`EdgeResult`; ``imported_by`` and
+#: ``subclasses`` are async.  ``imported_by`` may return ``None`` (its wrong-kind
+#: signal); ``subclasses`` always returns an :class:`EdgeResult` (non-class →
+#: ``EdgeResult([])``, never ``None``).  The value type therefore admits a
+#: sync-or-async resolver returning ``EdgeResult | None`` so ``expand`` can stay
+#: edge-agnostic (awaiting awaitable results, treating ``None`` as
 #: not-yet-implemented).
 EDGE_RESOLVERS: dict[
     str, Callable[[Any, JediAnalyzer], EdgeResult | None | Awaitable[EdgeResult | None]]
@@ -622,4 +763,5 @@ EDGE_RESOLVERS: dict[
     "members": resolve_members,
     "callees": resolve_callees,
     "imported_by": resolve_imported_by,
+    "subclasses": resolve_subclasses,
 }

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -742,6 +742,14 @@ async def resolve_subclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResu
         seen.add(key)
         adjacents.append((h, name))
 
+    # find_subclasses builds its result by iterating a Python set, so
+    # result["subclasses"] arrives in PYTHONHASHSEED-dependent order; the
+    # first-seen dedup above inherits that instability.  The edge contract
+    # requires deterministic order (identical subclass set AND order every run),
+    # so sort by the canonical handle string here — mirroring how
+    # resolve_imported_by relies on find_importers' already-sorted output.
+    adjacents.sort(key=lambda pair: str(pair[0]))
+
     return EdgeResult(adjacents=adjacents)
 
 

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -508,12 +508,20 @@ async def expand(
         with ``reason: "not_yet_implemented"`` (symbol-level ``imported_by`` is
         not yet implemented).  Ceiling: runtime-dynamic imports
         (``importlib``/``__import__`` with computed targets) are not detected.
+      - ``subclasses``  — class → the project classes that subclass it (class
+        Stubs), computed by an AST class-graph walk + forward ``goto`` (no
+        reverse symbol search).  Returns the full project subclass closure
+        (direct + indirect), so ``len(stubs) == inspect(handle).edge_counts``
+        ``.subclasses``.  ``stubs: []`` means the class has no project
+        subclasses (measured-none).  A non-class handle also returns the
+        supported branch with ``stubs: []`` — only a class CAN be subclassed,
+        so ``[]`` is true by definition, not an absence-vs-zero lie.
 
     Unsupported edges return the unsupported branch (never raise):
       - Inbound/reference edges (``callers``, ``references``,
         ``overrides``, …) require the Pyright reference backend (#333) and return
         ``unsupported: true, reason: "deferred_reference_backend"``.
-      - Other structural edges (``superclasses``, ``subclasses``, ``imports``,
+      - Other structural edges (``superclasses``, ``imports``,
         ``enclosing_scope``) are planned but not yet implemented in this slice;
         they return ``reason: "not_yet_implemented"``.
       - Unrecognised edge names return ``reason: "unknown_edge"``.

--- a/tests/conformance/test_linter_adversarial_expand.py
+++ b/tests/conformance/test_linter_adversarial_expand.py
@@ -39,6 +39,11 @@ from tests.conformance.response_linter import ConformanceViolation, lint_respons
 
 _FIXTURE = Path(__file__).parent.parent / "fixtures" / "resolve_project"
 
+#: Dedicated subclasses fixture (#348): ``pkg.base.Animal`` has a known project
+#: subclass closure {Mammal, Dog, Lizard}; ``pkg.base`` is a module (non-class →
+#: measured-empty supported result).
+_SUBCLASSES_FIXTURE = Path(__file__).parent.parent / "fixtures" / "subclasses_edge"
+
 # ---------------------------------------------------------------------------
 # Minimal valid objects (used as starting points; mutate via _clone)
 # ---------------------------------------------------------------------------
@@ -730,6 +735,54 @@ class TestRealExpandOutputConforms:
         # Unsupported branch — reason=not_yet_implemented.
         assert result.get("unsupported") is True
         assert result.get("reason") == "not_yet_implemented"
+        lint_response(result, "expand")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_real_subclasses_class_output_conforms(self) -> None:
+        """Real expand(Animal, subclasses) supported branch passes the linter.
+
+        ``subclasses`` is a class-only edge that IS measured in
+        ``inspect.edge_counts`` (unlike ``imported_by``).  Its supported result
+        carries ``source``/``edge``/``stubs`` with no ``unresolved_call_sites`` —
+        the existing E.* rules already accept any ``edge`` string and a stub-only
+        supported result, so NO linter change is needed.
+        """
+        from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+        from pyeye.mcp.operations.expand import expand
+
+        analyzer = JediAnalyzer(str(_SUBCLASSES_FIXTURE))
+        result = await expand("pkg.base.Animal", "subclasses", analyzer)
+
+        assert isinstance(result, dict), f"result must be a dict; got {type(result)!r}"
+        # Supported branch — non-empty stubs, no unsupported key.
+        assert "stubs" in result, f"expected supported branch with stubs; got {result!r}"
+        assert result["stubs"], "Animal has known project subclasses → non-empty stubs"
+        assert "unsupported" not in result
+        lint_response(result, "expand")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_real_subclasses_non_class_output_conforms(self) -> None:
+        """Real expand(pkg.base module, subclasses) measured-empty branch passes the linter.
+
+        A non-class handle yields the SUPPORTED measured-empty result
+        (``stubs: []``) — NOT the unsupported branch (decision 1, #348).  The
+        existing rule that accepts ``stubs=[]`` as a valid supported result
+        (``test_supported_members_empty_stubs_passes``) covers this with NO
+        linter change.
+        """
+        from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+        from pyeye.mcp.operations.expand import expand
+
+        analyzer = JediAnalyzer(str(_SUBCLASSES_FIXTURE))
+        result = await expand("pkg.base", "subclasses", analyzer)
+
+        assert isinstance(result, dict), f"result must be a dict; got {type(result)!r}"
+        # Supported measured-empty branch — stubs present and empty, no unsupported.
+        assert (
+            result.get("stubs") == []
+        ), f"expected measured-empty supported branch; got {result!r}"
+        assert "unsupported" not in result
+        assert "reason" not in result
         lint_response(result, "expand")  # must not raise
 
 

--- a/tests/fixtures/subclasses_edge/pkg/__init__.py
+++ b/tests/fixtures/subclasses_edge/pkg/__init__.py
@@ -1,0 +1,6 @@
+"""Package init for the subclasses-edge fixture (issue #348).
+
+Exposes nothing — the fixture's classes are addressed by their definition-site
+FQNs (``pkg.base.Animal`` etc.) so the ``subclasses`` expand resolver can be
+exercised against a known direct + indirect + non-importable-file topology.
+"""

--- a/tests/fixtures/subclasses_edge/pkg/base.py
+++ b/tests/fixtures/subclasses_edge/pkg/base.py
@@ -1,0 +1,25 @@
+"""Base class under test for the ``subclasses`` expand edge (issue #348).
+
+Canonical handle: ``pkg.base.Animal``.
+
+Topology exercised by the resolver tests:
+
+- ``pkg.middle.Mammal``      — DIRECT subclass (importable package module)
+- ``pkg.middle.Dog``         — INDIRECT (grandchild) via Mammal
+- ``script_animal.Lizard``   — DIRECT subclass defined in a NON-importable,
+                               script-style module at the project root
+
+``Loner`` is a sibling base with NO subclasses (measured-empty case).
+"""
+
+
+class Animal:
+    """Top of the inheritance chain under test."""
+
+    legs: int = 4
+
+
+class Loner:
+    """A class nobody subclasses — measured-empty subclasses case."""
+
+    pass

--- a/tests/fixtures/subclasses_edge/pkg/middle.py
+++ b/tests/fixtures/subclasses_edge/pkg/middle.py
@@ -1,0 +1,21 @@
+"""Direct and indirect subclasses of ``pkg.base.Animal`` (issue #348).
+
+- ``Mammal`` is a DIRECT subclass of ``Animal``.
+- ``Dog`` is an INDIRECT (grandchild) subclass of ``Animal`` via ``Mammal``.
+
+Both live in this importable package module.
+"""
+
+from pkg.base import Animal
+
+
+class Mammal(Animal):
+    """Direct subclass of Animal."""
+
+    warm_blooded: bool = True
+
+
+class Dog(Mammal):
+    """Indirect (grandchild) subclass of Animal via Mammal."""
+
+    breed: str = "mutt"

--- a/tests/fixtures/subclasses_edge/script_animal.py
+++ b/tests/fixtures/subclasses_edge/script_animal.py
@@ -1,0 +1,17 @@
+"""Non-importable, script-style subclass of ``pkg.base.Animal`` (issue #348).
+
+This module lives at the PROJECT ROOT, outside any package, so it has no
+importable dotted path — its class's path-derived handle is
+``script_animal.Lizard``.  ``scope="main"`` still discovers it, and the
+resolver must build its stub by enumerating THIS file (not by re-resolving the
+handle, which would drop a non-package script).  This proves the file-based
+Name-production breadth required by the plan.
+"""
+
+from pkg.base import Animal
+
+
+class Lizard(Animal):
+    """Direct subclass of Animal defined in a root-level script module."""
+
+    cold_blooded: bool = True

--- a/tests/integration/api_redesign/test_traversal_integration.py
+++ b/tests/integration/api_redesign/test_traversal_integration.py
@@ -28,6 +28,12 @@ import pytest
 
 _FIXTURE = Path(__file__).parent.parent.parent / "fixtures" / "resolve_project"
 
+#: Dedicated subclasses fixture project (#348): ``pkg.base.Animal`` has a known
+#: project subclass closure of {Mammal (direct), Dog (indirect grandchild),
+#: Lizard (non-importable root script)}; ``pkg.base.Loner`` is subclassed by
+#: nobody (measured-empty class case); ``pkg.base`` is a module (non-class).
+_SUBCLASSES_FIXTURE = Path(__file__).parent.parent.parent / "fixtures" / "subclasses_edge"
+
 # ---------------------------------------------------------------------------
 # Tool-registration assertions
 # ---------------------------------------------------------------------------
@@ -633,3 +639,271 @@ class TestExpandImportedByNonModuleEndToEnd:
         assert (
             type(result) is dict
         ), f"unsupported result must be exact dict; got {type(result)!r}"  # noqa: E721
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: subclasses edge — class (supported, stubs) and non-class
+# (supported, measured-empty stubs) over the wire
+# ---------------------------------------------------------------------------
+
+
+class TestExpandSubclassesClassEndToEnd:
+    """End-to-end tests for the ``subclasses`` edge on a CLASS handle over the wire.
+
+    ``pkg.base.Animal`` has a known project subclass closure — the result must be
+    the supported branch with non-empty class stubs (direct + indirect, including
+    the non-importable root script subclass).  No ``unresolved_call_sites``
+    (``subclasses`` is a forward class-graph walk, not callees).
+    """
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_returns_supported_branch(self) -> None:
+        """expand(Animal, 'subclasses') returns the supported branch (no 'unsupported')."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
+        assert "unsupported" not in result, (
+            "supported result must not carry 'unsupported'; " f"got result={result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_has_required_fields(self) -> None:
+        """expand(Animal, 'subclasses') returns source/edge/stubs."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert "source" in result, f"'source' missing from result: {result!r}"
+        assert "edge" in result, f"'edge' missing from result: {result!r}"
+        assert "stubs" in result, f"'stubs' missing from result: {result!r}"
+        assert result["edge"] == "subclasses"
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_stubs_non_empty(self) -> None:
+        """Animal has known project subclasses — stubs must be a non-empty list."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        stubs = result["stubs"]
+        assert isinstance(stubs, list), f"stubs must be a list; got {type(stubs)!r}"
+        assert len(stubs) > 0, "Animal has known project subclasses — stubs must be non-empty"
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_full_closure_present(self) -> None:
+        """The supported result carries the full direct+indirect closure over the wire.
+
+        The fixture's known closure is exactly {Mammal, Dog, Lizard} — including
+        ``script_animal.Lizard`` defined in a non-importable root script, proving
+        the file-based stub construction survives the wire.
+        """
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        handles = {stub["handle"] for stub in result["stubs"]}
+        assert handles == {
+            "pkg.middle.Mammal",
+            "pkg.middle.Dog",
+            "script_animal.Lizard",
+        }, f"expected the full Animal subclass closure; got {sorted(handles)!r}"
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_stubs_have_required_fields(self) -> None:
+        """Each subclass stub has handle/kind/scope/line_start/line_end."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        for i, stub in enumerate(result["stubs"]):
+            assert isinstance(stub, dict), f"stub[{i}] must be a plain dict; got {type(stub)!r}"
+            for field in ("handle", "kind", "scope", "line_start", "line_end"):
+                assert field in stub, f"stub[{i}] missing required field '{field}'; stub={stub!r}"
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_stubs_are_class_kind(self) -> None:
+        """Each subclass stub must have kind == 'class' (subclasses are always classes)."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        for i, stub in enumerate(result["stubs"]):
+            assert stub["kind"] == "class", (
+                f"stub[{i}] must have kind='class'; "
+                f"got kind={stub.get('kind')!r}; stub={stub!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_no_unresolved_call_sites(self) -> None:
+        """subclasses must NOT include 'unresolved_call_sites' (callees-only field)."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert "unresolved_call_sites" not in result, (
+            "'unresolved_call_sites' must be absent for subclasses edge; "
+            f"got result keys: {list(result.keys())!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_result_is_json_serialisable(self) -> None:
+        """The subclasses class result round-trips through json.dumps without error."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        # Must not raise — ensures no custom types leak across the wire
+        serialised = json.dumps(result)
+        roundtripped = json.loads(serialised)
+        assert isinstance(roundtripped, dict)
+        assert isinstance(roundtripped["stubs"], list)
+
+    @pytest.mark.asyncio
+    async def test_subclasses_class_result_is_plain_dict_with_plain_stubs(self) -> None:
+        """All nested values in the supported subclasses result are plain Python primitives."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Animal",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert (
+            type(result) is dict
+        ), f"result must be exact dict (not subclass); got {type(result)!r}"  # noqa: E721
+        for i, stub in enumerate(result["stubs"]):
+            assert (
+                type(stub) is dict
+            ), f"stub[{i}] must be exact dict; got {type(stub)!r}"  # noqa: E721
+
+
+class TestExpandSubclassesNonClassEndToEnd:
+    """End-to-end tests for the ``subclasses`` edge on a NON-CLASS handle over the wire.
+
+    ``pkg.base`` is a module — only a class CAN be subclassed, so ``[]`` for a
+    non-class is true BY DEFINITION.  Unlike ``imported_by`` (whose wrong-kind
+    result is the unsupported ``None`` branch), ``subclasses`` takes the
+    ``members``/``callees`` measured-empty route: the SUPPORTED branch with
+    ``stubs: []``.  This is the defining behavior of the slice (#348 decision 1).
+    """
+
+    @pytest.mark.asyncio
+    async def test_subclasses_non_class_returns_supported_branch(self) -> None:
+        """expand(pkg.base module, 'subclasses') returns the SUPPORTED branch."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
+        assert "unsupported" not in result, (
+            "non-class subclasses must be the SUPPORTED measured-empty branch, "
+            f"not unsupported; got result={result!r}"
+        )
+        assert "reason" not in result, (
+            "non-class subclasses must NOT carry a 'reason' (supported branch); "
+            f"got result={result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subclasses_non_class_has_empty_stubs(self) -> None:
+        """The non-class result is measured-empty: stubs present and empty."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert "stubs" in result, f"'stubs' missing from supported result: {result!r}"
+        assert result["stubs"] == [], (
+            "non-class subclasses must be measured-empty ('stubs': []); "
+            f"got stubs={result.get('stubs')!r}"
+        )
+        assert result["edge"] == "subclasses"
+
+    @pytest.mark.asyncio
+    async def test_subclasses_non_class_no_unresolved_call_sites(self) -> None:
+        """The non-class subclasses result must NOT include 'unresolved_call_sites'."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert "unresolved_call_sites" not in result, (
+            "'unresolved_call_sites' must be absent for subclasses edge; "
+            f"got result keys: {list(result.keys())!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subclasses_non_class_result_is_json_serialisable(self) -> None:
+        """The non-class measured-empty result round-trips through json.dumps."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        serialised = json.dumps(result)
+        roundtripped = json.loads(serialised)
+        assert isinstance(roundtripped, dict)
+        assert roundtripped["stubs"] == []
+
+    @pytest.mark.asyncio
+    async def test_subclasses_non_class_result_is_plain_dict(self) -> None:
+        """The non-class measured-empty result is an exact plain dict."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert (
+            type(result) is dict
+        ), f"result must be exact dict (not subclass); got {type(result)!r}"  # noqa: E721

--- a/tests/integration/api_redesign/test_traversal_integration.py
+++ b/tests/integration/api_redesign/test_traversal_integration.py
@@ -907,3 +907,54 @@ class TestExpandSubclassesNonClassEndToEnd:
         assert (
             type(result) is dict
         ), f"result must be exact dict (not subclass); got {type(result)!r}"  # noqa: E721
+
+
+class TestExpandSubclassesEmptyClassEndToEnd:
+    """End-to-end test for the ``subclasses`` edge on a CLASS with NO subclasses.
+
+    ``pkg.base.Loner`` is a class that nobody subclasses.  This is a DISTINCT
+    branch from the non-class case (``TestExpandSubclassesNonClassEndToEnd``):
+    the kind gate matches (it IS a class), the resolver runs ``find_subclasses``
+    and genuinely MEASURES zero subclasses — so the empty ``[]`` is produced by a
+    different code path than the wrong-kind short-circuit.  Both surface as the
+    same SUPPORTED measured-empty shape, and this pins the class-zero path over
+    the wire (the fixture docstring advertises ``Loner`` for exactly this case).
+    """
+
+    @pytest.mark.asyncio
+    async def test_subclasses_empty_class_returns_supported_measured_empty(self) -> None:
+        """expand(pkg.base.Loner, 'subclasses') is the SUPPORTED branch with stubs: []."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Loner",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
+        assert "unsupported" not in result, (
+            "a class with no subclasses must be the SUPPORTED measured-empty branch, "
+            f"not unsupported; got result={result!r}"
+        )
+        assert "reason" not in result
+        assert result["edge"] == "subclasses"
+        assert result["stubs"] == [], (
+            "a class measured to have no subclasses must yield 'stubs': []; "
+            f"got stubs={result.get('stubs')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subclasses_empty_class_result_is_json_serialisable(self) -> None:
+        """The empty-class measured-empty result round-trips through json.dumps."""
+        from pyeye.mcp.server import expand
+
+        result = await expand(
+            handle="pkg.base.Loner",
+            edge="subclasses",
+            project_path=str(_SUBCLASSES_FIXTURE),
+        )
+
+        roundtripped = json.loads(json.dumps(result))
+        assert isinstance(roundtripped, dict)
+        assert roundtripped["stubs"] == []

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -54,6 +54,7 @@ from pyeye.mcp.operations.edges import (
     resolve_callees,
     resolve_imported_by,
     resolve_members,
+    resolve_subclasses,
 )
 from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
 
@@ -77,6 +78,16 @@ _SCRIPT_IMPORTER_HANDLE = "script_importer"
 _DIRECT_IMPORTER_HANDLE = "mypackage._core.direct_importer"
 _REL_IMPORTER_HANDLE = "mypackage._core.rel_importer"
 _USAGE_IMPORTER_HANDLE = "mypackage.usage"
+
+# subclasses fixtures (issue #348): a dedicated fixture project with a known
+# direct + indirect + non-importable-file topology. ``Animal`` is the base under
+# test; ``Loner`` is a sibling base nobody subclasses (measured-empty case).
+_SUBCLASSES_FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "subclasses_edge"
+_ANIMAL_HANDLE = "pkg.base.Animal"
+_LONER_HANDLE = "pkg.base.Loner"
+_MAMMAL_HANDLE = "pkg.middle.Mammal"  # direct subclass (importable module)
+_DOG_HANDLE = "pkg.middle.Dog"  # indirect (grandchild) subclass
+_LIZARD_HANDLE = "script_animal.Lizard"  # direct subclass in a non-importable script
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +140,7 @@ class TestEdgeStatusModel:
 
     @pytest.mark.parametrize(
         "edge",
-        ["superclasses", "subclasses", "imports", "enclosing_scope"],
+        ["superclasses", "imports", "enclosing_scope"],
     )
     def test_not_yet_implemented_edges(self, edge: str) -> None:
         assert edge_status(edge) == "not_yet_implemented"
@@ -139,6 +150,13 @@ class TestEdgeStatusModel:
         # Phase 3: its resolver (resolve_imported_by) builds on the pure-AST
         # find_importers scan — no indexed reference backend needed.
         assert edge_status("imported_by") == "implemented"
+
+    def test_subclasses_is_implemented(self) -> None:
+        # subclasses moves from not_yet_implemented to implemented (#348): its
+        # resolver (resolve_subclasses) reuses the forward-only AST class-graph
+        # walk in find_subclasses — no reverse symbol search, so it belongs with
+        # members/callees/imported_by.
+        assert edge_status("subclasses") == "implemented"
 
     @pytest.mark.parametrize(
         "edge",
@@ -634,4 +652,182 @@ class TestResolveImportedByNeverReverseSearch:
             result = await _imported_by_for(_MODULE_HANDLE, analyzer)
         assert result is not None
         assert _SCRIPT_IMPORTER_HANDLE in {str(h) for h in result.handles}
+        spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Task 1.1/1.2 — subclasses resolver (#348): forward AST class-graph walk
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def subclasses_analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at the dedicated subclasses_edge fixture."""
+    return JediAnalyzer(str(_SUBCLASSES_FIXTURE))
+
+
+async def _subclasses_for(handle: str, analyzer: JediAnalyzer) -> EdgeResult:
+    """Resolve *handle* to a Jedi name and await its ``subclasses`` result.
+
+    Unlike ``imported_by``, ``subclasses`` NEVER returns ``None`` — a non-class
+    handle yields a measured-empty ``EdgeResult([])`` (only a class CAN be
+    subclassed, so ``[]`` for the wrong kind is true by definition, not the
+    absence-vs-zero lie that forced imported_by's None path).
+    """
+    jedi_name = _find_jedi_name_for_handle(handle, analyzer)
+    assert jedi_name is not None, f"Could not find Jedi name for handle {handle!r}"
+    return await resolve_subclasses(jedi_name, analyzer)
+
+
+class TestResolveSubclassesClass:
+    """``subclasses`` = the project classes that subclass a base, as canonical handles.
+
+    The resolver reuses ``find_subclasses(scope="main", include_indirect=True)``,
+    so the result is the full project subclass closure (direct + indirect). The
+    dedicated fixture pins a known topology:
+
+    - ``pkg.middle.Mammal``     — DIRECT subclass (importable module)
+    - ``pkg.middle.Dog``        — INDIRECT (grandchild) via Mammal
+    - ``script_animal.Lizard``  — DIRECT subclass in a NON-importable root script
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_edgeresult(self, subclasses_analyzer: JediAnalyzer) -> None:
+        result = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert all(isinstance(h, Handle) for h in result.handles)
+
+    @pytest.mark.asyncio
+    async def test_direct_subclass_present(self, subclasses_analyzer: JediAnalyzer) -> None:
+        handles = {
+            str(h) for h in (await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)).handles
+        }
+        assert _MAMMAL_HANDLE in handles, f"direct subclass Mammal missing; got {handles}"
+
+    @pytest.mark.asyncio
+    async def test_indirect_grandchild_subclass_present(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        # Dog(Mammal) is a grandchild of Animal — include_indirect=True must
+        # surface it (the single-hop edge intentionally returns the full closure
+        # so len(stubs) == inspect.edge_counts.subclasses).
+        handles = {
+            str(h) for h in (await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)).handles
+        }
+        assert _DOG_HANDLE in handles, f"indirect subclass Dog missing; got {handles}"
+
+    @pytest.mark.asyncio
+    async def test_non_importable_file_subclass_present(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        # Lizard lives in script_animal.py at the project root (no importable
+        # dotted path). scope="main" finds it, and file-based Name production
+        # (not handle re-resolution) is what keeps it in the result.
+        handles = {
+            str(h) for h in (await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)).handles
+        }
+        assert (
+            _LIZARD_HANDLE in handles
+        ), f"non-importable-file subclass Lizard missing; got {handles}"
+
+    @pytest.mark.asyncio
+    async def test_exact_subclass_handle_set(self, subclasses_analyzer: JediAnalyzer) -> None:
+        # The full project subclass closure of Animal is exactly these three.
+        handles = {
+            str(h) for h in (await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)).handles
+        }
+        assert handles == {_MAMMAL_HANDLE, _DOG_HANDLE, _LIZARD_HANDLE}, f"got {handles}"
+
+    @pytest.mark.asyncio
+    async def test_adjacents_are_handle_name_pairs_building_class_stubs(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        # Each adjacent is a (Handle, Jedi Name) pair whose Name is a real class
+        # name built from the subclass's OWN file, so expand can build a class
+        # stub without re-resolving. The Name's full_name matches the handle.
+        result = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
+        assert result.adjacents, "Animal should have subclasses"
+        for handle, name in result.adjacents:
+            assert isinstance(handle, Handle)
+            assert name.type == "class"
+            assert name.full_name == str(handle)
+
+    @pytest.mark.asyncio
+    async def test_unresolved_call_sites_is_none(self, subclasses_analyzer: JediAnalyzer) -> None:
+        # The unresolved-call-site notion is callees-only; subclasses never reports it.
+        result = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
+        assert result.unresolved_call_sites is None
+
+    @pytest.mark.asyncio
+    async def test_deterministic_across_runs(self, subclasses_analyzer: JediAnalyzer) -> None:
+        first = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
+        second = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
+        assert [str(h) for h in first.handles] == [str(h) for h in second.handles]
+
+
+class TestResolveSubclassesMeasuredEmpty:
+    """A class with NO project subclasses → ``EdgeResult([])`` (measured none)."""
+
+    @pytest.mark.asyncio
+    async def test_class_with_no_subclasses_is_measured_empty(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        result = await _subclasses_for(_LONER_HANDLE, subclasses_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert result.handles == [], f"Loner is subclassed by nobody; got {result.handles}"
+
+
+class TestResolveSubclassesNonClass:
+    """A non-class handle → measured-empty ``EdgeResult([])`` — NEVER ``None``.
+
+    This is the defining decision of the slice: only a class CAN be subclassed,
+    so ``[]`` for a function/variable/module is true BY DEFINITION (the
+    members/callees case), NOT the absence-vs-zero lie that forced imported_by's
+    ``None`` path. Returning ``EdgeResult([])`` (not ``None``) is what keeps
+    ``expand.py`` untouched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_function_handle_is_measured_empty(self, analyzer: JediAnalyzer) -> None:
+        result = await _subclasses_for(_MAKE_WIDGET_HANDLE, analyzer)
+        assert result is not None, "non-class must NOT be wrong-kind None"
+        assert isinstance(result, EdgeResult)
+        assert result.handles == []
+
+    @pytest.mark.asyncio
+    async def test_variable_handle_is_measured_empty(self, analyzer: JediAnalyzer) -> None:
+        result = await _subclasses_for(f"{_MODULE_HANDLE}.DEFAULT_NAME", analyzer)
+        assert result is not None
+        assert result.handles == []
+
+    @pytest.mark.asyncio
+    async def test_module_handle_is_measured_empty(self, analyzer: JediAnalyzer) -> None:
+        result = await _subclasses_for(_MODULE_HANDLE, analyzer)
+        assert result is not None
+        assert result.handles == []
+
+    @pytest.mark.asyncio
+    async def test_non_class_is_not_none(self, analyzer: JediAnalyzer) -> None:
+        # The load-bearing distinction: subclasses never uses the None wrong-kind
+        # signal, so expand.py's hardcoded module-only None branch stays correct.
+        result = await _subclasses_for(_MAKE_WIDGET_HANDLE, analyzer)
+        assert result is not None
+        assert result == EdgeResult(adjacents=[])
+
+
+class TestResolveSubclassesNeverReverseSearch:
+    """subclasses NEVER calls Jedi reverse search (it is forward AST + goto only).
+
+    Mirrors the callees/imported_by spies: patch ``get_references`` to explode if
+    touched, await the resolver over the fixture, then assert it completed (real
+    subclasses present) AND the spy was never called.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_references_not_called(self, subclasses_analyzer: JediAnalyzer) -> None:
+        assert hasattr(jedi.Script, "get_references")
+        spy = Mock(side_effect=AssertionError("get_references called on subclasses path"))
+        with patch.object(jedi.Script, "get_references", spy):
+            result = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
+        assert _MAMMAL_HANDLE in {str(h) for h in result.handles}
         spy.assert_not_called()

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -3,13 +3,11 @@
 The edge registry is the single source of truth for which edges ``expand``
 supports.  Every edge name MUST classify into exactly one status:
 
-- ``"implemented"`` — ``members``, ``callees``
-- ``"not_yet_implemented"`` — ``superclasses``, ``subclasses``, ``imports``,
-  ``enclosing_scope``
+- ``"implemented"`` — ``members``, ``callees``, ``imported_by``, ``subclasses``
+- ``"not_yet_implemented"`` — ``superclasses``, ``imports``, ``enclosing_scope``
 - ``"deferred_reference_backend"`` — the inbound / reference edges
   (``callers``, ``references``, ``read_by``, ``written_by``, ``passed_by``,
-  ``imported_by``, ``overrides``, ``overridden_by``, ``decorated_by``,
-  ``decorates``)
+  ``overrides``, ``overridden_by``, ``decorated_by``, ``decorates``)
 - ``"unknown_edge"`` — any unrecognised name
 
 The status string values ARE the ``reason`` strings ``expand`` emits, so the
@@ -760,9 +758,18 @@ class TestResolveSubclassesClass:
 
     @pytest.mark.asyncio
     async def test_deterministic_across_runs(self, subclasses_analyzer: JediAnalyzer) -> None:
+        # find_subclasses iterates a Python set, so its order is
+        # PYTHONHASHSEED-dependent. The resolver sorts adjacents by canonical
+        # handle string, so the ORDERED list must equal the sorted FQNs of the
+        # fixture's subclasses — pin that exact order (a same-process re-run
+        # comparison would pass even with the bug, since set order is fixed
+        # within a process). Run under multiple PYTHONHASHSEED values to prove
+        # cross-process stability.
+        expected_order = sorted([_MAMMAL_HANDLE, _DOG_HANDLE, _LIZARD_HANDLE])
         first = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
         second = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
-        assert [str(h) for h in first.handles] == [str(h) for h in second.handles]
+        assert [str(h) for h in first.handles] == expected_order
+        assert [str(h) for h in second.handles] == expected_order
 
 
 class TestResolveSubclassesMeasuredEmpty:

--- a/tests/unit/mcp/operations/test_expand.py
+++ b/tests/unit/mcp/operations/test_expand.py
@@ -51,6 +51,8 @@ _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_pr
 _WIDGET_HANDLE = "mypackage._core.widgets.Widget"
 _MAKE_WIDGET_HANDLE = "mypackage._core.widgets.make_widget"
 _ORCHESTRATE_HANDLE = "mypackage._core.callees_fixture.orchestrate"
+_MODULE_HANDLE = "mypackage._core.widgets"
+_DEFAULT_NAME_HANDLE = "mypackage._core.widgets.DEFAULT_NAME"
 
 #: imported_by fixtures (Phase 4): ``widgets`` is a module imported by several
 #: other modules (supported, non-empty); ``module_forms`` is a leaf module that
@@ -58,6 +60,17 @@ _ORCHESTRATE_HANDLE = "mypackage._core.callees_fixture.orchestrate"
 #: non-module handle for which ``imported_by`` does not apply (unsupported).
 _MODULE_WITH_IMPORTERS_HANDLE = "mypackage._core.widgets"
 _MODULE_NO_IMPORTERS_HANDLE = "mypackage._core.module_forms"
+
+#: subclasses fixtures (#348, Phase 2): a dedicated fixture project with a known
+#: direct + indirect + non-importable-file topology. ``Animal`` is the base whose
+#: full project subclass closure is exactly {Mammal, Dog, Lizard}; ``Loner`` is a
+#: sibling base nobody subclasses (measured-empty class case).
+_SUBCLASSES_FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "subclasses_edge"
+_ANIMAL_HANDLE = "pkg.base.Animal"
+_LONER_HANDLE = "pkg.base.Loner"
+_MAMMAL_HANDLE = "pkg.middle.Mammal"  # direct subclass (importable module)
+_DOG_HANDLE = "pkg.middle.Dog"  # indirect (grandchild) subclass
+_LIZARD_HANDLE = "script_animal.Lizard"  # direct subclass in a non-importable script
 
 #: The Phase-1 Stub keys that are ALWAYS present (spec §4.1; ``signature`` is
 #: callable-only and therefore not asserted as universally present).
@@ -73,6 +86,12 @@ _STUB_REQUIRED_KEYS = {"handle", "kind", "scope", "line_start", "line_end"}
 def analyzer() -> JediAnalyzer:
     """JediAnalyzer pointed at the resolve_project fixture."""
     return JediAnalyzer(str(_FIXTURE))
+
+
+@pytest.fixture
+def subclasses_analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at the dedicated subclasses_edge fixture (#348)."""
+    return JediAnalyzer(str(_SUBCLASSES_FIXTURE))
 
 
 def _assert_is_stub(stub: dict) -> None:
@@ -408,3 +427,174 @@ class TestExpandImportedByModuleNoImportersSupported:
         # And they are genuinely different shapes (stubs vs reason).
         assert "stubs" in empty_module and "stubs" not in non_module
         assert "reason" not in empty_module and "reason" in non_module
+
+
+# ---------------------------------------------------------------------------
+# Task 2.1 — subclasses wiring (#348): wrong-kind → measured-empty, never None
+# ---------------------------------------------------------------------------
+
+
+class TestExpandSubclassesSupported:
+    """``expand`` over ``subclasses`` for a CLASS returns the supported shape.
+
+    The resolver (``resolve_subclasses``) is async and returns an ``EdgeResult``
+    of canonical CLASS handles for the full project subclass closure (direct +
+    indirect, including subclasses defined in non-importable root scripts).
+    ``expand`` awaits it and builds a class stub per subclass.  This is a
+    callees-free supported branch — ``unresolved_call_sites`` is ABSENT (the
+    resolver carries it as ``None`` for this edge).
+    """
+
+    @pytest.mark.asyncio
+    async def test_class_subclasses_supported_shape(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
+        # Supported branch — never unsupported.
+        assert "unsupported" not in result
+        assert "reason" not in result
+        assert result["edge"] == "subclasses"
+        assert isinstance(result["source"], str)
+        assert isinstance(result["stubs"], list)
+        assert "cursor" not in result
+
+    @pytest.mark.asyncio
+    async def test_class_subclasses_stubs_are_class_stubs(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
+        assert result["stubs"], "Animal has known project subclasses → non-empty stubs"
+        for stub in result["stubs"]:
+            _assert_is_stub(stub)
+            # Each adjacent is itself a class.
+            assert stub["kind"] == "class", f"subclass stub should be a class: {stub}"
+
+    @pytest.mark.asyncio
+    async def test_class_subclasses_full_closure_present(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        # include_indirect=True → the full project subclass closure: the direct
+        # subclass (Mammal), the indirect grandchild (Dog), AND the subclass in a
+        # non-importable root script (Lizard, preserved by file-based stub build).
+        result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
+        handles = {stub["handle"] for stub in result["stubs"]}
+        assert handles == {_MAMMAL_HANDLE, _DOG_HANDLE, _LIZARD_HANDLE}, f"got {handles}"
+
+    @pytest.mark.asyncio
+    async def test_class_subclasses_omits_unresolved_call_sites(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        # unresolved_call_sites is callees-specific — it must be ABSENT for the
+        # subclasses edge (the resolver carries it as None).
+        result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
+        assert "unresolved_call_sites" not in result
+
+
+class TestExpandSubclassesClassNoSubclassesSupported:
+    """A CLASS with no project subclasses → supported ``stubs: []`` (measured none).
+
+    ``Loner`` IS a class (the edge applies), so the resolver returns a MEASURED
+    empty ``EdgeResult([])`` and ``expand`` returns the SUPPORTED branch with
+    ``stubs: []`` — NOT the unsupported branch.
+    """
+
+    @pytest.mark.asyncio
+    async def test_class_no_subclasses_is_supported_empty(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        result = await expand(_LONER_HANDLE, "subclasses", subclasses_analyzer)
+        assert result["stubs"] == [], "Loner is subclassed by nobody → measured []"
+        assert "unsupported" not in result
+        assert "reason" not in result
+        assert result["edge"] == "subclasses"
+        assert "unresolved_call_sites" not in result
+
+
+class TestExpandSubclassesNonClassMeasuredEmpty:
+    """A NON-CLASS handle → SUPPORTED ``stubs: []`` — NOT the unsupported branch.
+
+    This is the DEFINING behavior of the slice (decision 1): only a class CAN be
+    subclassed, so ``[]`` for a function/variable/module is true BY DEFINITION —
+    exactly the ``members``/``callees`` measured-empty route, NOT the
+    ``imported_by`` ``None``/``not_yet_implemented`` route.  ``resolve_subclasses``
+    returns ``EdgeResult([])`` (never ``None``) for the wrong kind, so ``expand``
+    lands on the supported branch and needs NO change.  The explicit "no
+    ``unsupported``, no ``reason``" assertions are what prove the resolver did not
+    regress to the ``None`` path.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "handle",
+        [_MAKE_WIDGET_HANDLE, _DEFAULT_NAME_HANDLE, _MODULE_HANDLE],
+        ids=["function", "variable", "module"],
+    )
+    async def test_non_class_is_supported_measured_empty(
+        self, analyzer: JediAnalyzer, handle: str
+    ) -> None:
+        result = await expand(handle, "subclasses", analyzer)
+        # Measured-empty: stubs present and empty.
+        assert result["stubs"] == [], f"non-class {handle!r} → measured [] subclasses"
+        assert result["edge"] == "subclasses"
+        # The crux: this is the SUPPORTED branch, explicitly NOT the unsupported
+        # branch (which is what the imported_by None path would have produced).
+        assert (
+            "unsupported" not in result
+        ), f"non-class subclasses must NOT be unsupported: {result}"
+        assert "reason" not in result, f"non-class subclasses must NOT carry a reason: {result}"
+        # subclasses never reports unresolved_call_sites (callees-only).
+        assert "unresolved_call_sites" not in result
+
+    @pytest.mark.asyncio
+    async def test_non_class_distinct_from_imported_by_non_module(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        # Contrast with imported_by: a non-module imported_by IS unsupported
+        # (None path), but a non-class subclasses is SUPPORTED measured-empty.
+        # This pins that the two wrong-kind designs are genuinely different.
+        subclasses_wrong_kind = await expand(_MAKE_WIDGET_HANDLE, "subclasses", analyzer)
+        imported_by_wrong_kind = await expand(_WIDGET_HANDLE, "imported_by", analyzer)
+        assert "unsupported" not in subclasses_wrong_kind
+        assert "stubs" in subclasses_wrong_kind
+        assert imported_by_wrong_kind["unsupported"] is True
+        assert "stubs" not in imported_by_wrong_kind
+
+
+class TestExpandSubclassesCountListConsistency:
+    """Progressive-disclosure contract: len(stubs) == inspect.edge_counts.subclasses.
+
+    The resolver and ``inspect._count_subclasses`` share the EXACT call shape
+    (``scope="main"``, ``include_indirect=True``, ``show_hierarchy=False``), so
+    the number of subclass stubs ``expand`` produces MUST equal the count
+    ``inspect`` reports for the same class.  This is the contract that justifies
+    the shared call shape; if it diverges, the resolver's enumeration or dedup
+    has drifted from ``find_subclasses``' result list (reconcile, don't relax).
+    """
+
+    @pytest.mark.asyncio
+    async def test_expand_len_equals_inspect_count(self, subclasses_analyzer: JediAnalyzer) -> None:
+        from pyeye.mcp.operations.inspect import inspect
+
+        expand_result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
+        inspect_result = await inspect(_ANIMAL_HANDLE, subclasses_analyzer)
+
+        stub_count = len(expand_result["stubs"])
+        edge_count = inspect_result["edge_counts"]["subclasses"]
+        assert stub_count == edge_count, (
+            f"len(expand subclasses stubs)={stub_count} must equal "
+            f"inspect edge_counts['subclasses']={edge_count} (shared call shape)"
+        )
+        # The fixture's known closure is exactly 3 (Mammal, Dog, Lizard); pin it
+        # so a fixture-topology change can't silently make this a 0==0 tautology.
+        assert stub_count == 3, f"fixture Animal closure should be 3 subclasses; got {stub_count}"
+
+    @pytest.mark.asyncio
+    async def test_no_subclasses_consistency_holds_at_zero(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        # The contract also holds for the measured-empty class case: 0 == 0.
+        from pyeye.mcp.operations.inspect import inspect
+
+        expand_result = await expand(_LONER_HANDLE, "subclasses", subclasses_analyzer)
+        inspect_result = await inspect(_LONER_HANDLE, subclasses_analyzer)
+        assert len(expand_result["stubs"]) == inspect_result["edge_counts"]["subclasses"] == 0

--- a/tests/unit/mcp/operations/test_expand.py
+++ b/tests/unit/mcp/operations/test_expand.py
@@ -45,6 +45,7 @@ import pytest
 
 from pyeye.analyzers.jedi_analyzer import JediAnalyzer
 from pyeye.mcp.operations.expand import expand
+from pyeye.mcp.operations.inspect import inspect
 
 _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
 
@@ -573,8 +574,6 @@ class TestExpandSubclassesCountListConsistency:
 
     @pytest.mark.asyncio
     async def test_expand_len_equals_inspect_count(self, subclasses_analyzer: JediAnalyzer) -> None:
-        from pyeye.mcp.operations.inspect import inspect
-
         expand_result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
         inspect_result = await inspect(_ANIMAL_HANDLE, subclasses_analyzer)
 
@@ -593,8 +592,6 @@ class TestExpandSubclassesCountListConsistency:
         self, subclasses_analyzer: JediAnalyzer
     ) -> None:
         # The contract also holds for the measured-empty class case: 0 == 0.
-        from pyeye.mcp.operations.inspect import inspect
-
         expand_result = await expand(_LONER_HANDLE, "subclasses", subclasses_analyzer)
         inspect_result = await inspect(_LONER_HANDLE, subclasses_analyzer)
         assert len(expand_result["stubs"]) == inspect_result["edge_counts"]["subclasses"] == 0


### PR DESCRIPTION
## Summary

Promotes `subclasses` from a `not_yet_implemented` edge to a **supported** `expand` edge, mirroring the merged `imported_by` promotion (#345/#346). `expand(class_handle, "subclasses")` now returns the project classes that subclass the target as canonical class stubs.

`subclasses` is the plan's deliberate "directionally-inbound but reliably-static" exception: it is produced by `JediAnalyzer.find_subclasses` (AST class-graph walk + forward `goto`/`resolve_canonical`), with **no `get_references` / reverse symbol search** on the path — so it belongs with `members`/`callees`/`imported_by`, not with the Pyright-deferred inbound edges.

## What changed

- **One production file** — `src/pyeye/mcp/operations/edges.py`:
  - Moved `subclasses` from `_NOT_YET_IMPLEMENTED_EDGES` to `_IMPLEMENTED_EDGES`.
  - Added async `resolve_subclasses`, **reusing** `find_subclasses(handle, scope="main", include_indirect=True, show_hierarchy=False)` — the exact call shape `inspect._count_subclasses` uses, so `len(expand stubs) == inspect.edge_counts.subclasses`.
  - Adjacents are canonical class `(Handle, Name)` pairs; each `Name` is produced by forward file-enumeration (mirroring `_class_members`), not dotted-handle re-resolution — preserving breadth for subclasses defined in non-importable files (tests/scripts). Deterministically sorted by FQN.
  - Registered in `EDGE_RESOLVERS`; docstrings updated.

- **Wrong-kind → measured-empty.** A non-class handle returns the supported `stubs: []` (mirroring `members`/`callees`), **not** the `imported_by` `None`/`not_yet_implemented` path — because only a class *can* be subclassed, so `[]` is true by definition rather than the #332 absence-vs-zero lie. Consequence: **`expand.py` is unchanged.**

- `jedi_analyzer.py` and the conformance linter are **unchanged** — behavior-preserving reuse (legacy `find_subclasses` and `inspect.edge_counts.subclasses` tests pass unmodified).

## Test plan

- [x] Unit (`test_edges.py`): status-matrix flip; class adjacency incl. indirect grandchild + non-importable-file subclass; class with no subclasses → `EdgeResult([])`; non-class → `EdgeResult([])` (explicitly not `None`); no-`get_references` spy; cross-hash-seed determinism.
- [x] Operation (`test_expand.py`): supported class stubs; non-class supported measured-empty (not unsupported); no `unresolved_call_sites`; count/list consistency vs `inspect.edge_counts.subclasses`.
- [x] Integration (`test_traversal_integration.py`): `subclasses` over the registered MCP `expand` tool — class, non-class, and empty-class branches; plain-dict + JSON round-trip.
- [x] Conformance (`test_linter_adversarial_expand.py`): real `subclasses` output dogfooded through `lint_response(..., "expand")` — no linter change.
- [x] Full suite: 1865 passed, 8 skipped, coverage 86.59% (≥85%). No `get_references` on the subclasses path (grep + spy verified).

Implementation plan: `docs/superpowers/plans/2026-06-13-subclasses-edge.md`.

Fixes #348