### PR TITLE
feat(decision-log): commit-checkpoint decision-note skill + seeded log

### DIFF
--- a/.claude/agents/smart-commit.md
+++ b/.claude/agents/smart-commit.md
@@ -34,6 +34,7 @@ cd "$CLAUDE_WORKING_DIR" && git commit
 5. **Auto-fix & Retry**: Re-stage ONLY files in the initial stage set that hooks modified; never blanket-stage
 6. **Iterate Smart**: May take 2-3 cycles (format → type fix → commit)
 7. **Validate Success**: Ensure commit created and coverage gate met
+8. **Decision-Note Checkpoint**: If the committed diff touched a contract surface, invoke the `decision-log` skill to propose ONE entry — see step 6 below
 
 ### Staging Strategy (MANDATORY)
 
@@ -153,6 +154,20 @@ Flag any untracked files that:
 If any are found, **stage them and commit immediately** with a follow-up commit message like `fix(fixtures): stage <X> referenced by committed tests`. Don't report DONE until `git status` shows only files that genuinely don't belong to this work (modified `.mcp.json`, untracked plan/scratch files, npm artifacts unrelated to the task, etc.).
 
 **Why this matters:** local tests pass because the unstaged files exist in the working tree. A fresh clone fails. The gap is silent until the user pushes and someone else (or CI on a fresh checkout) hits the broken state. Confirmed instance 2026-05-04: two fixture files referenced by committed tests sat untracked across multiple commits before being caught.
+
+### 6. Decision-Note Checkpoint (contract-touching diffs)
+
+The commit is the deterministic pause where the diff is already on the table — the right moment to capture *why* a contract-significant change was made, before the reasoning evaporates.
+
+After the commit succeeds, inspect the committed diff. If it touched a **contract surface** — a public/exported signature, a documented invariant or guarantee, a predicate/schema/config contract, an edge/API contract, or a non-obvious "why" decided in the working conversation — invoke the `decision-log` skill to propose ONE entry for `docs/decisions/DECISIONS.md`.
+
+```bash
+# What did this commit actually change? (contract-surface check)
+git show --stat HEAD
+git show HEAD -- '*.py' | grep -E '^[-+](def |class |    def |async def )' | head -20
+```
+
+Delegate the judgement and the entry format to the `decision-log` skill — do NOT inline its rules here. Honour its discipline: propose in one line, never nag, `Verify` honestly tiered, `Anchor` by stable reference (not bare `file:line`). Pure bugfix / rename / formatting / dependency-bump diffs get NO entry. When unsure it clears the contract-significant bar, stay silent.
 
 ## Output Format Standards
 

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -1,0 +1,24 @@
+# Decision Log
+
+Contract/invariant-significant, friction-driven decisions. Each entry is a small verifiable fact: Friction · Decision · Anchor (stable ref) · Verify (checkable or honestly-labelled). Newest on top. Maintained via the `decision-log` skill.
+
+## 2026-06-13 — decision-log ships in the pyeye plugin, not ~/.claude/skills
+
+**Friction:** A loose `~/.claude/skills/` file is unmanaged — not versioned, lost on a machine move, not shareable — and it split the work across two homes (user dir + repo).
+**Decision:** Bundle the skill in the pyeye plugin's `skills/` (alongside `python-explore`) so it ships, versions, and reinstalls with pyeye while staying globally available. Keep the pyeye-dependency *soft* — `Verify` tiers allow grep / import-linter / tests / human, not just pyeye. Rejected: loose user-level skill.
+**Anchor:** `skills/decision-log/SKILL.md` ; `.claude-plugin/plugin.json` ; this session
+**Verify:** gold — `test -f skills/decision-log/SKILL.md && ! test -e ~/.claude/skills/decision-log` (skill present in plugin, no shadow copy).
+
+## 2026-06-13 — decision-log fires at the commit checkpoint, not ambient AI vigilance
+
+**Friction:** An ambient "agent watches for significant changes and pipes up" trigger decays — the agent is heads-down on the task and catches the moment inconsistently (the same reason "always do X" instructions lapse).
+**Decision:** Anchor the trigger to the commit — a deterministic pause with the diff already on the table — via the `smart-commit` agent, plus on-demand ("log this decision"). Rejected: always-on agent vigilance.
+**Anchor:** `skills/decision-log/SKILL.md` ("When This Fires") ; `.claude/agents/smart-commit.md`
+**Verify:** PARTIAL — `grep -q "commit checkpoint" skills/decision-log/SKILL.md` and a decision-note step exists in `.claude/agents/smart-commit.md` confirm the documented trigger. Whether it *actually* fires reliably is behavioural — human-observed over time [unverifiable mechanically].
+
+## 2026-06-13 — decisions captured as an append-only log, not one ADR file per decision
+
+**Friction:** Per-file ADRs (`NNNN-slug.md`) are ceremony that rots; the goal is the lowest friction that still yields retrievable, verifiable facts (avoid the ADR graveyard).
+**Decision:** A single append-only `docs/decisions/DECISIONS.md`, newest on top, one short entry per distinct decision (Friction · Decision · Anchor · Verify). Rejected: one ADR file per decision; commit-trailer-only (buried in git history).
+**Anchor:** `docs/decisions/DECISIONS.md` ; `skills/decision-log/SKILL.md` ("File Convention")
+**Verify:** gold — `head -1 docs/decisions/DECISIONS.md` equals `# Decision Log`; entries are `##` headings carrying the four bold fields Friction/Decision/Anchor/Verify.

--- a/skills/decision-log/SKILL.md
+++ b/skills/decision-log/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: decision-log
+description: Use at the commit checkpoint — or on demand ("log this decision", "record why we did this") — when a change is BOTH contract/invariant-significant AND driven by friction. Captures a short, honest, verifiable decision note into the repo's docs/decisions/DECISIONS.md. Triggers on diffs touching a public signature, a documented invariant, a predicate/schema, or an edge/API contract. Does NOT trigger for pure bugfixes, renames, formatting, dependency bumps, or any change without a non-obvious "why". Tool-agnostic — synergises with pyeye but does not require it.
+---
+
+# Decision Log
+
+Capture the *why* of contract-significant, friction-driven changes as small, **verifiable** notes — before the reasoning evaporates into the diff. Each entry is forward-compatible with a future trust-layer / architecture-fact checker that re-runs the `Verify` lines.
+
+This habit must survive deadlines. It optimises for low friction and honest, checkable facts over completeness. Capturing a high-signal *subset* reliably beats capturing everything and rotting (the ADR graveyard).
+
+## Skill Type: Mixed Rigid/Flexible
+
+**Rigid gates (non-negotiable):**
+
+- Propose in ONE line; never write the entry before the user confirms.
+- Never nag — if the user declines, drop it silently and continue.
+- `Verify` MUST be honestly tiered (gold / partial / unverifiable) — never a vague "looks right".
+- `Anchor` MUST use stable references (symbol names, #issue/PR, commit-pinned permalinks) — NEVER a bare `file:line`.
+- Never fabricate the date.
+
+**Flexible path (use judgement):**
+
+- Whether a given diff is genuinely "contract-significant" (when unsure, do NOT propose — false positives train the user to ignore you, which kills the habit).
+- How to phrase Friction/Decision concisely.
+- Which verification mechanism fits (test, pyeye query, grep, import-linter contract, human review).
+
+## When This Fires
+
+**Primary trigger — the commit checkpoint.** When a commit is being prepared and the staged diff touches a **contract surface**, propose ONE decision note before finalising. Contract surfaces:
+
+- a public/exported signature changed (params, return, raises)
+- a documented invariant or guarantee (e.g. "never raises", "pure consumer", "absence ≠ zero")
+- a predicate / schema / config contract (a new key, a changed default)
+- an edge / API contract (what a tool returns, a discriminated-union branch)
+- a non-obvious "why we did it this way" decided in the working conversation
+
+**Secondary trigger — on demand.** The user says "log this decision" (or similar), commit or not.
+
+## Do NOT Trigger When
+
+- Pure bugfix, rename, formatting, dependency bump — no contract change, no non-obvious why.
+- A new test case only (not test-infrastructure contracts).
+- The change is mechanical and self-explanatory from the diff.
+- You are unsure it clears the contract-significant bar — default to silence.
+
+## The Flow (propose → draft → confirm → append)
+
+1. **Propose in ONE line.** e.g. *"That `stop_when` change alters a predicate contract — log a decision note?"* Do not draft yet.
+2. **Draft from the diff + conversation.** Fill every field. Pull the *why* from what was actually said/decided, not a guess.
+3. **Show the drafted entry** for confirmation.
+4. **Append on confirm** to `docs/decisions/DECISIONS.md` (newest on top; create with the header if absent). On decline, drop it.
+
+## Entry Schema
+
+```text
+## YYYY-MM-DD — <one-line title>
+**Friction:** <the frustration that drove the change — what broke / didn't work / was unsafe>
+**Decision:** <what was decided and chosen; the rejected alternative if non-obvious>
+**Anchor:** <stable refs only — canonical symbol name(s) + #issue/PR or commit-pinned permalink>
+**Verify:** <gold | partial | unverifiable — see below>
+```
+
+Keep each field to a line or two. A 6-line entry that gets written beats a 40-line ADR that doesn't.
+
+## Honesty Discipline (what makes this more than prose)
+
+The `Verify` line is the bridge to the trust layer. It MUST be one of three honestly-labelled tiers:
+
+- **Gold (mechanically checkable):** a concrete assertion something can run — a test, a pyeye query, a grep, an import-linter contract. Precise enough to execute.
+  `Verify: trace(<project handle>, ["callees"], stop_when={scope:"project"}) returns zero nodes with scope=="external".`
+- **Partial:** the checkable portion as a gold assertion, plus the residue explicitly marked unverifiable.
+  `Verify: PARTIAL — "module A imports B; B does not import A" via import-linter forbidden contract. "Must not mutate the registry" needs human/AST review.`
+- **Unverifiable:** `Verify: unverifiable — <reason>.` Still record the intent; just be honest the checker can't confirm it.
+
+**Environment caveats are part of honesty.** If a `Verify` depends on conditions that can make it lie (a warm semantic index, a built feature, a running service), say so inline — e.g. `[needs warm index]`. A `Verify` that silently fails on a cold index is a false alarm, not a verification.
+
+## File Convention
+
+- Location: `docs/decisions/DECISIONS.md` at the repo root. Create `docs/decisions/` if absent.
+- Append-only, **newest entry on top**, one entry per *distinct* decision (not per commit; one commit may yield zero or one).
+- When creating the file, start it with this header, then the first entry:
+
+```text
+# Decision Log
+
+Contract/invariant-significant, friction-driven decisions. Each entry is a small verifiable fact: Friction · Decision · Anchor (stable ref) · Verify (checkable or honestly-labelled). Newest on top. Maintained via the `decision-log` skill.
+```
+
+## Workflow
+
+```dot
+digraph decision_log {
+    rankdir=TB;
+
+    "Change being committed / user says 'log this'" [shape=diamond];
+    "Touches a contract surface?" [shape=diamond];
+    "Friction-driven (non-obvious why)?" [shape=diamond];
+    "User confirms?" [shape=diamond];
+
+    "Stay silent" [shape=box];
+    "Propose in ONE line" [shape=box];
+    "Draft entry from diff + conversation" [shape=box];
+    "Show entry for confirmation" [shape=box];
+    "Append to docs/decisions/DECISIONS.md" [shape=box];
+    "Drop silently" [shape=box];
+
+    "Change being committed / user says 'log this'" -> "Touches a contract surface?";
+    "Touches a contract surface?" -> "Stay silent" [label="no"];
+    "Touches a contract surface?" -> "Friction-driven (non-obvious why)?" [label="yes"];
+    "Friction-driven (non-obvious why)?" -> "Stay silent" [label="no"];
+    "Friction-driven (non-obvious why)?" -> "Propose in ONE line" [label="yes"];
+    "Propose in ONE line" -> "User confirms?";
+    "User confirms?" -> "Drop silently" [label="no"];
+    "User confirms?" -> "Draft entry from diff + conversation" [label="yes"];
+    "Draft entry from diff + conversation" -> "Show entry for confirmation";
+    "Show entry for confirmation" -> "Append to docs/decisions/DECISIONS.md";
+}
+```
+
+## Date
+
+Take the date from the environment (the session's current date, or `date +%F` / `git log`). NEVER fabricate it.
+
+## Failure Mode
+
+This skill has NO hard tool dependency. If a chosen `Verify` mechanism is unavailable (pyeye down, no import-linter, etc.):
+
+1. Pick a different mechanism that IS available (grep, a test, human review), or
+2. Drop the `Verify` to a lower tier and label it honestly (`partial` / `unverifiable — <reason>`).
+
+Never invent a passing check. An honest `unverifiable` is correct; a fabricated gold assertion is a lie that will mislead the future checker.
+
+## Red Flags — You're About to Violate This Skill
+
+- Drafting the entry before the user confirmed.
+- Proposing on a pure bugfix / rename / format / dep-bump.
+- Writing `Verify: looks correct` or any assertion nothing can run.
+- Using a bare `file:line` as the `Anchor`.
+- Proposing a second time after the user already declined.
+- Inventing a date or a passing check.
+
+**If you catch yourself doing any of these: STOP.**


### PR DESCRIPTION
## Summary

Adds **`decision-log`** — a portable skill for capturing the *why* of contract-significant, friction-driven changes as small, **verifiable** decision notes, before the reasoning evaporates into the diff.

- **Skill, bundled in the plugin** (`skills/decision-log/SKILL.md`, alongside `python-explore`) — ships/versions/reinstalls with pyeye, globally available, but **soft** pyeye dependency (Verify tiers allow grep / import-linter / tests / human).
- **Commit-checkpoint trigger** wired into `.claude/agents/smart-commit.md` (workflow step 8 + a "Decision-Note Checkpoint" section) — fires at the deterministic commit pause rather than relying on ambient AI vigilance.
- **Per-repo log** at `docs/decisions/DECISIONS.md`: append-only, newest on top, one short entry each (`Friction · Decision · Anchor · Verify`). Anchors use stable refs (symbol/issue/permalink), never bare `file:line`.
- **Honesty discipline:** `Verify` is three-tier (gold / partial / unverifiable), honestly labelled — the bridge to a future trust-layer checker that re-runs the assertions.
- **Seeded by dogfooding** the skill on its own three build decisions; each seed entry's gold `Verify` was run and passes.

## What this is NOT
A general-purpose product feature (yet). It's opinionated trust-infrastructure. Open question deferred: whether it belongs in a publicly-distributed pyeye, or stays a personal/team workflow skill.

## Test plan / what to monitor over time
- [x] Commit landed clean via `smart-commit` (pre-commit green incl. conformance linter + markdownlint; pytest N/A — markdown-only diff).
- [x] Checkpoint *fired* when prompted, identified the right contract surfaces, drafted a correctly-tiered entry, and showed restraint (declined a near-duplicate of a seeded entry).
- [ ] **Open question — reliability:** does the checkpoint fire *unprompted*? The first test was confounded (the dispatch told it to run the checkpoint). The real measure is whether future contract-touching commits through `smart-commit` — with a plain commit prompt, no checkpoint mention — surface a decision note on their own. Monitoring this over time is the point of merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)