### PR TITLE
feat(outline): progressive-disclosure structural skeleton primitive (#355)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-outline-expand-trace.md
+++ b/docs/superpowers/plans/2026-06-02-outline-expand-trace.md
@@ -1,0 +1,272 @@
+# Outline / Expand / Trace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the progressive-disclosure traversal primitives — `outline`, `expand`, and `trace` — on top of the existing `resolve`/`inspect` surface, restricted to the edge types pyeye can produce reliably today (outbound/structural), with inbound/reference edges explicitly deferred to a later reference-backend phase.
+
+**Architecture:** A shared `Stub` builder and an internal edge-resolver registry underpin all three primitives. `outline` is a scope-bounded recursive walk of the `members` edge. `expand` is a single-hop, paginated walk along one edge. `trace` is a bounded BFS composing `expand` over multiple edges. The keystone decision: this plan ships **only the edges backed by reliable Jedi local operations** (`members`, `superclasses`, `subclasses`, `callees`, `imports`, `enclosing_scope`); the inbound/reverse-search edges (`callers`, `references` and its `read_by`/`written_by`/`passed_by` components, `imported_by`, `overrides`/`overridden_by`, `decorated_by`/`decorates`) depend on project-wide reference search, which is the known-broken `get_references` path (issue #332). Those edges are surfaced as explicitly-unsupported (an honest "requires reference backend" signal), never as wrong/empty data, and light up in a non-breaking follow-up once the Pyright backend (#333) lands.
+
+**Tech Stack:** Python, FastMCP, Jedi (local ops only: `goto`, `get_names`, `infer`, AST walks), pytest. Reuses `pyeye.handle.Handle`, `pyeye.scope.classify_scope`, `pyeye.canonicalization`, `pyeye._jedi_location`, and the existing `mcp/operations/inspect.py` helpers.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md` (operations section, `Stub`/`OutlineTree`/`ExpandResult`/`Subgraph` types, and the edge-type vocabulary table).
+
+**Carrier branch:** lands incrementally on the resolve/inspect dev branch (no separate issue/worktree), consistent with how `resolve`/`inspect` were delivered.
+
+---
+
+## Hard constraints (apply to every task)
+
+- **No source content.** Stubs carry pointers (`handle`, `kind`, `scope`, `signature`, `line_start`, `line_end`) only — never bodies, snippets, or surrounding text. The conformance linter's layering check (Check A) already enforces this; new responses must pass it.
+- **Absence-vs-zero, applied to edges.** An edge pyeye does not yet support must be reported as *explicitly unsupported* (a distinct, documented signal), NOT as an empty result set. An empty `stubs` list must mean "measured, none found"; "we can't measure this edge" must be a different, unmistakable response. This mirrors the `edge_counts` decision in #332.
+- **Reliable edges only in this plan.** Do not wire any edge whose only implementation route is project-wide reference search (`get_references`). If an edge cannot be produced from local Jedi ops + bounded AST walks, it belongs in the deferred set, not this plan.
+- **Reuse, don't duplicate.** Member enumeration, superclass resolution, scope classification, location-span building, and kind normalisation already exist in `inspect.py`/`resolve.py`/`scope.py`/`_jedi_location.py`. Extract and share rather than reimplement (note the existing duplication tracked in #330 — do not add more).
+- **Canonical handles throughout.** Every stub's `handle` is a canonical definition-site handle (via `canonicalization`), so traversal dedup and cross-primitive composition work. `trace` dedups by handle.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/pyeye/mcp/operations/stubs.py` | Create | The shared `Stub` builder: given a Jedi name / handle, produce the spec `Stub` shape (handle, kind, scope, signature, line span). Single source of truth reused by outline/expand/trace and convertible from inspect's data. |
+| `src/pyeye/mcp/operations/edges.py` | Create | Internal edge-resolver registry. Maps each supported edge type to a function returning the adjacent handles for a source handle. Declares which edges are supported-now vs. deferred-to-reference-backend. The one place edge support is defined. |
+| `src/pyeye/mcp/operations/outline.py` | Create | `outline(handle, max_depth)` — recursive `members` walk, scope-bounded, external cap. |
+| `src/pyeye/mcp/operations/expand.py` | Create | `expand(handle, edge, limit, cursor, filter)` — single-hop paginated walk over one edge via the registry. |
+| `src/pyeye/mcp/operations/trace.py` | Create | `trace(start, follow, max_depth, max_nodes, stop_when)` — bounded BFS composing the edge registry; dedup by handle; `truncated` accounting. |
+| `src/pyeye/mcp/server.py` | Modify | Register `outline`, `expand`, `trace` as new `@mcp.tool` endpoints. Do not modify existing tools. |
+| `src/pyeye/mcp/operations/inspect.py` | Modify (small) | Extract the stub-shaped fields it already computes so `stubs.py` is the shared builder; no behavioural change to `inspect`'s output. |
+| `tests/unit/mcp/operations/test_stubs.py` | Create | Stub builder unit tests across kinds. |
+| `tests/unit/mcp/operations/test_edges.py` | Create | Edge-registry tests: each supported edge returns correct adjacents on a fixture; each deferred edge returns the explicit unsupported signal. |
+| `tests/unit/mcp/operations/test_outline.py` | Create | Outline shape, depth bounding, scope cap, nested classes. |
+| `tests/unit/mcp/operations/test_expand.py` | Create | Per-edge expansion, pagination (cursor round-trip), filter behaviour, deferred-edge signal. |
+| `tests/unit/mcp/operations/test_trace.py` | Create | Multi-hop traversal, dedup/cycle handling, `truncated` accounting, `stop_when`. |
+| `tests/integration/api_redesign/test_traversal_integration.py` | Create | End-to-end via the MCP wire format against a real fixture project. |
+| `tests/conformance/response_linter.py` | Modify | Extend the linter to validate `Stub`/`OutlineTree`/`ExpandResult`/`Subgraph` shapes (layering + structural floors). |
+| `docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md` | Modify | Add an implementation-status note recording which edges are supported now vs. deferred to the reference backend (mirrors the existing `edge_counts` note). |
+
+---
+
+## Phase 1: Shared foundation — Stub builder + edge registry
+
+This phase builds the two shared units everything else depends on. Nothing user-facing ships yet, but it locks in the contracts (`Stub` shape, edge support matrix) that the three primitives rely on, so it must be correct first.
+
+### Task 1.1: Failing tests for the `Stub` builder
+
+- [ ] Create `tests/unit/mcp/operations/test_stubs.py`
+- [ ] Write tests asserting the builder produces the exact spec `Stub` shape for each kind (class, function, method, module, attribute, property, variable): canonical `handle`, normalised `kind`, `scope` (`project`/`external`), one-line `signature` for callable kinds (absent for non-callable), and `line_start`/`line_end` from the symbol's span — because every traversal primitive returns stubs and they must be uniform across primitives
+- [ ] Write a test asserting no stub field ever contains source content (multi-line bodies/snippets), so the layering invariant holds at the unit level
+- [ ] Run the tests so they fail because the module does not exist
+- [ ] Commit
+
+**Constraint:** The signature must be the same single-line form `inspect` already produces — extract and share that logic, do not write a second signature extractor (see #330 for the cost of parallel implementations).
+
+**Acceptance:** Tests fail for "module missing" reasons, and pin the stub contract for all kinds including the no-signature and external-scope cases.
+
+### Task 1.2: Implement the `Stub` builder
+
+- [ ] Create `src/pyeye/mcp/operations/stubs.py` with a builder that takes a Jedi name (or a resolved handle) and returns the spec `Stub`
+- [ ] Reuse existing kind normalisation, scope classification, location-span, and signature helpers rather than reimplementing them
+- [ ] Modify `inspect.py` minimally so the shared builder is the single source of the stub-shaped fields, with no change to `inspect`'s observable output
+- [ ] Run the failing tests so they pass
+- [ ] Run the full suite to confirm `inspect` did not regress
+- [ ] Commit
+
+**Constraint:** This is a refactor-plus-extract on a file already in production (`inspect.py`). The `inspect` response shape must not change — only the internal source of those fields. Verify by the existing `inspect` tests staying green untouched.
+
+**Risk:** Over-eager extraction could change `inspect`'s output subtly (e.g. signature formatting). Keep the extraction behaviour-preserving; if any `inspect` test needs editing, that is a signal the extraction changed behaviour and should be reconsidered.
+
+**Acceptance:** Stub tests pass; all existing `inspect` tests pass unmodified; full suite green.
+
+### Task 1.3: Failing tests for the edge registry
+
+- [ ] Create `tests/unit/mcp/operations/test_edges.py`
+- [ ] For each **supported-now** edge (`members`, `superclasses`, `subclasses`, `callees`, `imports`, `enclosing_scope`): write a test asserting the resolver returns the correct adjacent handles for a fixture symbol, because these are the edges `expand`/`trace` will traverse
+- [ ] For each **deferred** edge (`callers`, `references`, `read_by`, `written_by`, `passed_by`, `imported_by`, `overrides`, `overridden_by`, `decorated_by`, `decorates`): write a test asserting the registry reports it as *explicitly unsupported* — a distinct signal, never an empty adjacency list — because conflating "unsupported" with "none found" is the exact failure #332 exists to prevent
+- [ ] Run the tests so they fail
+- [ ] Commit
+
+**Constraint:** `callees` requires reading the *target function's own body* and resolving each call via `goto` — this is local (one file) and reliable, distinct from the project-wide reverse search that `callers` needs; it is the one outbound call-edge in the supported set. Be precise about which direction each edge walks — outbound (this symbol points out: members, superclasses, callees, imports, enclosing_scope) is supported; inbound (others point at this symbol) is deferred. `subclasses` is the deliberate exception: it is directionally inbound but reliably produced by an AST-walk + `goto` (no reverse search), so it is supported. The spec's edge-vocabulary table gives each edge's direction.
+
+**Note on `overrides`:** although a method's own ancestors' same-named methods are reachable via MRO (locally), `overrides` is placed in the **deferred** set for this plan to keep the supported scope to the six edges above and avoid a "reliable-ish" edge that risks falling through to reverse search. It can be promoted in a later phase if a purely-local implementation is confirmed.
+
+**Risk:** `callees` is "reliable-ish" — it involves more than a single local call (read the body, resolve each call site). During implementation, confirm it stays within local-file operations and does **not** fall through to `get_references`. If it cannot be done reliably without reverse search, move it to the deferred set and note it; do not ship a shaky edge.
+
+**Acceptance:** Failing tests define the support matrix: every supported edge has an expected-adjacency test; every deferred edge has an unsupported-signal test.
+
+### Task 1.4: Implement the edge registry
+
+- [ ] Create `src/pyeye/mcp/operations/edges.py` with a registry mapping each supported edge to a resolver function (source handle → list of adjacent canonical handles), and a declared set of deferred edges that resolve to the explicit unsupported signal
+- [ ] Implement only the supported-now resolvers, reusing existing analyzer helpers (member enumeration, subclass search, superclass resolution, import extraction)
+- [ ] Run the failing tests so they pass
+- [ ] Run the full suite
+- [ ] Commit
+
+**Constraint:** Each resolver returns canonical handles (so downstream dedup/composition works), not raw Jedi names or positions. The deferred-edge signal must be machine-distinguishable from an empty result by callers (`expand`/`trace` will translate it into their own response shapes).
+
+**Acceptance:** All edge tests pass. Grep confirms no supported-edge resolver calls `get_references` / `find_references`. Full suite green.
+
+---
+
+## Phase 2: `outline` ✅ COMPLETE
+
+> **Status:** Implemented and merged (issue #355, branch `feat/355-outline`).
+> Refined spec: `docs/superpowers/specs/2026-06-13-outline-design.md`.
+> Implementation plan: `docs/superpowers/plans/2026-06-13-outline.md`.
+>
+> The original tasks below are preserved for historical context. All acceptance
+> criteria were met; the conformance linter (Check O) enforces the two absence
+> contracts in both directions.
+
+The cheapest, most independent primitive — a recursive `members` walk on reliable Jedi ops. Delivers the "structural skeleton of a module/class" view the empirical analysis flagged as missing in LSP-bridges. No dependency on the reference backend.
+
+### Task 2.1: Failing tests for `outline`
+
+- [x] Create `tests/unit/mcp/operations/test_outline.py`
+- [x] Write tests asserting: a module handle yields an `OutlineTree` whose children are its top-level classes/functions; a class handle yields its methods/nested classes; nested classes are walked but function bodies are not (no descent into local variables inside a function); each node is a `Stub`
+- [x] Write a test asserting `max_depth` bounds the recursion as specified
+- [x] Write a test asserting the external-scope cap: an external handle is walked at most one level deep regardless of requested `max_depth`
+- [x] Run the tests so they fail
+- [x] Commit
+
+**Constraint:** Default `max_depth` is unbounded *within scope*. "Bodies are not walked" means the recursion follows `members` (class → method, module → class), not statements inside a function. Reuse the Phase 1 `members` resolver and `Stub` builder.
+
+**Acceptance:** Failing tests pin the tree shape, depth bounding, and external cap.
+
+### Task 2.2: Implement `outline`
+
+- [x] Create `src/pyeye/mcp/operations/outline.py` implementing the recursive `members` walk via the edge registry, building each node with the shared `Stub` builder
+- [x] Apply the external-scope cap (treat requested depth as at most one level for external handles)
+- [x] Run the failing tests so they pass
+- [x] Run the full suite
+- [x] Commit
+
+**Risk:** Deeply nested or large modules could produce very large trees. The scope bound and `max_depth` are the guards; confirm a large fixture module returns in reasonable time and the tree is bounded. If unbounded-within-scope proves too large in practice, note it — but do not add a silent cap that hides nodes (that would violate the honesty principle; prefer surfacing depth limits explicitly).
+
+**Acceptance:** Outline tests pass; full suite green; manual check on a real fixture module produces a sensible skeleton with no source content.
+
+---
+
+## Phase 3: `expand`
+
+Single-hop, paginated walk over one edge. The keystone that makes `inspect`'s orientation *actionable* — but in this plan only for the supported (outbound/structural) edges. Inbound edges return the explicit unsupported signal.
+
+### Task 3.1: Failing tests for `expand` over supported edges
+
+- [ ] Create `tests/unit/mcp/operations/test_expand.py`
+- [ ] For each supported edge, write a test asserting `expand` returns `Stub`s for the correct adjacents of a fixture symbol
+- [ ] Write pagination tests: a `limit` smaller than the result set returns a `cursor`; passing that cursor back returns the next page; the final page omits the cursor; the concatenation of pages equals the full set with no duplicates or gaps — because pagination correctness is the contract agents rely on to know when they have everything
+- [ ] Write filter tests for `include_tests`, `module_pattern`, and `same_package` per the spec's `ExpandFilter`
+- [ ] Run the tests so they fail
+- [ ] Commit
+
+**Constraint:** `expand` deliberately returns **no total count** — pagination state is read from cursor presence only (absent = complete). Ordering for stubs is `(file, line_start)` ascending for determinism, so cursors advance through a stable flat list. The cursor is opaque to callers but must encode enough to resume deterministically.
+
+**Risk:** Cursor design is the subtle part. It must survive the result set being recomputed between calls (pyeye is stateless per call) — i.e. encode a position in a deterministic ordering rather than an in-memory offset. Constraint: the ordering must be total and stable across calls or pagination will skip/repeat. Verify with a test that paginates a set larger than one page and reconstructs it exactly.
+
+**Acceptance:** Failing tests define per-edge expansion, exact pagination round-trips, and filter semantics.
+
+### Task 3.2: Failing tests for `expand` over deferred edges
+
+- [ ] Add tests asserting that calling `expand` with a deferred edge (e.g. `callers`, `references`) returns the explicit *unsupported* response — distinguishable from an empty page — and never a wrong/empty stub list, because returning `[]` for `callers` would falsely imply "no callers" (the #332 failure mode)
+- [ ] Run the tests so they fail
+- [ ] Commit
+
+**Constraint:** The unsupported response must be self-describing enough that an agent understands the edge is not-yet-measured (and, ideally, that a reference backend is required), not that the symbol has zero such neighbours.
+
+**Acceptance:** Failing tests pin the deferred-edge behaviour as an explicit signal.
+
+### Task 3.3: Implement `expand`
+
+- [ ] Create `src/pyeye/mcp/operations/expand.py` implementing single-hop expansion via the edge registry, with ordering, pagination/cursor, and filter support for supported edges, and the unsupported signal for deferred edges
+- [ ] Run the failing tests from 3.1 and 3.2 so they pass
+- [ ] Run the full suite
+- [ ] Commit
+
+**Acceptance:** All `expand` tests pass; pagination reconstructs full sets exactly; deferred edges return the explicit signal; full suite green; grep confirms no supported-edge path touches `get_references`.
+
+---
+
+## Phase 4: `trace`
+
+Bounded multi-hop BFS composing `expand` over a `follow` set of edges. Restricted here to supported edges (so trace closures are trustworthy). Completes the orient → drill → traverse flow, enabling end-to-end assessment of the primitive set without the reference backend.
+
+### Task 4.1: Failing tests for `trace`
+
+- [ ] Create `tests/unit/mcp/operations/test_trace.py`
+- [ ] Write a multi-hop test: tracing `members` (or `subclasses`/`callees`) from a start handle returns a `Subgraph` whose `nodes` are reachable stubs and whose `edges` record `(from, to, kind)` — because trace's value is exposing structure across hops, with fan-in visible
+- [ ] Write a dedup/cycle test: a cyclic fixture (e.g. mutually-referencing modules or self-referential class) terminates; each handle appears once in `nodes`; edges to already-visited handles are still recorded so cycles are visible
+- [ ] Write `truncated` tests: hitting `max_depth` or `max_nodes` before natural termination sets `truncated: true`; a fully-explored closure sets `truncated: false`
+- [ ] Write a `stop_when` test: traversal halts at the predicate boundary (e.g. entering a matching module, or excluding tests)
+- [ ] Write a multi-edge `follow` test: following more than one edge type produces edges of each kind with correct `kind` labels (edges not deduped across types)
+- [ ] Run the tests so they fail
+- [ ] Commit
+
+**Constraint:** Dedup by handle; visit each handle at most once; record-but-don't-re-expand edges to visited handles (this guarantees termination on cycles even with unbounded depth). `truncated` means specifically "caps hit before natural termination," not merely "caps were set." Defaults: `max_depth` 3, `max_nodes` 50.
+
+**Risk:** If `follow` includes a deferred edge, `trace` must surface that clearly (e.g. refuse or annotate), not silently return a partial graph that looks complete — same honesty concern as `expand`. Decide and test this behaviour explicitly.
+
+**Acceptance:** Failing tests define traversal, cycle-safe termination, `truncated` accounting, `stop_when`, and multi-edge labelling.
+
+### Task 4.2: Implement `trace`
+
+- [ ] Create `src/pyeye/mcp/operations/trace.py` implementing bounded BFS over the edge registry with dedup, cycle handling, `truncated` accounting, `stop_when`, and multi-edge `follow`
+- [ ] Decide and implement the behaviour when `follow` contains a deferred edge (refuse-with-signal or annotate), consistent with `expand`'s unsupported handling
+- [ ] Run the failing tests so they pass
+- [ ] Run the full suite
+- [ ] Commit
+
+**Acceptance:** All `trace` tests pass; cyclic fixtures terminate; `truncated` is accurate; deferred-edge-in-follow is handled honestly; full suite green.
+
+---
+
+## Phase 5: MCP registration, conformance, and docs
+
+Surfaces the three primitives on the wire and locks the contracts into the conformance suite.
+
+### Task 5.1: Register `outline`, `expand`, `trace` as MCP tools
+
+- [ ] Modify `src/pyeye/mcp/server.py` to register the three new `@mcp.tool` endpoints, wrapping the operation implementations and resolving the analyzer per the existing pattern used by `resolve`/`inspect`. Do not modify existing tools
+- [ ] Create `tests/integration/api_redesign/test_traversal_integration.py` exercising each new tool end-to-end via the MCP wire format against a real fixture project, including a pagination round-trip through the wire and a deferred-edge call
+- [ ] Run the integration tests so they pass
+- [ ] Run the full suite with coverage to confirm zero regressions and threshold held
+- [ ] Commit
+
+**Constraint:** Wrappers convert the operation's typed result to the plain-dict wire shape the existing tools use (same widening pattern as `resolve`/`inspect`). Tool docstrings must state plainly which edges are supported now and that inbound/reference edges require the reference backend.
+
+**Acceptance:** Three new tools discoverable and callable via the wire; integration tests pass; full suite green at coverage threshold.
+
+### Task 5.2: Extend the conformance linter and update the spec
+
+- [ ] Modify `tests/conformance/response_linter.py` to validate the `Stub`, `OutlineTree`, `ExpandResult`, and `Subgraph` shapes: enforce the layering check (no source content) on all of them, and structural floors (required keys per type, cursor optionality, `truncated` boolean presence)
+- [ ] Add adversarial linter tests for the new shapes (well-formed passes; source-content smuggling rejected; malformed structure rejected)
+- [ ] Update `docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md` with an implementation-status note recording the supported-now vs. deferred edge split for `expand`/`trace` and pointing to #332/#333 — mirroring the existing `edge_counts` status note
+- [ ] Run the conformance suite so it passes
+- [ ] Commit
+
+**Acceptance:** Linter validates all new response shapes in both directions (accepts valid, rejects violations); spec records the edge split honestly; conformance suite green.
+
+---
+
+## Deferred to the reference-backend phase (NOT in this plan)
+
+Explicitly out of scope here, to be delivered after the Pyright reference backend (#333) lands, as a non-breaking addition (the registry's deferred edges flip from unsupported to supported; `expand`/`trace` gain them automatically):
+
+- Inbound / reverse-search edges: `callers`, `references` (and `read_by`/`written_by`/`passed_by`), `imported_by`, `overrides`/`overridden_by`, `decorated_by`/`decorates`. (`overrides` may instead be promoted earlier if a purely-local MRO implementation is confirmed — see Task 1.3 note.)
+- Restoring `edge_counts.callers`/`references` on `inspect` (#332).
+
+**Note:** This split is the deliberate strategic sequencing — validate the full progressive-disclosure flow (orient → expand → trace) on trustworthy outbound edges *before* investing in the non-trivial Pyright backend, then light up the inbound half once the backend exists.
+
+---
+
+## Verification gates between phases
+
+After each phase, before the next:
+
+- [ ] Full test suite green at the coverage threshold (the project's standard gate).
+- [ ] Pre-commit hooks pass (no bypass flags).
+- [ ] No new call to `get_references`/`find_references` introduced on any supported-edge path (grep-verified) — the load-bearing constraint that keeps this plan's outputs trustworthy.
+- [ ] New response shapes pass the conformance linter's layering check (no source content).
+
+## Rollout note
+
+Phases 1–2 (foundation + `outline`) are pure additive wins on reliable ops and safe to land independently. Phase 3 (`expand`) is the keystone for actionability. Phase 4 (`trace`) completes the flow and enables end-to-end assessment of whether the primitive set works — which is the decision point for whether/when to invest in the Pyright backend. Phase 5 makes it real on the wire. The deferred inbound edges are a separate, later, non-breaking initiative.

--- a/docs/superpowers/plans/2026-06-13-outline.md
+++ b/docs/superpowers/plans/2026-06-13-outline.md
@@ -49,6 +49,7 @@ The whole behavioural core. Independent of the wire and the linter — delivers 
   - methods and functions are genuine leaves carrying `children: []` (a method has no members); nested classes recurse — **because** this is the "follow `members`, never walk function bodies" rule
   - `max_depth` bounds recursion, and at the frontier the **peek** distinguishes a genuine empty container (`children: []`) from a cut-off one (`truncated: true`, `truncation_reason` `"max_depth"`, **no** `children` key) — **because** this distinction is the load-bearing §4.2 contract
   - `max_nodes` cutoff marks not-yet-expanded containers `truncated`/`"max_nodes"` with no `children`, and never peeks past the budget — **because** a budget that peeks defeats itself
+  - the precedence tiebreaker: a node where both a depth/external cap *and* the node budget could fire reports `truncation_reason` `"max_nodes"` (the harder global bound) — **because** spec §5.4 makes the budget win, and an untested tiebreaker is one an implementation can get backwards unnoticed
   - an external-scope handle is walked at most one level; a deeper external container is `truncated`/`"external"` — **because** of the lazy-resolution cap for third-party code; note the root-vs-nested asymmetry (the external root still gets its one level of members)
   - sibling `children` are ordered by `(line_start, handle)` (source order), verified with members that are alphabetically-out-of-source-order — **because** presentation order is source order even though inclusion is BFS
   - a `truncated` node never carries `truncated: false` anywhere, and fully-walked nodes omit the key entirely
@@ -117,6 +118,8 @@ Locks the contracts into the conformance suite (so future changes can't silently
 - [ ] Commit
 
 **Constraint:** Reuse the existing Check A layering machinery (`_check_layering` and the recursive walk) — do not write a second source-content scanner. The new validation is structural (the §4.2 invariants); layering is already handled by the recursive walk and just needs to reach into `OutlineTree` nodes.
+
+**Constraint:** `outline`'s valid `truncation_reason` set is `{max_depth, max_nodes, external}` — it includes `external`, which `trace` never emits. Do NOT extend the shared `_VALID_TRUNCATION_REASONS` constant `trace`'s checks use (that holds only `{max_depth, max_nodes}`); extending it would silently loosen `trace`'s validation to accept a value it never produces. Add a separate constant (or an outline-specific set) for the `outline` enum.
 
 **Risk:** The linter must recurse into `children` so a violation buried deep in the tree is caught, not just at the root. Add an adversarial test with the violation at depth ≥ 2 to prove the recursion reaches it.
 

--- a/docs/superpowers/plans/2026-06-13-outline.md
+++ b/docs/superpowers/plans/2026-06-13-outline.md
@@ -1,0 +1,147 @@
+# Outline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `outline(handle)` — the last unbuilt progressive-disclosure primitive — returning the structural skeleton of a module or class as a tree of stubs, with no source content.
+
+**Architecture:** `outline` is a pure *consumer* of the existing `members` edge (`edges.resolve_members`), exactly as `trace` consumes the edge registry. It adds a bounded recursive walk (BFS inclusion, source-order presentation) and two honesty contracts (absence-of-`children` ⇔ not-walked; `truncated` absent-not-false) on top of the already-shipped `stubs.build_stub` + `resolve_members` + `inspect._find_jedi_name_for_handle` foundation. **No new edge logic; no change to `edges.py`.**
+
+**Tech Stack:** Python, FastMCP, Jedi (local ops only — via the existing `resolve_members`), pytest. Reuses `mcp/operations/edges.py`, `mcp/operations/stubs.py`, `mcp/operations/inspect.py`.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-outline-design.md` (authoritative — §4.2 absence contracts, §5 semantics, §6 invariants). Issue: #355. Branch: `feat/355-outline`.
+
+---
+
+## Hard constraints (apply to every task)
+
+- **No source content.** Every `node` is a `Stub` (pointers only). The conformance linter's Check A layering walk must pass on the whole `OutlineTree` recursively.
+- **The two absence contracts are load-bearing** (spec §4.2). `children` absent ⇔ not-walked; `children: []` = measured-empty. `truncated` is present-and-`true` only on cut-off nodes, never `false`, always with `truncation_reason` and absent `children`. Getting this wrong reintroduces the #332 absence-vs-zero lie the whole surface guards against.
+- **Consumer, not producer.** `outline` calls `resolve_members` and `build_stub`; it MUST NOT add or modify any edge resolver, and MUST NOT touch `edges.py` / `resolve_members`. No `get_references` / `find_references` anywhere on the `outline` path (grep-verified).
+- **Reuse the carried `Name`.** `resolve_members(...).adjacents` yields `(Handle, Name)` pairs — recurse on the carried `Name`, never re-resolve a child handle.
+- **Match the surface.** Tool wiring, async signature, and wire-widening follow the `trace`/`inspect` pattern already in `server.py`. Do not invent a new shape.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/pyeye/mcp/operations/outline.py` | Create | `outline(handle, analyzer, max_depth=None, max_nodes=200)` — BFS-bounded recursive `members` walk → nested `OutlineTree`; the two absence contracts; depth/node/external bounds. |
+| `tests/unit/mcp/operations/test_outline.py` | Create | Unit coverage of tree shape per kind, bounds, frontier-peek distinction, ordering, fallback. |
+| `src/pyeye/mcp/server.py` | Modify | Register one new `@mcp.tool`: `outline`. Existing tools untouched. |
+| `tests/integration/api_redesign/test_outline_integration.py` | Create | End-to-end via the MCP wire against a real fixture project. |
+| `tests/conformance/response_linter.py` | Modify | Validate `OutlineTree`: layering + the §4.2 invariants, recursively. |
+| `tests/conformance/test_linter_adversarial_outline.py` | Create | Valid tree passes; contract violations rejected. |
+| `docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md` | Modify (small) | Implementation-status note: `outline` shipped, pointing to this spec/plan for the refined contracts (mirrors the existing `edge_counts`/expand status notes). |
+| `docs/superpowers/plans/2026-06-02-outline-expand-trace.md` | Modify (small) | Mark Phase 2 complete, pointing to this plan. |
+
+---
+
+## Phase 1: The `outline` operation
+
+The whole behavioural core. Independent of the wire and the linter — delivers a tested, correct `outline` function. Build it test-first so the two absence contracts are pinned before the implementation can fudge them.
+
+### Task 1.1: Failing unit tests for `outline`
+
+- [ ] Create `tests/unit/mcp/operations/test_outline.py`
+- [ ] Write tests covering, against a small fixture with a module, top-level functions, a class with methods, and a nested class:
+  - a module handle yields a tree whose `node` is the module stub and whose `children` are its top-level definitions; a class handle yields its methods + nested classes; **because** the skeleton must reflect the `members` hierarchy
+  - methods and functions are genuine leaves carrying `children: []` (a method has no members); nested classes recurse — **because** this is the "follow `members`, never walk function bodies" rule
+  - `max_depth` bounds recursion, and at the frontier the **peek** distinguishes a genuine empty container (`children: []`) from a cut-off one (`truncated: true`, `truncation_reason` `"max_depth"`, **no** `children` key) — **because** this distinction is the load-bearing §4.2 contract
+  - `max_nodes` cutoff marks not-yet-expanded containers `truncated`/`"max_nodes"` with no `children`, and never peeks past the budget — **because** a budget that peeks defeats itself
+  - an external-scope handle is walked at most one level; a deeper external container is `truncated`/`"external"` — **because** of the lazy-resolution cap for third-party code; note the root-vs-nested asymmetry (the external root still gets its one level of members)
+  - sibling `children` are ordered by `(line_start, handle)` (source order), verified with members that are alphabetically-out-of-source-order — **because** presentation order is source order even though inclusion is BFS
+  - a `truncated` node never carries `truncated: false` anywhere, and fully-walked nodes omit the key entirely
+  - an unresolvable handle yields a minimal single-node tree with `children: []` (mirrors `inspect`'s minimal-node fallback)
+- [ ] Run the tests so they fail because the module does not exist
+- [ ] Commit
+
+**Constraint:** Use a real fixture directory, not a tmp-dir symlink, for any Jedi-backed resolution — Jedi degrades on macOS symlinked temp dirs (this repo has hit that; see the `find_subclasses`/`resolve_canonical` history). Prefer an existing `tests/fixtures` project or a committed fixture.
+
+**Risk:** The frontier-peek behaviour is the subtle part to pin. Make the depth-bounding tests assert *both* sides explicitly — a genuine `[]` leaf at the frontier AND a `truncated` container at the frontier — so an implementation that skips the peek (and emits `[]` for both) fails loudly.
+
+**Acceptance:** Tests fail for "module missing" reasons and pin all of: tree shape per kind, the two absence contracts, depth/node/external bounds, the frontier-peek distinction, source ordering, and the fallback.
+
+### Task 1.2: Implement `outline`
+
+- [ ] Create `src/pyeye/mcp/operations/outline.py` implementing `outline(handle, analyzer, max_depth=None, max_nodes=200)` as an `async` function (matching the surface; if the body does not actually await, document the "async for surface uniformity" reason inline so it does not read as an oversight)
+- [ ] Resolve the root via `inspect._find_jedi_name_for_handle` (the `trace` root pattern); build every node with `stubs.build_stub`; obtain children by calling `edges.resolve_members` and recursing on each carried `Name`
+- [ ] Implement BFS inclusion against the shared `max_nodes` budget, source-order (`(line_start, handle)`) presentation of siblings, the depth-frontier peek, and the no-peek budget/external cutoffs, per spec §5
+- [ ] Apply the external-scope cap (effective depth `min(max_depth, 1)` for `external` nodes; root still rendered with one member level)
+- [ ] Run the Task 1.1 tests so they pass
+- [ ] Run the full suite to confirm nothing else regressed
+- [ ] Commit
+
+**Constraint:** Inclusion order (BFS, for the budget) and presentation order (source, for `children`) are independent and must compose — BFS decides *which* nodes are in; the `(line_start, handle)` sort decides *how* each parent's kept children are arranged. Do not let one collapse into the other.
+
+**Constraint:** `max_depth=None` means unbounded *within scope* — the external cap and `max_nodes` still apply. The root is depth 0 and always counts as node 1.
+
+**Risk:** A large/wide module could blow up without the budget; confirm a large fixture (or a real `src/pyeye` module) returns a bounded tree quickly. **Do not** add any silent cap that hides nodes — every omission must surface as `truncated` + reason (the honesty principle). If a needed bound isn't covered by `max_depth`/`max_nodes`/external, raise it rather than hiding it.
+
+**Risk:** When both a depth/external cap and the node budget could apply to one node, `truncation_reason` reports `max_nodes` (the harder global bound) — a reporting tiebreaker only; `children` is omitted either way (spec §5.4).
+
+**Acceptance:** All Task 1.1 tests pass; full suite green; grep confirms `outline.py` introduces no `get_references`/`find_references` and no import from / edit to `edges.py` beyond *calling* `resolve_members`.
+
+---
+
+## Phase 2: MCP wire registration
+
+Surfaces `outline` as a callable tool. Small and mechanical, but gets its own phase + integration test because "works as a function" and "works over the wire" are different guarantees (the widening to plain-dict wire shape is where subtle shape drift hides).
+
+### Task 2.1: Register `outline` and prove it end-to-end
+
+- [ ] Modify `src/pyeye/mcp/server.py` to register `outline` as a new `@mcp.tool`, resolving the analyzer and widening the typed result to the plain-dict wire shape the same way `trace`/`inspect` do; do not modify existing tools
+- [ ] Write the tool docstring to state plainly what `outline` returns (a structural skeleton, no source content), the `max_depth`/`max_nodes` defaults, and — critically — the `children` absent⇔not-walked and `truncated` contracts, so an agent reading the tool description understands the absence semantics without reading the spec
+- [ ] Create `tests/integration/api_redesign/test_outline_integration.py` exercising `outline` over the wire against a real fixture project: a module skeleton; a depth-bounded call that exhibits the `truncated`/`truncation_reason` markers; and a count-consistency check asserting that for a fully-walked, non-truncated container `len(children)` equals `inspect(handle).edge_counts.members` (spec §6.4) — **because** both derive from `resolve_members` and this catches divergence between the two consumers
+- [ ] Run the integration tests so they pass
+- [ ] Run the full suite with coverage to confirm zero regressions and the threshold holds
+- [ ] Commit
+
+**Constraint:** The count-consistency check holds only for a container that is **not** truncated and **not** below the external cap — choose a fixture container small enough to be fully walked at the default bounds, or set bounds generously for that assertion.
+
+**Risk:** Wire-widening can silently drop or rename keys (e.g. the optional `children`/`truncated` absence). The integration test must assert the *absence* of `children` on a truncated node survives the wire, not just its presence on a walked one — absence is the easy thing for a serializer to mangle.
+
+**Acceptance:** `outline` discoverable and callable via the wire; integration tests pass including the absence-survives-the-wire and count-consistency assertions; full suite green at the coverage threshold.
+
+---
+
+## Phase 3: Conformance + docs
+
+Locks the contracts into the conformance suite (so future changes can't silently break the absence semantics) and records that the primitive shipped.
+
+### Task 3.1: Extend the conformance linter for `OutlineTree`
+
+- [ ] Modify `tests/conformance/response_linter.py` to recognise and validate the `OutlineTree` shape recursively: the Check A layering walk applies to every `node`; `node` is required and is a valid `Stub`; and the §4.2 invariants both directions — `truncated` present ⇒ value exactly `true` + `truncation_reason` one of the three enum values + `children` ABSENT; `truncated` absent ⇒ `truncation_reason` absent; `children` present ⇒ a list of `OutlineTree`
+- [ ] Create `tests/conformance/test_linter_adversarial_outline.py` asserting: a well-formed tree passes; a tree smuggling source content is rejected; `children: []` on a `truncated` node is rejected; `truncated: false` is rejected; `truncation_reason` without `truncated` is rejected; a non-`true` `truncated` value is rejected
+- [ ] Run the conformance suite so it passes
+- [ ] Commit
+
+**Constraint:** Reuse the existing Check A layering machinery (`_check_layering` and the recursive walk) — do not write a second source-content scanner. The new validation is structural (the §4.2 invariants); layering is already handled by the recursive walk and just needs to reach into `OutlineTree` nodes.
+
+**Risk:** The linter must recurse into `children` so a violation buried deep in the tree is caught, not just at the root. Add an adversarial test with the violation at depth ≥ 2 to prove the recursion reaches it.
+
+**Acceptance:** Linter accepts valid `OutlineTree`s and rejects each contract violation (including a deep one); conformance suite green.
+
+### Task 3.2: Record that `outline` shipped
+
+- [ ] Add a short implementation-status note to `docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md` recording that `outline` is implemented and that its refined absence/truncation contracts live in `docs/superpowers/specs/2026-06-13-outline-design.md` — mirroring the existing `edge_counts`/expand status notes; do not rewrite the original §`outline` section, just annotate it
+- [ ] Mark Phase 2 complete in `docs/superpowers/plans/2026-06-02-outline-expand-trace.md`, pointing to this plan and #355
+- [ ] Commit
+
+**Acceptance:** The parent design and parent plan both reflect that `outline` is built and point to the governing spec; no contradictory "deferred/unbuilt" language for `outline` remains.
+
+---
+
+## Verification gates between phases
+
+After each phase, before the next:
+
+- [ ] Full test suite green at the coverage threshold (run the whole suite, not just the new tests — the project's standard gate; note `-p no:randomly` gives a clean read for the known cache-test flake under coverage).
+- [ ] Pre-commit hooks pass with no bypass flags.
+- [ ] No `get_references` / `find_references` and no edit to `edges.py`/`resolve_members` introduced on the `outline` path (grep-verified).
+- [ ] New response shapes pass the conformance linter's layering check (no source content).
+
+## Rollout note
+
+Phase 1 is a pure additive win on already-shipped, reliable foundations and is safe to land independently. Phase 2 makes it real on the wire. Phase 3 locks the contracts and updates the record. `outline` completes the progressive-disclosure primitive set (`resolve`/`inspect`/`outline`/`expand`/`trace`); the remaining surface work is the deferred inbound/reference edges behind the Pyright backend (#333), which is unrelated to this plan.
+</content>

--- a/docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md
+++ b/docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md
@@ -253,6 +253,17 @@ Returns the structural skeleton of a module or class. No bodies. No metrics.
 
 **External-scope cap.** `outline(external_handle, max_depth=N)` treats `max_depth` as `min(N, 1)` — the immediate members of the external class or module are returned, but deeper nesting inside third-party code is not walked even if requested. This is consistent with the lazy-resolution principle for external symbols: agents wanting to walk deeper into installed packages call `inspect` per-member, which lazily resolves through Jedi/Pyright on demand. Predictable behavior; no eager dep-tree indexing.
 
+> **Implementation status (2026-06): `outline` is implemented.** The refined
+> `OutlineTree` shape — including the `max_nodes` budget, the depth-frontier
+> peek, and the two absence contracts (`children` absent ⇔ not-walked;
+> `truncated` absent-not-false) — is defined and governs in
+> `docs/superpowers/specs/2026-06-13-outline-design.md` (§4.2). This spec's
+> original `OutlineTree` type sketch above should be read as the initial design
+> intent; the 2026-06-13 spec resolves all open questions (node budget, external
+> cap, BFS inclusion vs. source-order presentation, linter invariants). The
+> conformance linter enforces both contracts in both directions (Check O). Issue:
+> #355.
+
 ### `expand(handle, edge, ...) → ExpandResult`
 
 Single-hop walk along one edge type. Paginated.

--- a/docs/superpowers/specs/2026-06-13-outline-design.md
+++ b/docs/superpowers/specs/2026-06-13-outline-design.md
@@ -102,6 +102,10 @@ OutlineTree = {
 
 `node` is exactly the §4.1 `Stub` (`handle`, `kind`, `scope`, optional
 `signature`, `line_start`, `line_end`) — no new fields, no source content.
+Implementation note: `Stub` is a *shape*, not a class — `stubs.build_stub`
+returns a plain `dict[str, Any]` (the established "widen to plain-dict wire
+shape" pattern). There is no `Stub` class to import; `outline` builds each
+`node` by calling `build_stub` and nests it.
 
 ### 4.2 The two absence contracts (load-bearing)
 
@@ -265,6 +269,12 @@ When both a depth/external cap *and* the node budget could apply to the same nod
 `max_nodes` takes precedence in `truncation_reason` (the budget is the harder
 global bound). This is a reporting tiebreaker only; in all cases `children` is
 omitted and the node is honestly marked cut-off.
+
+`truncation_reason` is deliberately a **single string** (one node has exactly
+one cut-off cause), unlike `trace`'s `truncation_reasons` **list** (one BFS can
+hit several caps across different frontier nodes). This divergence is
+intentional — do not "harmonise" `outline` to a list for false symmetry with
+`trace`.
 
 ### 5.5 Cycles / termination
 

--- a/docs/superpowers/specs/2026-06-13-outline-design.md
+++ b/docs/superpowers/specs/2026-06-13-outline-design.md
@@ -1,9 +1,9 @@
 # Outline design — `outline(handle)` structural skeleton
 
 **Date:** 2026-06-13
-**Issue:** TBD (to be filed before implementation)
+**Issue:** #355
 **Status:** design (pre-implementation)
-**Branch:** TBD (`feat/<issue>-outline`)
+**Branch:** `feat/355-outline`
 
 ## 1. Context & goal
 

--- a/docs/superpowers/specs/2026-06-13-outline-design.md
+++ b/docs/superpowers/specs/2026-06-13-outline-design.md
@@ -1,0 +1,332 @@
+# Outline design — `outline(handle)` structural skeleton
+
+**Date:** 2026-06-13
+**Issue:** TBD (to be filed before implementation)
+**Status:** design (pre-implementation)
+**Branch:** TBD (`feat/<issue>-outline`)
+
+## 1. Context & goal
+
+The redesigned pyeye API ships `resolve`/`resolve_at` (orient: "give me a handle"),
+`inspect` (orient: "what is this?"), and the traversal primitives `expand` (single
+hop) and `trace` (bounded BFS). `outline` is the **last unbuilt progressive-disclosure
+primitive** — Phase 2 of the reviewer-approved plan
+`docs/superpowers/plans/2026-06-02-outline-expand-trace.md`. Phases 1 (the shared
+`stubs.py` + `edges.py` foundation), 3 (`expand`), and 4 (`trace`) have all landed.
+
+`outline` returns the **structural skeleton of a module or class** — a tree of
+`(name, kind, signature, line span)` with no source content. The empirical analysis
+in the parent design (`docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md`,
+§Empirical anchor) flagged the *absence* of an outline primitive as the #1 shape
+failure in LSP-bridge MCPs: with no "structure of this scope" operation, an agent
+either assembles it from many `documentSymbol`/`definition` calls (agent-lsp: 7
+calls) or pulls full source (~13× the bytes of the skeleton it needed). `outline`
+is the single-call answer.
+
+This spec **refines** the `outline(handle) → Tree` section of the 2026-05-02 parent
+design with decisions made after that design was written — specifically the honesty
+conventions (`absence-vs-zero` applied to tree edges) that `expand` and `trace`
+established in practice, plus a node budget the parent design lacked. Where this
+spec and the 2026-05-02 section differ, **this spec governs** for `outline`.
+
+## 2. Scope
+
+**In:**
+
+- `src/pyeye/mcp/operations/outline.py` — `outline(handle, max_depth, max_nodes)`
+  recursive `members` walk → `OutlineTree`. Pure consumer of the existing edge
+  registry.
+- `src/pyeye/mcp/server.py` — register one new `@mcp.tool`: `outline`.
+- `tests/conformance/response_linter.py` — `OutlineTree` shape + the two absence
+  contracts (§4.2), plus adversarial tests.
+- Unit + integration tests.
+
+**Out (explicitly not this slice):**
+
+- Any new edge or any change to `edges.py` / `resolve_members`. `outline` is a
+  registry *consumer* (like `trace`); it adds **no** edge-resolution logic.
+- Pagination/cursors (that is `expand`'s concern; an outline tree is delivered
+  whole, bounded by `max_depth`/`max_nodes`).
+- Filters (`include_tests` / `module_pattern` / `same_package`) — `outline` walks
+  `members` only; scope filtering belongs to `expand`/`trace`.
+- Walking any edge other than `members` (no `callees`/`subclasses`/etc. in the
+  tree — those are `expand`/`trace`).
+
+## 3. Architecture
+
+### 3.1 Components / file map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/pyeye/mcp/operations/outline.py` | Create | `outline(handle, analyzer, max_depth=None, max_nodes=200)` — BFS-bounded recursive `members` walk, building each node with `build_stub`, returning a nested `OutlineTree`. |
+| `src/pyeye/mcp/server.py` | Modify | Register `outline` as a new `@mcp.tool`, widening the typed result to the plain-dict wire shape (same pattern as `resolve`/`inspect`/`trace`). Existing tools untouched. |
+| `tests/conformance/response_linter.py` | Modify | Validate the `OutlineTree` shape: layering (no source content), required `node` key, the `children` absence contract, and the `truncated`/`truncation_reason` invariants (§4.2). |
+| `tests/unit/mcp/operations/test_outline.py` | Create | Tree shape per kind; depth bounding; node-budget cutoff; external cap; the genuine-leaf-vs-truncated distinction; source ordering. |
+| `tests/integration/api_redesign/test_outline_integration.py` | Create | End-to-end via the MCP wire format against a real fixture project. |
+| `tests/conformance/test_linter_adversarial_outline.py` | Create | Well-formed passes; source-content smuggling rejected; `children: []` on a `truncated` node rejected; `truncated: false` rejected. |
+
+### 3.2 Reuse (no new machinery)
+
+`outline` introduces no analysis logic. It composes existing, battle-tested units:
+
+- **`edges.resolve_members(jedi_name, analyzer) → EdgeResult`** — the single
+  member-enumeration source (the same one `inspect.edge_counts.members` and
+  `expand(handle, "members")` use). Returns `(Handle, Name)` pairs as
+  `EdgeResult.adjacents`, so each child's Jedi `Name` is **carried** — `outline`
+  recurses by calling `resolve_members` on that carried `Name`, never
+  re-resolving a handle.
+- **`stubs.build_stub(jedi_name, handle, analyzer) → Stub`** — builds every
+  `node`. `build_stub` already returns `scope`, which the external cap reads.
+- **`inspect._find_jedi_name_for_handle(handle, analyzer)`** — resolves the root
+  handle to a Jedi `Name` (identical to how `trace` resolves its roots).
+
+Because `resolve_members` returns `[]` for non-containers, recursion terminates
+naturally: a `function`/`method`/`variable`/`attribute`/`property` node is always
+a leaf. Nested classes recurse; class methods are leaves (a method has no
+`members`); **function bodies are never walked** — the recursion follows the
+`members` edge (module → class/function, class → method/nested-class), not
+statements inside a function.
+
+## 4. Response shape
+
+### 4.1 `OutlineTree`
+
+```text
+OutlineTree = {
+  "node":      Stub,                  # ALWAYS present (spec §4.1 Stub)
+  "children":  [OutlineTree, ...],    # see §4.2 — present iff the node was walked
+  "truncated": true,                  # see §4.2 — present ONLY on cut-off nodes
+  "truncation_reason": "max_depth" | "max_nodes" | "external",  # iff truncated
+}
+```
+
+`node` is exactly the §4.1 `Stub` (`handle`, `kind`, `scope`, optional
+`signature`, `line_start`, `line_end`) — no new fields, no source content.
+
+### 4.2 The two absence contracts (load-bearing)
+
+These apply the `absence-vs-zero` invariant (the same principle behind
+`inspect.edge_counts` omissions and `expand`'s unsupported-edge signal) to the
+tree. They are the reason `outline` is honest rather than merely cheap, and the
+conformance linter enforces both.
+
+**Contract 1 — `children` absent ⇔ not expanded.**
+
+- `children` **present** (including `children: []`) means *measured: this is the
+  complete set of the node's direct members*. `children: []` is a genuine leaf —
+  a container with no members, or any non-container.
+- `children` **absent** means *we did not walk this node* (a cap fired). A
+  consumer MUST treat a missing `children` as "unknown," never as "empty."
+
+This is what stops a cut-off container from impersonating a genuine leaf — the
+exact `absence-vs-zero` failure (#332) the whole surface guards against. Emitting
+`children: []` for a depth-capped class would falsely read as "this class has no
+members."
+
+**Contract 2 — `truncated` is absent-not-false.**
+
+- `truncated: true` is present **only** on a node that a cap cut off; it always
+  co-occurs with `truncation_reason` and with an **absent** `children`.
+- A fully-walked node OMITS `truncated` entirely (never `truncated: false`) —
+  same idiom as a `Stub` omitting `signature` and `inspect` omitting an unmeasured
+  edge count. No `truncated: false` noise anywhere in the tree.
+
+Linter invariants (both directions):
+
+- `truncated` present ⇒ value is exactly `true`, `truncation_reason` present and
+  one of the three enum values, and `children` ABSENT. (`truncated: false`
+  rejected; a `truncated` node carrying `children` rejected.)
+- `truncated` absent ⇒ `truncation_reason` absent.
+- `children` present ⇒ it is a list (possibly empty) of `OutlineTree`.
+
+### 4.3 Worked example
+
+```jsonc
+// outline("pkg.widgets", max_depth=2)  — module with two classes
+{
+  "node": { "handle": "pkg.widgets", "kind": "module", "scope": "project",
+            "line_start": 1, "line_end": 1 },
+  "children": [
+    { "node": { "handle": "pkg.widgets.Widget", "kind": "class",
+                "scope": "project", "signature": "Widget(name: str)",
+                "line_start": 10, "line_end": 48 },
+      "children": [                         // depth 1 → walked
+        { "node": { "handle": "pkg.widgets.Widget.render", "kind": "method",
+                    "signature": "render(self) -> str", "scope": "project",
+                    "line_start": 12, "line_end": 14 },
+          "children": [] },                 // method: genuine leaf
+        { "node": { "handle": "pkg.widgets.Widget.Style", "kind": "class",
+                    "scope": "project", "line_start": 20, "line_end": 30 },
+          "truncated": true,                // nested class AT depth 2 frontier,
+          "truncation_reason": "max_depth"  // peek found members → cut off
+                                            // (no "children" key)
+        }
+      ] },
+    { "node": { "handle": "pkg.widgets.helper", "kind": "function",
+                "signature": "helper() -> None", "scope": "project",
+                "line_start": 50, "line_end": 52 },
+      "children": [] }                      // function: genuine leaf
+  ]
+}
+```
+
+`Widget.render` (method) and `helper` (function) carry `children: []` — measured
+leaves. `Widget.Style` (nested class at the `max_depth=2` frontier) carries
+`truncated`/`truncation_reason` and NO `children` — its members exist but were not
+walked. The two are unmistakable to the consumer.
+
+## 5. Semantics
+
+### 5.1 Signature
+
+```python
+async def outline(
+    handle: str,
+    analyzer: JediAnalyzer,
+    max_depth: int | None = None,
+    max_nodes: int = 200,
+) -> dict[str, Any]
+```
+
+- `max_depth=None` → unbounded within scope (the parent-design default). The root
+  is depth 0.
+- `max_nodes=200` → total-node budget (the parent design had none; see §5.4). The
+  root always counts as 1 and is always included.
+- Returns the root `OutlineTree`. Never raises; an unresolvable root yields a
+  minimal single-node tree (mirroring `inspect`'s minimal-node fallback), with
+  `children: []`.
+
+`async` matches the surrounding tool surface (`inspect`/`trace` are async) and
+leaves room for an async edge in the tree later. Whether the body actually awaits
+(`resolve_members` is sync today) is an implementation detail settled in the plan;
+if it does not await, document the "async for surface uniformity" reason inline so
+it does not read as an oversight.
+
+### 5.2 Traversal: BFS inclusion, source-order presentation
+
+Two orderings, deliberately independent:
+
+- **Inclusion order is BFS (level-order).** Nodes are discovered and admitted to
+  the budget breadth-first by depth. This makes the `max_nodes` cutoff degrade
+  gracefully — "all of depth 1, most of depth 2" — rather than DFS burning the
+  whole budget on the first subtree and never showing its siblings.
+- **Presentation order is source order.** Within each parent, `children` are
+  sorted by `(line_start, handle)`. The skeleton reads top-to-bottom like the
+  file an agent will `Read` next, so `line_start` values climb monotonically as it
+  scans. The `handle` tiebreaker keeps order total and deterministic in the
+  (degenerate) case of equal `line_start`.
+
+Source order is fully deterministic (line numbers are a file property), so it
+gives up nothing on stability/caching/test-repeatability versus a handle sort —
+it strictly adds information (authorial co-location is preserved). This diverges
+from `subclasses`/`imported_by`, which sort by handle **out of necessity** (their
+members span files and arrive in `PYTHONHASHSEED`-dependent set order with no
+single source order to fall back on); a single container's `members` are
+same-file and have a real source order, so that precedent does not transfer.
+
+### 5.3 Depth frontier peeks; budget/external cutoffs do not
+
+To honour Contract 1, `outline` must distinguish a genuine empty leaf from a
+cut-off container. The rule differs by cause:
+
+- **`max_depth` frontier — peek.** At `depth == max_depth`, call `resolve_members`
+  once on the node (one hop, do not recurse). Empty → emit `children: []` (genuine
+  leaf). Non-empty → emit `truncated: "max_depth"`, omit `children`. This mirrors
+  `trace` resolving edges one hop past its frontier to detect truncation.
+- **`max_nodes` — do not peek.** When the budget is exhausted, a not-yet-expanded
+  container is marked `truncated: "max_nodes"` with `children` omitted, WITHOUT
+  calling `resolve_members` — peeking would defeat the budget. Honest: "didn't
+  walk," not a false `[]`.
+- **`external` cap — do not peek deeper.** See §5.4.
+
+### 5.4 Bounds
+
+**Node budget (`max_nodes`, default 200).** The parent design bounded `outline`
+only by scope + `max_depth`; a large package or wide module could still produce an
+unbounded tree (the parent plan's Phase 2 Risk note flagged exactly this). A node
+budget bounds worst-case size. It is safe *because* Contract 1/2 land with it: a
+budget cutoff is surfaced honestly (`truncated: "max_nodes"`), never as silently
+dropped/empty nodes. Default 200 (higher than `trace`'s 50 — an outline is a cheap
+structural skeleton meant to show a whole module, whereas a trace deliberately
+samples a neighbourhood). The root counts as node 1.
+
+**External-scope cap.** For a node whose `scope` is `external`, effective depth is
+`min(max_depth, 1)`: the immediate members of an external class/module are
+returned, but pyeye does not walk deeper into third-party code even if a larger
+`max_depth` was requested. A container that would recurse past that one level is
+cut off with `truncated: "external"`, `children` omitted (no peek deeper — that is
+the point of the cap). This matches the lazy-resolution principle for external
+symbols already stated in the parent design: agents wanting to go deeper into an
+installed package call `inspect`/`outline` on a specific member. The root itself,
+even if external, is always rendered with one level of members (subject to the
+node budget).
+
+When both a depth/external cap *and* the node budget could apply to the same node,
+`max_nodes` takes precedence in `truncation_reason` (the budget is the harder
+global bound). This is a reporting tiebreaker only; in all cases `children` is
+omitted and the node is honestly marked cut-off.
+
+### 5.5 Cycles / termination
+
+The `members` edge is a strict containment hierarchy (module ⊃ class ⊃
+method/nested-class), which is acyclic, so unlike `trace` there is no cycle to
+guard. Termination is guaranteed by: natural leaves (`resolve_members` → `[]`),
+`max_depth`, and `max_nodes`. Each node is built exactly once.
+
+## 6. Honesty / layering invariants (enforced by the linter)
+
+1. **No source content** anywhere in the tree — every `node` is a `Stub`; the
+   existing Check A layering walk applies to the whole `OutlineTree` recursively.
+2. **Contract 1** (`children` absent ⇔ not expanded) and **Contract 2**
+   (`truncated` absent-not-false, co-occurs with `truncation_reason` and absent
+   `children`) per §4.2.
+3. **`members`-only.** No edge other than `members` ever contributes a child —
+   `outline` does not smuggle `callees`/`subclasses`/references into the tree.
+4. **Count consistency.** For a fully-walked container (one with `children`
+   present and not `truncated`), `len(children) == inspect(handle).edge_counts.members`
+   — because both derive from `resolve_members`. (Holds only when the node is not
+   truncated and the container was not below the external cap.)
+
+## 7. Test strategy
+
+- **Unit (`test_outline.py`):** module root → top-level classes/functions as
+  children; class root → methods/nested classes; nested-class recursion; methods
+  and functions are `children: []` leaves; `max_depth` bounds recursion and the
+  frontier peek yields genuine `[]` vs `truncated: "max_depth"`; `max_nodes`
+  cutoff marks excess containers `truncated: "max_nodes"` with no `children`;
+  external handle capped at one level (`truncated: "external"`); children sorted by
+  `(line_start, handle)`; unresolvable root → minimal single-node tree.
+- **Conformance (`response_linter.py` + `test_linter_adversarial_outline.py`):**
+  the §4.2 invariants in both directions — valid tree passes; `children: []` on a
+  `truncated` node rejected; `truncated: false` rejected; `truncation_reason`
+  without `truncated` rejected; source content anywhere rejected.
+- **Integration (`test_outline_integration.py`):** `outline` over the MCP wire
+  against a real fixture project — a module skeleton, a depth-bounded call showing
+  the truncation markers, and the §6.4 count-consistency check against
+  `inspect(...).edge_counts.members` for a fully-walked container.
+- **Grep gate:** `outline.py` introduces no `get_references`/`find_references`
+  call (it only consumes `resolve_members`, already grep-clean).
+
+## 8. Acceptance criteria
+
+1. `outline` callable on the MCP wire, returning an `OutlineTree` for module and
+   class handles.
+2. The §4.2 absence contracts hold and are linter-enforced in both directions.
+3. `max_depth`, `max_nodes`, and the external cap each bound the tree and surface
+   their cutoff honestly via `truncated`/`truncation_reason`.
+4. Children are in source order; inclusion under budget is breadth-first.
+5. No source content; no new edge logic; no change to `edges.py`/`resolve_members`.
+6. Full suite green at the coverage threshold; pre-commit clean; no
+   `get_references` on the `outline` path.
+
+## 9. Open questions
+
+- **Issue/branch:** to be filed (the parent plan landed `expand`/`trace`
+  incrementally on a dev branch; `outline` should get its own issue for
+  traceability, consistent with #348 `subclasses`).
+- **`async` body:** confirmed `async def` for surface uniformity; the plan decides
+  whether the implementation awaits anything today or documents the no-await
+  rationale inline.
+</content>
+
+</invoke>

--- a/src/pyeye/mcp/operations/outline.py
+++ b/src/pyeye/mcp/operations/outline.py
@@ -153,7 +153,7 @@ async def outline(
     # 3. BFS — decide whether to expand each node, build children.
     # ------------------------------------------------------------------
     while queue:
-        jedi_name, node_handle, depth, tree_node = queue.popleft()
+        jedi_name, _, depth, tree_node = queue.popleft()
         stub = tree_node["node"]
         kind = stub["kind"]
         scope = stub["scope"]

--- a/src/pyeye/mcp/operations/outline.py
+++ b/src/pyeye/mcp/operations/outline.py
@@ -1,0 +1,256 @@
+"""outline(handle) — structural skeleton of a module or class.
+
+Returns a nested ``OutlineTree`` — a tree of ``(node, children?)`` entries
+covering the ``members`` hierarchy of the given handle, with no source content.
+
+Two load-bearing absence contracts (spec §4.2) guard the response:
+
+**Contract 1 — ``children`` absent ⇔ not expanded.**
+``children`` present (including ``[]``) means *measured*: the complete set of
+direct members.  ``children`` absent means a cap fired; the consumer MUST treat
+it as "unknown," never "empty."
+
+**Contract 2 — ``truncated`` absent-not-false.**
+``truncated: true`` is present ONLY on a node that a cap cut off, always
+co-occurring with ``truncation_reason`` and an absent ``children``.  Fully-walked
+nodes OMIT ``truncated`` entirely — never ``truncated: false``.
+
+``outline`` is a pure *consumer* of the existing edge registry (spec §2 "Out"):
+it CALLS ``edges.resolve_members`` and ``stubs.build_stub``; it adds NO new edge
+logic and MUST NOT modify ``edges.py``/``resolve_members``.
+
+Public API
+----------
+.. code-block:: python
+
+    tree = await outline("mypackage._core.widgets.Widget", analyzer)
+    # → {"node": Stub, "children": [...OutlineTree...]}
+
+    tree = await outline("mypackage._core.widgets", analyzer, max_depth=2)
+    # → root with children; containers at depth 2 are truncated
+
+``async def`` matches the surrounding tool surface (``inspect``/``trace`` are
+async) and leaves room for an async edge resolver in the future.  The body does
+not currently await — ``resolve_members`` is synchronous today — but the
+``async`` signature is kept for surface uniformity with the rest of the API.
+
+Truncation reasons (spec §5.4)
+-------------------------------
+- ``"max_depth"`` — node is at the depth frontier and has non-empty members
+  (detected by a single peek call to ``resolve_members``).  Genuine empty
+  containers at the frontier receive ``children: []`` instead of truncation.
+- ``"max_nodes"`` — the node budget is exhausted.  No peek is performed.
+- ``"external"`` — the node is an external-scope container at depth ≥ 1.  The
+  external cap allows one level of members from the root and one from its
+  immediate children, but no deeper walk into third-party code.  No peek.
+
+Tiebreaker (spec §5.4): when both ``max_nodes`` AND ``max_depth``/``external``
+could fire on the same node, ``truncation_reason`` is ``"max_nodes"`` (the harder
+global bound).  In all cases ``children`` is omitted.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import TYPE_CHECKING, Any
+
+from pyeye.mcp.operations.edges import resolve_members
+from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
+from pyeye.mcp.operations.stubs import build_stub
+
+if TYPE_CHECKING:
+    from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+
+# ---------------------------------------------------------------------------
+# Truncation reason constants (single string per node — not a list; see spec §5.4)
+# ---------------------------------------------------------------------------
+
+_REASON_MAX_DEPTH: str = "max_depth"
+_REASON_MAX_NODES: str = "max_nodes"
+_REASON_EXTERNAL: str = "external"
+
+# ---------------------------------------------------------------------------
+# Container kinds — resolve_members returns [] for non-containers by definition,
+# so non-container nodes always get children: [] without calling resolve_members.
+# ---------------------------------------------------------------------------
+
+_CONTAINER_KINDS: frozenset[str] = frozenset({"class", "module"})
+
+
+def _is_container(kind: str) -> bool:
+    """Return True if *kind* is a container (class or module) that can have members."""
+    return kind in _CONTAINER_KINDS
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def outline(
+    handle: str,
+    analyzer: JediAnalyzer,
+    max_depth: int | None = None,
+    max_nodes: int = 200,
+) -> dict[str, Any]:
+    """Return the structural skeleton of *handle* as a nested ``OutlineTree``.
+
+    Walks the ``members`` edge from *handle* via BFS-bounded recursion, building
+    each node with ``stubs.build_stub`` and stopping at depth, budget, or
+    external-scope limits.  The §4.2 absence contracts are enforced on every node:
+
+    - ``children`` present ⇔ the node was expanded (walked).
+    - ``truncated: true`` + ``truncation_reason`` present ⇔ a cap prevented expansion.
+    - Fully-walked nodes omit ``truncated`` entirely.
+
+    Args:
+        handle: Canonical dotted-name handle of the root symbol.
+        analyzer: Configured ``JediAnalyzer`` for the project.
+        max_depth: Maximum depth of recursion from the root (depth 0).  ``None``
+            means unbounded within scope (the external cap and ``max_nodes`` still
+            apply regardless).
+        max_nodes: Maximum total nodes in the tree (root counts as 1, default
+            200).  Containers that cannot be expanded due to an exhausted budget
+            are marked ``truncated: "max_nodes"`` without peeking.
+
+    Returns:
+        A nested ``OutlineTree`` dict.  Never raises; an unresolvable root
+        yields a minimal single-node tree ``{"node": ..., "children": []}``.
+
+    Note:
+        ``async def`` for surface uniformity with ``inspect``/``trace``.  The body
+        does not currently await — ``resolve_members`` is synchronous today.
+    """
+    # ------------------------------------------------------------------
+    # 1. Resolve root handle to a Jedi Name.
+    # ------------------------------------------------------------------
+    root_jedi_name = _find_jedi_name_for_handle(handle, analyzer)
+
+    if root_jedi_name is None:
+        # Unresolvable — return minimal single-node fallback (mirrors inspect).
+        # We need a minimal stub; build a placeholder with what we know.
+        stub = _make_fallback_stub(handle)
+        return {"node": stub, "children": []}
+
+    root_stub = build_stub(root_jedi_name, handle, analyzer)
+
+    # ------------------------------------------------------------------
+    # 2. Build root tree node and initialise BFS state.
+    # ------------------------------------------------------------------
+    root_tree: dict[str, Any] = {"node": root_stub}
+
+    # node_count tracks every node added to the tree (root + all children).
+    # The root always counts as node 1.
+    node_count: int = 1
+
+    # BFS queue entries: (jedi_name, handle_str, depth, tree_node_dict)
+    # tree_node_dict is the MUTABLE dict for this node — we fill in "children"
+    # or "truncated"/"truncation_reason" as we process it.
+    queue: deque[tuple[Any, str, int, dict[str, Any]]] = deque()
+    queue.append((root_jedi_name, handle, 0, root_tree))
+
+    # ------------------------------------------------------------------
+    # 3. BFS — decide whether to expand each node, build children.
+    # ------------------------------------------------------------------
+    while queue:
+        jedi_name, node_handle, depth, tree_node = queue.popleft()
+        stub = tree_node["node"]
+        kind = stub["kind"]
+        scope = stub["scope"]
+
+        # Non-containers: always a genuine leaf (resolve_members always returns
+        # [] for them — no need to call it, no budget consumed for the peek).
+        if not _is_container(kind):
+            tree_node["children"] = []
+            continue
+
+        # --- Container: determine which cap (if any) fires. ---
+
+        # TIEBREAKER (spec §5.4): budget check wins over depth/external.
+        # Check it FIRST so that when both could fire, we report "max_nodes".
+        if node_count >= max_nodes:
+            # Budget is full; this container was added but cannot be expanded.
+            # No peek — that would defeat the budget.
+            tree_node["truncated"] = True
+            tree_node["truncation_reason"] = _REASON_MAX_NODES
+            continue
+
+        # External-scope cap: external containers at depth ≥ 1 are capped.
+        # The root (depth 0) always gets one level of members even if external.
+        if scope == "external" and depth >= 1:
+            # No peek deeper into third-party code.
+            tree_node["truncated"] = True
+            tree_node["truncation_reason"] = _REASON_EXTERNAL
+            continue
+
+        # Depth-frontier peek (spec §5.3): at max_depth, call resolve_members
+        # ONCE to distinguish genuine empty containers from cut-off ones.
+        if max_depth is not None and depth >= max_depth:
+            adjacents = resolve_members(jedi_name, analyzer).adjacents
+            if not adjacents:
+                # Genuine empty container (no members).
+                tree_node["children"] = []
+            else:
+                # Has members but cannot be walked — cut off.
+                tree_node["truncated"] = True
+                tree_node["truncation_reason"] = _REASON_MAX_DEPTH
+            continue
+
+        # --- Expand: add children and enqueue for BFS. ---
+
+        adjacents = resolve_members(jedi_name, analyzer).adjacents
+
+        children: list[dict[str, Any]] = []
+        for child_handle, child_jedi_name in adjacents:
+            # Budget: add a child only if there is room.
+            if node_count >= max_nodes:
+                # Budget exhausted mid-expansion: remaining children silently
+                # not added.  (The parent's children list is partial, but the
+                # contract does not require a sentinel — the consumer can infer
+                # incompleteness from any truncated nodes elsewhere in the tree
+                # and from the tree's overall node count vs the budget.)
+                break
+
+            child_handle_str = str(child_handle)
+            child_stub = build_stub(child_jedi_name, child_handle_str, analyzer)
+            child_tree: dict[str, Any] = {"node": child_stub}
+            children.append(child_tree)
+            node_count += 1
+            queue.append((child_jedi_name, child_handle_str, depth + 1, child_tree))
+
+        # Sort children by (line_start, handle) — source order (spec §5.2).
+        # BFS inclusion order is independent of presentation order: BFS decides
+        # WHICH nodes are in the tree; (line_start, handle) decides HOW they are
+        # arranged within each parent's children list.
+        children.sort(key=lambda t: (t["node"]["line_start"], t["node"]["handle"]))
+
+        tree_node["children"] = children
+
+    return root_tree
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fallback_stub(handle: str) -> dict[str, Any]:
+    """Build a minimal fallback stub for an unresolvable *handle*.
+
+    Mirrors ``inspect``'s minimal-node fallback: returns a dict with all
+    required Stub fields populated with reasonable defaults so the caller can
+    return a well-formed (but clearly minimal) ``OutlineTree``.
+
+    Args:
+        handle: The unresolvable handle string.
+
+    Returns:
+        A dict with ``handle``, ``kind``, ``scope``, ``line_start``, ``line_end``.
+    """
+    return {
+        "handle": handle,
+        "kind": "variable",  # safest default for an unknown symbol
+        "scope": "external",
+        "line_start": 1,
+        "line_end": 1,
+    }

--- a/src/pyeye/mcp/operations/outline.py
+++ b/src/pyeye/mcp/operations/outline.py
@@ -128,7 +128,6 @@ async def outline(
 
     if root_jedi_name is None:
         # Unresolvable — return minimal single-node fallback (mirrors inspect).
-        # We need a minimal stub; build a placeholder with what we know.
         stub = _make_fallback_stub(handle)
         return {"node": stub, "children": []}
 
@@ -143,17 +142,17 @@ async def outline(
     # The root always counts as node 1.
     node_count: int = 1
 
-    # BFS queue entries: (jedi_name, handle_str, depth, tree_node_dict)
+    # BFS queue entries: (jedi_name, depth, tree_node_dict)
     # tree_node_dict is the MUTABLE dict for this node — we fill in "children"
     # or "truncated"/"truncation_reason" as we process it.
-    queue: deque[tuple[Any, str, int, dict[str, Any]]] = deque()
-    queue.append((root_jedi_name, handle, 0, root_tree))
+    queue: deque[tuple[Any, int, dict[str, Any]]] = deque()
+    queue.append((root_jedi_name, 0, root_tree))
 
     # ------------------------------------------------------------------
     # 3. BFS — decide whether to expand each node, build children.
     # ------------------------------------------------------------------
     while queue:
-        jedi_name, _, depth, tree_node = queue.popleft()
+        jedi_name, depth, tree_node = queue.popleft()
         stub = tree_node["node"]
         kind = stub["kind"]
         scope = stub["scope"]
@@ -216,7 +215,7 @@ async def outline(
             child_tree: dict[str, Any] = {"node": child_stub}
             children.append(child_tree)
             node_count += 1
-            queue.append((child_jedi_name, child_handle_str, depth + 1, child_tree))
+            queue.append((child_jedi_name, depth + 1, child_tree))
 
         # Sort children by (line_start, handle) — source order (spec §5.2).
         # BFS inclusion order is independent of presentation order: BFS decides

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -53,6 +53,7 @@ from ..validation import validate_mcp_inputs
 from .lookup import lookup as _lookup_impl
 from .operations.expand import expand as _expand_impl
 from .operations.inspect import inspect as _inspect_impl
+from .operations.outline import outline as _outline_impl
 from .operations.resolve import (
     resolve as _resolve_impl,
     resolve_at as _resolve_at_impl,
@@ -642,6 +643,79 @@ async def trace(
             stop_when=stop_when,
         )
     )
+
+
+@mcp.tool()
+@validate_mcp_inputs
+@metrics.measure("outline")
+@track_mcp_operation("outline")
+async def outline(
+    handle: str,
+    project_path: str = ".",
+    max_depth: int | None = None,
+    max_nodes: int = 200,
+) -> dict[str, Any]:
+    """Python: Structural skeleton of a module or class — names, kinds, signatures, line spans.
+
+    Returns a nested ``OutlineTree`` — the ``members`` hierarchy of *handle* as a
+    tree of lightweight structural nodes (``Stub``).  Each node carries
+    ``handle``, ``kind``, ``scope``, ``line_start``, ``line_end``, and
+    ``signature`` when Jedi yields one.  No source content anywhere in the tree.
+
+    Use ``resolve()`` or ``inspect()`` first to obtain a canonical handle, then
+    ``outline()`` to see the complete structural skeleton in one call — the
+    single-call answer to "show me the structure of this scope."
+
+    **Absence contracts — an agent MUST read these before consuming the tree.**
+
+    *Contract 1 — ``children`` absent ⇔ not expanded.*
+
+    ``children`` present (including ``children: []``) means *measured*: the
+    complete set of direct members of this node.  ``children: []`` is a genuine
+    leaf — a container with no members, or a non-container (function/method/
+    variable).  ``children`` **absent** means a cap fired and this node was not
+    walked — treat it as "unknown," **never as empty.**
+
+    *Contract 2 — ``truncated`` absent-not-false.*
+
+    ``truncated: true`` is present **only** on a node that a cap cut off; it
+    always co-occurs with ``truncation_reason`` and an **absent** ``children``.
+    Fully-walked nodes omit ``truncated`` entirely — ``truncated: false`` never
+    appears.
+
+    **Truncation reasons (one string per node — not a list):**
+
+    - ``"max_depth"`` — at the depth frontier; ``resolve_members`` was peeked
+      once and found members (a genuine empty container at the frontier gets
+      ``children: []`` instead).
+    - ``"max_nodes"`` — total-node budget exhausted; no peek performed.
+    - ``"external"`` — external-scope container at depth ≥ 1; no deeper walk
+      into third-party code.
+
+    When both ``max_nodes`` AND a depth/external cap could apply to the same
+    node, ``truncation_reason`` is ``"max_nodes"`` (the harder global bound).
+
+    Args:
+        handle: Canonical Python dotted-name string (from resolve/inspect).
+        project_path: Project root path (default: current directory).
+        max_depth: Maximum depth from the root (root is depth 0).  ``None``
+            means unbounded within scope; the external cap and ``max_nodes``
+            still apply.  At the frontier, ``resolve_members`` is peeked once
+            to distinguish a genuine empty container from a cut-off one.
+        max_nodes: Total-node budget for the tree (root counts as 1, default
+            200).  Containers that exceed the budget are marked
+            ``truncated: "max_nodes"`` without peeking.
+
+    Returns:
+        ``OutlineTree`` dict — ``{"node": Stub, "children": [OutlineTree, ...]}``.
+        Never raises; an unresolvable handle yields a minimal single-node tree
+        with ``children: []``.  Children within each parent are in source order
+        (sorted by ``line_start``); BFS inclusion order bounds the budget
+        gracefully (all of depth 1 before any of depth 2, etc.).
+    """
+    analyzer = get_analyzer(project_path)
+    # dict(...) widens the operation's return to plain dict[str, Any] for the wire.
+    return dict(await _outline_impl(handle, analyzer, max_depth=max_depth, max_nodes=max_nodes))
 
 
 # NOTE: superseded by future expand(handle, edge="references"); kept until Phase B migration.

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -710,7 +710,7 @@ async def outline(
         ``OutlineTree`` dict — ``{"node": Stub, "children": [OutlineTree, ...]}``.
         Never raises; an unresolvable handle yields a minimal single-node tree
         with ``children: []``.  Children within each parent are in source order
-        (sorted by ``line_start``); BFS inclusion order bounds the budget
+        (sorted by ``(line_start, handle)``); BFS inclusion order bounds the budget
         gracefully (all of depth 1 before any of depth 2, etc.).
     """
     analyzer = get_analyzer(project_path)

--- a/tests/conformance/response_linter.py
+++ b/tests/conformance/response_linter.py
@@ -77,6 +77,24 @@ T.4 Each ``unsupported_edges`` entry is ``{edge, reason, detail}`` with ``reason
 T.5 ``truncation_reasons`` is a list of valid causes (``max_depth`` / ``max_nodes``)
     and is consistent with ``truncated`` (true iff the list is non-empty).
 
+Check O — outline OutlineTree structural floors (operation == "outline")
+------------------------------------------------------------------------
+O.1 ``node`` is REQUIRED and passes the Stub structural floor (S.*).
+O.2 ``truncated`` present ⇒ value is exactly ``true`` (absent-not-false contract),
+    ``truncation_reason`` present and in the outline enum
+    {``max_depth``, ``max_nodes``, ``external``}, and ``children`` ABSENT.
+    ``truncated: false`` is rejected.  A truncated node carrying ``children``
+    (even ``children: []``) is rejected (Contract 1 — absent ⇔ not expanded).
+O.3 ``truncated`` absent ⇒ ``truncation_reason`` absent.
+O.4 ``children`` present ⇒ it is a list (possibly empty) of OutlineTree; each
+    item is validated recursively (applies the same O.* + A.* rules at every
+    depth).
+
+Note: Check A layering (no source content) is applied to the whole tree by
+``_check_layering`` / ``_walk``, which already recurses into nested dicts and
+lists.  No second traversal is needed in Check O — the existing walk reaches
+``node`` Stubs and ``children`` items at any depth automatically.
+
 Usage
 -----
 ::
@@ -641,7 +659,16 @@ _VALID_UNSUPPORTED_REASONS: frozenset[str] = frozenset(
 _VALID_STUB_SCOPES: frozenset[str] = frozenset({"project", "external"})
 
 # T.1 — Valid trace truncation-cause values.
+# IMPORTANT: This is TRACE's enum only.  Do NOT extend it with "external" — that
+# would silently loosen trace validation.  Outline uses a separate constant below.
 _VALID_TRUNCATION_REASONS: frozenset[str] = frozenset({"max_depth", "max_nodes"})
+
+# O.2 — Valid outline truncation_reason values (superset of trace's: adds "external").
+# Outline's external cap fires when a subtree of an external node is not walked;
+# trace never emits "external" as a per-node reason, so the two enums are kept apart.
+_VALID_OUTLINE_TRUNCATION_REASONS: frozenset[str] = frozenset(
+    {"max_depth", "max_nodes", "external"}
+)
 
 # ---------------------------------------------------------------------------
 # Check S — Stub structural-floor helpers
@@ -1133,6 +1160,147 @@ def _check_trace_structural_floor(
 
 
 # ---------------------------------------------------------------------------
+# Check O — OutlineTree structural-floor helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_outline_tree_node(
+    tree: Any,
+    path: str,
+    violations: list[str],
+) -> None:
+    """O.1–O.4 — Validate one OutlineTree node recursively.
+
+    Layering (A.*) is run separately by ``_check_layering`` which already
+    recurses into the whole response dict/list tree, so every ``node`` Stub
+    and every ``children`` list item is covered automatically.
+
+    O.1 ``node`` is REQUIRED and passes the Stub structural floor (S.*).
+    O.2 ``truncated`` present ⇒ value is exactly ``True`` (not false, not a
+        string), ``truncation_reason`` is present and in the outline enum,
+        and ``children`` is ABSENT.  ``truncated: False`` is rejected.
+    O.3 ``truncated`` absent ⇒ ``truncation_reason`` absent.
+    O.4 ``children`` present ⇒ it is a list (possibly empty) of OutlineTree;
+        each item is validated recursively.
+
+    Args:
+        tree: The candidate OutlineTree value (should be a dict).
+        path: Path prefix for error messages (e.g. ``"children[0]"``).
+        violations: Mutable list to append violation messages to.
+    """
+    if not isinstance(tree, dict):
+        violations.append(
+            f"[O.1 outline tree type] {path!r}: expected a dict (OutlineTree); "
+            f"got {type(tree).__name__!r}."
+        )
+        return
+
+    # O.1 — node: REQUIRED, must pass Stub structural floor
+    if "node" not in tree:
+        violations.append(
+            f"[O.1 outline required key] {path!r}: missing required key 'node'. "
+            "Every OutlineTree must carry a 'node' (Stub) identifying the scope."
+        )
+    else:
+        _check_stub_structural_floor(tree["node"], f"{path}.node", violations)
+
+    has_truncated = "truncated" in tree
+    has_truncation_reason = "truncation_reason" in tree
+    has_children = "children" in tree
+
+    # O.2 — truncated: if present, must be exactly True (absent-not-false contract)
+    if has_truncated:
+        truncated_val = tree["truncated"]
+        if truncated_val is False:
+            violations.append(
+                f"[O.2 outline truncated absent-not-false] {path}.truncated: "
+                "value is False, which is forbidden. "
+                "The absence-not-false contract requires fully-walked nodes to OMIT "
+                "'truncated' entirely — never set it to false. "
+                "See spec §4.2: truncated is present ONLY on cut-off nodes."
+            )
+        elif truncated_val is not True:
+            violations.append(
+                f"[O.2 outline truncated type] {path}.truncated: "
+                f"value must be exactly True (boolean); got {_truncate(truncated_val)} "
+                f"(type={type(truncated_val).__name__!r})."
+            )
+        else:
+            # truncated is True — validate co-occurring fields
+            if not has_truncation_reason:
+                violations.append(
+                    f"[O.2 outline truncated co-occurrence] {path}: "
+                    "'truncated': true requires 'truncation_reason' to be present. "
+                    f"Valid reasons: {sorted(_VALID_OUTLINE_TRUNCATION_REASONS)}."
+                )
+            if has_children:
+                violations.append(
+                    f"[O.2 outline truncated no-children] {path}: "
+                    "'truncated': true must NOT carry 'children'. "
+                    "A cut-off node's members were not walked; emitting 'children' "
+                    "(even []) would falsely read as 'measured-empty'. "
+                    "See spec §4.2 Contract 1."
+                )
+
+    # O.2 — truncation_reason: validate if present
+    if has_truncation_reason:
+        reason_val = tree["truncation_reason"]
+        if not isinstance(reason_val, str):
+            violations.append(
+                f"[O.2 outline truncation_reason type] {path}.truncation_reason: "
+                f"expected str; got {type(reason_val).__name__!r} ({_truncate(reason_val)})."
+            )
+        elif reason_val not in _VALID_OUTLINE_TRUNCATION_REASONS:
+            violations.append(
+                f"[O.2 outline truncation_reason value] {path}.truncation_reason: "
+                f"value {reason_val!r} is not recognised. "
+                f"Must be one of {sorted(_VALID_OUTLINE_TRUNCATION_REASONS)}."
+            )
+
+    # O.3 — truncation_reason without truncated is forbidden
+    if has_truncation_reason and not has_truncated:
+        violations.append(
+            f"[O.3 outline truncation_reason without truncated] {path}: "
+            "'truncation_reason' is present but 'truncated' is absent. "
+            "'truncation_reason' must only appear alongside 'truncated': true. "
+            "See spec §4.2 Contract 2."
+        )
+
+    # O.4 — children: if present, must be a list of OutlineTree
+    if has_children:
+        children_val = tree["children"]
+        if not isinstance(children_val, list):
+            violations.append(
+                f"[O.4 outline children type] {path}.children: "
+                f"expected a list (possibly empty) of OutlineTree; "
+                f"got {type(children_val).__name__!r} ({_truncate(children_val)})."
+            )
+        else:
+            for idx, child in enumerate(children_val):
+                _check_outline_tree_node(child, f"{path}.children[{idx}]", violations)
+
+
+def _check_outline_structural_floor(
+    response: dict[str, Any],
+    violations: list[str],
+) -> None:
+    """O.1–O.4 — Validate the structural floor of an ``OutlineTree`` response.
+
+    Entry point for the ``outline`` operation.  Delegates to
+    ``_check_outline_tree_node`` which recurses through the whole tree.
+
+    Layering (A.*) is run separately by ``_check_layering`` and already
+    reaches every nested dict/list via ``_walk``, so all ``node`` Stubs and
+    ``children`` items at any depth are covered without duplication.
+
+    Args:
+        response: The OutlineTree dict returned by the ``outline`` operation.
+        violations: Mutable list to append violation messages to.
+    """
+    _check_outline_tree_node(response, "", violations)
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -1144,14 +1312,15 @@ def lint_response(response: dict[str, Any], operation: str) -> None:
     at once.  The linter is pure (no I/O, no analyzer instantiation).
 
     Args:
-        response: The dict returned by resolve / resolve_at / inspect / expand,
-            or a standalone Stub dict.
+        response: The dict returned by resolve / resolve_at / inspect / expand /
+            outline, or a standalone Stub dict.
         operation: One of ``"resolve"``, ``"resolve_at"``, ``"inspect"``,
-            ``"expand"``, ``"trace"``, ``"stub"`` — used in error messages and for
-            operation-specific contract checks:
+            ``"expand"``, ``"trace"``, ``"outline"``, ``"stub"`` — used in error
+            messages and for operation-specific contract checks:
             - ``inspect``  gets B.3 Phase 4 cross-check
             - ``expand``   gets E.1–E.4 structural-floor + top-level source exemption
             - ``trace``    gets T.1–T.4 Subgraph structural-floor
+            - ``outline``  gets O.1–O.4 OutlineTree structural-floor (recursive)
             - ``stub``     gets S.1–S.2 structural-floor
             - others don't get operation-specific checks
 
@@ -1169,6 +1338,8 @@ def lint_response(response: dict[str, Any], operation: str) -> None:
         _check_trace_structural_floor(response, violations)
     elif operation == "stub":
         _check_stub_structural_floor(response, "", violations)
+    elif operation == "outline":
+        _check_outline_structural_floor(response, violations)
     else:
         _check_absence_vs_zero(response, operation, violations)
 

--- a/tests/conformance/test_linter_adversarial_outline.py
+++ b/tests/conformance/test_linter_adversarial_outline.py
@@ -1,0 +1,348 @@
+"""Adversarial test suite for the conformance linter — ``OutlineTree`` shape.
+
+Each test targets one structural-floor (Check O) or layering (Check A) violation
+for the ``outline`` operation, plus a dogfood test that runs REAL ``outline``
+output through the linter.
+
+Rule tags enforced here:
+    O.1  ``node`` is REQUIRED and passes the Stub structural floor (S.*)
+    O.2  ``truncated`` present ⇒ value is exactly ``true``, ``truncation_reason``
+         present and in the outline enum, and ``children`` ABSENT.
+         ``truncated: false`` rejected.
+    O.3  ``truncated`` absent ⇒ ``truncation_reason`` absent.
+    O.4  ``children`` present ⇒ list (possibly empty) of valid ``OutlineTree``.
+    O.5  The outline ``truncation_reason`` enum includes ``external``; trace's
+         narrower enum does NOT include ``external``.
+    A.*  No source content anywhere in the tree, including at depth ≥ 2.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from tests.conformance.response_linter import ConformanceViolation, lint_response
+
+_FIXTURE = Path(__file__).parent.parent / "fixtures" / "resolve_project"
+
+# ---------------------------------------------------------------------------
+# Minimal well-formed OutlineTree (depth-2 tree: module → class → method)
+# ---------------------------------------------------------------------------
+
+_STUB_MODULE: dict = {
+    "handle": "mypackage._core.widgets",
+    "kind": "module",
+    "scope": "project",
+    "line_start": 1,
+    "line_end": 100,
+}
+
+_STUB_CLASS: dict = {
+    "handle": "mypackage._core.widgets.Widget",
+    "kind": "class",
+    "scope": "project",
+    "signature": "Widget(name: str)",
+    "line_start": 10,
+    "line_end": 50,
+}
+
+_STUB_METHOD: dict = {
+    "handle": "mypackage._core.widgets.Widget.render",
+    "kind": "method",
+    "scope": "project",
+    "signature": "render(self) -> str",
+    "line_start": 20,
+    "line_end": 25,
+}
+
+# A well-formed tree: module → class → method (both leaves carry children: [])
+_VALID_OUTLINE: dict = {
+    "node": _STUB_MODULE,
+    "children": [
+        {
+            "node": _STUB_CLASS,
+            "children": [
+                {
+                    "node": _STUB_METHOD,
+                    "children": [],  # genuine leaf (method has no members)
+                }
+            ],
+        }
+    ],
+}
+
+
+def _clone() -> dict:
+    return copy.deepcopy(_VALID_OUTLINE)
+
+
+# ---------------------------------------------------------------------------
+# TestOutlineAcceptsValid
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineAcceptsValid:
+    def test_well_formed_outline_passes(self) -> None:
+        """A well-formed OutlineTree with children at depth 2 must not raise."""
+        lint_response(_clone(), "outline")
+
+    def test_empty_children_on_leaf_passes(self) -> None:
+        """children: [] is a valid genuine-leaf marker (measured-empty)."""
+        # Top-level node with no children (empty module-like)
+        lint_response({"node": _STUB_MODULE, "children": []}, "outline")
+
+    def test_truncated_node_passes(self) -> None:
+        """A node cut off by max_depth with truncation_reason and no children passes."""
+        tree = {
+            "node": _STUB_CLASS,
+            "truncated": True,
+            "truncation_reason": "max_depth",
+        }
+        lint_response(tree, "outline")
+
+    def test_truncated_max_nodes_passes(self) -> None:
+        tree = {
+            "node": _STUB_CLASS,
+            "truncated": True,
+            "truncation_reason": "max_nodes",
+        }
+        lint_response(tree, "outline")
+
+    def test_truncated_external_passes(self) -> None:
+        """external is a valid truncation_reason for outline (not for trace)."""
+        tree = {
+            "node": {**_STUB_CLASS, "scope": "external"},
+            "truncated": True,
+            "truncation_reason": "external",
+        }
+        lint_response(tree, "outline")
+
+
+# ---------------------------------------------------------------------------
+# TestOutlineStructuralFloor (Check O)
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineStructuralFloor:
+    def test_missing_node_rejected(self) -> None:
+        """O.1 — node is REQUIRED."""
+        tree = _clone()
+        del tree["node"]
+        with pytest.raises(ConformanceViolation, match="node"):
+            lint_response(tree, "outline")
+
+    def test_node_must_be_dict(self) -> None:
+        """O.1 — node must be a dict (Stub), not a string or list."""
+        tree = _clone()
+        tree["node"] = "not-a-stub"
+        with pytest.raises(ConformanceViolation):
+            lint_response(tree, "outline")
+
+    def test_node_missing_handle_rejected(self) -> None:
+        """O.1 — node passes the Stub structural floor: handle required."""
+        tree = _clone()
+        del tree["node"]["handle"]
+        with pytest.raises(ConformanceViolation, match="handle"):
+            lint_response(tree, "outline")
+
+    def test_node_missing_scope_rejected(self) -> None:
+        """O.1 — node passes the Stub structural floor: scope required."""
+        tree = _clone()
+        del tree["node"]["scope"]
+        with pytest.raises(ConformanceViolation, match="scope"):
+            lint_response(tree, "outline")
+
+    def test_truncated_false_rejected(self) -> None:
+        """O.2 — truncated: false is forbidden (absent-not-false contract)."""
+        tree = _clone()
+        tree["truncated"] = False
+        with pytest.raises(ConformanceViolation, match="truncated.*false|false.*truncated"):
+            lint_response(tree, "outline")
+
+    def test_truncated_true_without_truncation_reason_rejected(self) -> None:
+        """O.2 — truncated: true requires truncation_reason."""
+        tree = {"node": _STUB_CLASS, "truncated": True}
+        with pytest.raises(ConformanceViolation, match="truncation_reason"):
+            lint_response(tree, "outline")
+
+    def test_truncated_true_with_children_rejected(self) -> None:
+        """O.2 — a truncated node must NOT carry children (absent-not-empty)."""
+        tree = {
+            "node": _STUB_CLASS,
+            "truncated": True,
+            "truncation_reason": "max_depth",
+            "children": [],  # must be rejected — truncated + children is contradictory
+        }
+        with pytest.raises(ConformanceViolation, match="children"):
+            lint_response(tree, "outline")
+
+    def test_truncation_reason_without_truncated_rejected(self) -> None:
+        """O.3 — truncation_reason present without truncated is rejected."""
+        tree = _clone()
+        tree["truncation_reason"] = "max_depth"
+        with pytest.raises(ConformanceViolation, match="truncation_reason"):
+            lint_response(tree, "outline")
+
+    def test_unknown_truncation_reason_rejected(self) -> None:
+        """O.2 — truncation_reason must be one of the outline enum values."""
+        tree = {
+            "node": _STUB_CLASS,
+            "truncated": True,
+            "truncation_reason": "max_galaxies",  # not in the outline enum
+        }
+        with pytest.raises(ConformanceViolation, match="truncation_reason"):
+            lint_response(tree, "outline")
+
+    def test_children_must_be_list(self) -> None:
+        """O.4 — children, when present, must be a list."""
+        tree = _clone()
+        tree["children"] = {"not": "a list"}
+        with pytest.raises(ConformanceViolation, match="children"):
+            lint_response(tree, "outline")
+
+    def test_children_items_must_be_outline_trees(self) -> None:
+        """O.4 — each item in children must be a valid OutlineTree (has node)."""
+        tree = _clone()
+        tree["children"] = ["not-a-tree"]  # string, not a dict
+        with pytest.raises(ConformanceViolation):
+            lint_response(tree, "outline")
+
+    def test_child_missing_node_rejected(self) -> None:
+        """O.4 — each child OutlineTree must have node."""
+        tree = _clone()
+        tree["children"] = [{"children": []}]  # no 'node' key
+        with pytest.raises(ConformanceViolation, match="node"):
+            lint_response(tree, "outline")
+
+    def test_child_stub_floor_enforced(self) -> None:
+        """O.1 via O.4 — Stub floor applied to each child node."""
+        tree = _clone()
+        tree["children"][0]["node"] = {
+            "handle": "h",
+            "kind": "class",
+            # missing scope, line_start, line_end
+        }
+        with pytest.raises(ConformanceViolation):
+            lint_response(tree, "outline")
+
+
+# ---------------------------------------------------------------------------
+# TestOutlineTruncationReasonEnum (O.5)
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineTruncationReasonEnum:
+    def test_external_is_accepted_for_outline(self) -> None:
+        """O.5 — external is in the outline enum and must be accepted."""
+        tree = {
+            "node": {**_STUB_CLASS, "scope": "external"},
+            "truncated": True,
+            "truncation_reason": "external",
+        }
+        lint_response(tree, "outline")  # must not raise
+
+    def test_external_is_rejected_for_trace(self) -> None:
+        """O.5 — external is NOT in trace's enum; adding it did not loosen trace."""
+        from tests.conformance.response_linter import _VALID_TRUNCATION_REASONS
+
+        assert "external" not in _VALID_TRUNCATION_REASONS, (
+            "external was incorrectly added to _VALID_TRUNCATION_REASONS (trace's "
+            "constant). It must be in a separate outline-only constant."
+        )
+
+    def test_external_reason_on_trace_response_rejected(self) -> None:
+        """Feeding external as a trace truncation_reason must be rejected by trace."""
+        subgraph = {
+            "nodes": {},
+            "edges": [],
+            "truncated": True,
+            "truncation_reasons": ["external"],  # external is NOT valid for trace
+            "unsupported_edges": [],
+        }
+        with pytest.raises(ConformanceViolation, match="truncation_reasons"):
+            lint_response(subgraph, "trace")
+
+
+# ---------------------------------------------------------------------------
+# TestOutlineLayering (Check A)
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineLayering:
+    def test_source_key_at_root_rejected(self) -> None:
+        """A.2 — a 'source' key at the root of an outline tree is rejected."""
+        tree = _clone()
+        tree["source"] = "def foo(): pass"
+        with pytest.raises(ConformanceViolation):
+            lint_response(tree, "outline")
+
+    def test_body_key_in_node_stub_rejected(self) -> None:
+        """A.2 — a 'body' key inside a node stub smuggles source content."""
+        tree = _clone()
+        tree["node"]["body"] = "def render(self):\n    return '<html>'"
+        with pytest.raises(ConformanceViolation):
+            lint_response(tree, "outline")
+
+    def test_snippet_key_in_child_node_rejected(self) -> None:
+        """A.2 — a 'snippet' key inside a child node is rejected."""
+        tree = _clone()
+        tree["children"][0]["node"]["snippet"] = "class Widget: ..."
+        with pytest.raises(ConformanceViolation):
+            lint_response(tree, "outline")
+
+    def test_source_content_buried_at_depth_2_rejected(self) -> None:
+        """A.* — layering check must reach source content at depth ≥ 2 in the tree.
+
+        The violation is placed in the grandchild node (depth-2 child of root)
+        to prove that _walk reaches into nested OutlineTree nodes.
+        """
+        tree = _clone()
+        # The grandchild is tree["children"][0]["children"][0]
+        grandchild_node = tree["children"][0]["children"][0]["node"]
+        grandchild_node["body"] = "return '<html>'"
+        with pytest.raises(ConformanceViolation, match="body|A.2"):
+            lint_response(tree, "outline")
+
+    def test_multiline_string_in_node_rejected(self) -> None:
+        """A.1 — multi-line string value in a node field is rejected."""
+        tree = _clone()
+        # Inject a multi-line value into a non-allowlisted field
+        tree["node"]["signature"] = "foo(\n    a: int,\n    b: str,\n    c: float,\n    d: bool\n)"
+        with pytest.raises(ConformanceViolation, match="multi-line|signature"):
+            lint_response(tree, "outline")
+
+    def test_indented_code_block_in_node_rejected(self) -> None:
+        """A.4 — indented code block pattern in a node field is rejected."""
+        tree = _clone()
+        tree["node"]["handle"] = "pkg.Widget    def __init__(self): pass"
+        with pytest.raises(ConformanceViolation, match="indented"):
+            lint_response(tree, "outline")
+
+
+# ---------------------------------------------------------------------------
+# TestRealOutlineOutputConforms
+# ---------------------------------------------------------------------------
+
+
+class TestRealOutlineOutputConforms:
+    """Dogfood: real outline output passes the linter with no regressions."""
+
+    @pytest.mark.asyncio
+    async def test_real_outline_module_conforms(self) -> None:
+        from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+        from pyeye.mcp.operations.outline import outline
+
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        result = await outline("mypackage._core.widgets.Widget", analyzer, max_depth=2)
+        lint_response(result, "outline")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_real_outline_with_max_nodes_conforms(self) -> None:
+        from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+        from pyeye.mcp.operations.outline import outline
+
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        result = await outline("mypackage._core.widgets", analyzer, max_nodes=5)
+        lint_response(result, "outline")  # must not raise

--- a/tests/fixtures/nested_class_inspect/pkg/mod.py
+++ b/tests/fixtures/nested_class_inspect/pkg/mod.py
@@ -6,6 +6,9 @@
   This is the case ``_is_method`` previously misclassified as "function",
   because it re-derived the parent by dotted-name string arithmetic + a
   filesystem module lookup, which can't see that ``Outer`` is a class.
+- ``Empty`` is a class with no members; used to test the max_depth frontier
+  peek branch (outline.py §5.3): at the frontier, a genuine empty container
+  must receive ``children: []``, not ``truncated: "max_depth"``.
 """
 
 
@@ -27,3 +30,12 @@ class Outer:
         def inner_method(self) -> int:
             """A method on a nested class — the #337 misclassification case."""
             return 3
+
+
+class Empty:
+    """A class with no members.
+
+    Used to drive the genuine-empty-container peek branch in outline (spec
+    §5.3): when ``Empty`` is at the ``max_depth`` frontier, ``resolve_members``
+    returns [] → the node receives ``children: []`` (NOT ``truncated``).
+    """

--- a/tests/integration/api_redesign/test_outline_integration.py
+++ b/tests/integration/api_redesign/test_outline_integration.py
@@ -521,3 +521,61 @@ class TestOutlineCountConsistencyEndToEnd:
         assert "children" in roundtripped
         # Children survive round-trip.
         assert isinstance(roundtripped["children"], list)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: unresolvable-handle contract — "never raises" guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineUnresolvableHandleEndToEnd:
+    """Calling outline with a bogus handle must never raise and must return
+    a minimal single-node OutlineTree with children: [].
+
+    This is the docstring's "never raises" guarantee tested at the wire
+    boundary (through the full decorator stack), not just the unit layer.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_handle_does_not_raise(self) -> None:
+        """outline with a bogus handle returns without raising."""
+        from pyeye.mcp.server import outline
+
+        # Must not raise any exception.
+        result = await outline(
+            handle="does.not.exist.Nope",
+            project_path=str(_FIXTURE),
+        )
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_handle_returns_dict_with_required_keys(self) -> None:
+        """outline with a bogus handle returns a plain dict with 'node' and 'children'."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="does.not.exist.Nope",
+            project_path=str(_FIXTURE),
+        )
+
+        assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
+        assert "node" in result, f"'node' missing from minimal-fallback result: {result!r}"
+        assert "children" in result, (
+            "'children' must be present on the minimal single-node fallback "
+            f"(docstring guarantee); got keys={list(result.keys())!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_handle_returns_empty_children(self) -> None:
+        """The minimal fallback OutlineTree has children: [] (no members to walk)."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="does.not.exist.Nope",
+            project_path=str(_FIXTURE),
+        )
+
+        assert result["children"] == [], (
+            f"Minimal fallback must have children=[] (docstring guarantee); "
+            f"got children={result['children']!r}"
+        )

--- a/tests/integration/api_redesign/test_outline_integration.py
+++ b/tests/integration/api_redesign/test_outline_integration.py
@@ -1,0 +1,523 @@
+"""Integration tests for the outline MCP tool endpoint.
+
+These tests exercise the MCP wrapper layer (server.py) end-to-end —
+from the decorated function down through the operation into the fixture
+project.  They verify:
+
+1. The tool is registered (importable, callable, async).
+2. A module skeleton call returns a well-formed OutlineTree over the wire.
+3. A depth-bounded call exhibits the ``truncated``/``truncation_reason`` markers,
+   AND the ABSENCE of ``children`` on truncated nodes survives wire serialisation
+   (a serialiser that mangles absence to ``[]`` or ``null`` would break Contract 1).
+4. Count-consistency (spec §6.4): for a fully-walked non-truncated container,
+   ``len(children) == inspect(handle).edge_counts.members``.  Both derive from
+   ``resolve_members``, so this catches divergence between the two consumers.
+
+Unit-level contract tests live in tests/unit/mcp/operations/test_outline.py.
+These integration tests verify only the MCP wrapper layer delegation.
+"""
+
+from __future__ import annotations
+
+import inspect as _inspect_stdlib
+import json
+from pathlib import Path
+
+import pytest
+
+_FIXTURE = Path(__file__).parent.parent.parent / "fixtures" / "resolve_project"
+
+
+# ---------------------------------------------------------------------------
+# Tool-registration assertions
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineToolRegistered:
+    """Verify that outline is importable from pyeye.mcp.server and is callable."""
+
+    def test_outline_is_importable(self) -> None:
+        """outline can be imported from pyeye.mcp.server."""
+        from pyeye.mcp.server import outline  # noqa: F401
+
+    def test_outline_is_callable(self) -> None:
+        """outline is a callable (decorated async function)."""
+        from pyeye.mcp.server import outline
+
+        assert callable(outline)
+
+    def test_outline_is_async(self) -> None:
+        """outline is an async function (or wrapped to behave as one)."""
+        from pyeye.mcp.server import outline
+
+        assert _inspect_stdlib.iscoroutinefunction(outline)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: module skeleton
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineModuleSkeletonEndToEnd:
+    """A module skeleton call returns a well-formed OutlineTree over the wire.
+
+    ``mypackage._core.widgets`` is a module with a known set of top-level members
+    (DEFAULT_NAME, Widget, Config, make_widget, Premium, Deluxe).  At default
+    bounds (no max_depth, max_nodes=200) all members are walked and returned.
+    """
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_returns_outline_tree(self) -> None:
+        """outline(widgets module) returns a dict with 'node' and 'children' keys."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        assert isinstance(result, dict), f"result must be a plain dict; got {type(result)!r}"
+        assert "node" in result, f"'node' missing from result: {result!r}"
+        assert "children" in result, (
+            "'children' must be present for a fully-walked module "
+            f"(absence means 'not walked', which is wrong here); result={result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_node_has_required_fields(self) -> None:
+        """The root node Stub has handle/kind/scope/line_start/line_end."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        node = result["node"]
+        assert isinstance(node, dict), f"node must be a plain dict; got {type(node)!r}"
+        for field in ("handle", "kind", "scope", "line_start", "line_end"):
+            assert field in node, f"node missing required field '{field}'; node={node!r}"
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_root_is_module_kind(self) -> None:
+        """The root node has kind='module'."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        node = result["node"]
+        assert (
+            node["kind"] == "module"
+        ), f"root node must have kind='module'; got {node.get('kind')!r}"
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_children_are_list(self) -> None:
+        """children is a list of OutlineTree nodes."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        children = result["children"]
+        assert isinstance(children, list), f"children must be a list; got {type(children)!r}"
+        assert (
+            len(children) > 0
+        ), "mypackage._core.widgets has top-level members — children must be non-empty"
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_children_have_node_field(self) -> None:
+        """Each child in the tree is an OutlineTree with a 'node' field."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        for i, child in enumerate(result["children"]):
+            assert isinstance(child, dict), f"child[{i}] must be a plain dict; got {type(child)!r}"
+            assert "node" in child, f"child[{i}] missing 'node' field; child={child!r}"
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_no_source_content(self) -> None:
+        """No source content anywhere in the tree — spec §6 invariant 1."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        # Recursively check that no node contains 'source', 'text', or 'snippet'
+        _forbidden = {"source", "text", "snippet"}
+
+        def check_node(tree: dict, path: str) -> None:
+            node = tree["node"]
+            for bad_field in _forbidden:
+                assert (
+                    bad_field not in node
+                ), f"source content '{bad_field}' found in node at {path}: {node!r}"
+            for i, child in enumerate(tree.get("children", [])):
+                check_node(child, f"{path}.children[{i}]")
+
+        check_node(result, "root")
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_result_is_json_serialisable(self) -> None:
+        """The module skeleton round-trips through json.dumps without error."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        serialised = json.dumps(result)
+        roundtripped = json.loads(serialised)
+        assert isinstance(roundtripped, dict)
+        assert "node" in roundtripped
+        assert "children" in roundtripped
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_result_is_plain_dict(self) -> None:
+        """The result is an exact plain dict — no custom type subclasses."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        assert (
+            type(result) is dict  # noqa: E721
+        ), f"result must be exact dict (not subclass); got {type(result)!r}"
+
+    @pytest.mark.asyncio
+    async def test_module_skeleton_fully_walked_omits_truncated(self) -> None:
+        """A fully-walked tree node has no 'truncated' key (Contract 2 — absent-not-false)."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+        )
+
+        assert "truncated" not in result, (
+            "A fully-walked root must OMIT 'truncated' (absent-not-false, Contract 2); "
+            f"got keys={list(result.keys())!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: depth-bounded call — truncation markers over the wire
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineTruncationEndToEnd:
+    """A depth-bounded call exhibits truncated/truncation_reason markers over the wire.
+
+    ``mypackage._core.widgets`` has class members (Widget, Config, Premium, Deluxe).
+    At ``max_depth=1`` the root (depth 0) is walked — its class children are placed
+    at depth 1, which is the frontier.  Each of those class children has members,
+    so they are marked ``truncated: "max_depth"`` and OMIT ``children``.
+
+    The critical assertion here is that ``children`` is GENUINELY ABSENT (not ``[]``
+    and not ``null``) on a truncated node — this is the Contract 1 absence that a
+    naive serialiser would mangle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_depth_bounded_produces_truncated_nodes(self) -> None:
+        """At max_depth=1, class children at the frontier are marked truncated."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+
+        # The root itself must be fully walked (it is at depth 0, not the frontier).
+        assert "children" in result, (
+            "Root (depth 0) must have 'children' at max_depth=1; "
+            f"got keys={list(result.keys())!r}"
+        )
+
+        # At least one class child must be truncated (Widget, Config, Premium, Deluxe all have members).
+        truncated_children = [c for c in result["children"] if c.get("truncated") is True]
+        assert len(truncated_children) > 0, (
+            "At max_depth=1, class children with members must be marked truncated; "
+            f"got children={[c['node']['handle'] for c in result['children']]!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_truncated_node_has_truncation_reason(self) -> None:
+        """Every truncated node carries a truncation_reason."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+
+        for child in result["children"]:
+            if child.get("truncated") is True:
+                assert "truncation_reason" in child, (
+                    f"truncated node must carry 'truncation_reason'; "
+                    f"got keys={list(child.keys())!r}; node={child['node']!r}"
+                )
+                assert child["truncation_reason"] in ("max_depth", "max_nodes", "external"), (
+                    f"truncation_reason must be one of the three enum values; "
+                    f"got {child['truncation_reason']!r}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_truncated_node_reason_is_max_depth(self) -> None:
+        """Class children truncated at the depth frontier have reason='max_depth'."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+
+        # Widget, Config, Premium, Deluxe are classes at the depth-1 frontier.
+        class_children = [
+            c
+            for c in result["children"]
+            if c["node"]["kind"] == "class" and c.get("truncated") is True
+        ]
+        assert len(class_children) > 0, "Expected at least one truncated class child at max_depth=1"
+        for child in class_children:
+            assert child["truncation_reason"] == "max_depth", (
+                f"Class child at depth frontier must have reason='max_depth'; "
+                f"got {child.get('truncation_reason')!r}; node={child['node']!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_truncated_node_children_absent_not_empty(self) -> None:
+        """CRITICAL (Contract 1): truncated nodes have 'children' ABSENT, not [] or null.
+
+        This is the exact serialiser-mangle that absence-vs-zero guards against.
+        A truncated container MUST NOT appear to be an empty leaf (children: []).
+        The key must be genuinely missing from the dict.
+        """
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+
+        for child in result["children"]:
+            if child.get("truncated") is True:
+                # The key must be GENUINELY ABSENT — not [] and not None.
+                assert "children" not in child, (
+                    f"Contract 1 VIOLATION: truncated node must have 'children' ABSENT "
+                    f"(not [] or null); got 'children'={child.get('children')!r} "
+                    f"in node={child['node']['handle']!r}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_absence_survives_json_round_trip(self) -> None:
+        """Contract 1 absence survives json.dumps/loads — the easy serialiser-mangle target."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+
+        # Round-trip through JSON
+        roundtripped = json.loads(json.dumps(result))
+
+        # After round-trip: truncated nodes must STILL have 'children' absent.
+        for child in roundtripped["children"]:
+            if child.get("truncated") is True:
+                assert "children" not in child, (
+                    f"Contract 1 VIOLATION after JSON round-trip: 'children' appeared "
+                    f"in truncated node {child['node']['handle']!r}; "
+                    f"got 'children'={child.get('children')!r}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_non_truncated_nodes_omit_truncated_key(self) -> None:
+        """Contract 2: fully-walked (non-truncated) nodes omit 'truncated' entirely."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+
+        for child in result["children"]:
+            if child.get("truncated") is not True:
+                # 'truncated' must be absent, not False.
+                assert "truncated" not in child, (
+                    f"Contract 2 VIOLATION: non-truncated node must OMIT 'truncated' "
+                    f"(never 'truncated: false'); "
+                    f"got {child.get('truncated')!r} in node={child['node']['handle']!r}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_genuine_leaf_at_frontier_gets_empty_children(self) -> None:
+        """At the depth frontier, a container with no members gets children: [] (genuine leaf).
+
+        Non-container kinds (function, variable, etc.) always get children: [] regardless
+        of depth.  This test verifies the depth-frontier peek path too: make_widget is a
+        function — it is a genuine leaf and must carry children: [] at any depth.
+        """
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+
+        # make_widget is a function — always a genuine leaf, never truncated.
+        make_widget_child = next(
+            (c for c in result["children"] if "make_widget" in c["node"]["handle"]),
+            None,
+        )
+        assert make_widget_child is not None, "make_widget must be present in the module's children"
+        assert (
+            "children" in make_widget_child
+        ), "make_widget (function) must have 'children' key present as a genuine leaf"
+        assert make_widget_child["children"] == [], (
+            f"make_widget (function) must have children=[] (genuine leaf); "
+            f"got {make_widget_child['children']!r}"
+        )
+        assert (
+            "truncated" not in make_widget_child
+        ), "make_widget must not have 'truncated' (it is a genuine leaf)"
+
+    @pytest.mark.asyncio
+    async def test_depth_bounded_result_is_json_serialisable(self) -> None:
+        """The depth-bounded result round-trips through json.dumps without error."""
+        from pyeye.mcp.server import outline
+
+        result = await outline(
+            handle="mypackage._core.widgets",
+            project_path=str(_FIXTURE),
+            max_depth=1,
+        )
+
+        serialised = json.dumps(result)
+        roundtripped = json.loads(serialised)
+        assert isinstance(roundtripped, dict)
+        assert "children" in roundtripped
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: count-consistency check — spec §6.4
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineCountConsistencyEndToEnd:
+    """Spec §6.4: for a fully-walked container, len(children) == inspect.edge_counts.members.
+
+    Both ``outline`` and ``inspect`` derive from ``resolve_members``.  A divergence
+    between them would indicate a bug in one consumer.
+
+    Fixture: ``mypackage._core.widgets.Config`` — a small class with 2 attribute
+    members (``debug``, ``host``) and no methods.  At default bounds (no max_depth,
+    max_nodes=200) it is fully walked, so the count comparison is valid.
+
+    ``inspect("mypackage._core.widgets.Config").edge_counts.members`` returns 2;
+    ``outline("mypackage._core.widgets.Config").children`` must also be length 2.
+    """
+
+    @pytest.mark.asyncio
+    async def test_config_outline_children_matches_inspect_edge_count(self) -> None:
+        """len(outline.children) == inspect.edge_counts.members for Config."""
+        from pyeye.mcp.server import (
+            inspect as mcp_inspect,
+            outline as mcp_outline,
+        )
+
+        # Get the member count from inspect.
+        inspect_result = await mcp_inspect(
+            handle="mypackage._core.widgets.Config",
+            project_path=str(_FIXTURE),
+        )
+        inspect_members_count: int = inspect_result["edge_counts"]["members"]
+
+        # Get the children from outline (fully walked — no truncation at defaults).
+        outline_result = await mcp_outline(
+            handle="mypackage._core.widgets.Config",
+            project_path=str(_FIXTURE),
+        )
+
+        # Precondition: the outline must be fully walked (no truncated key on root).
+        assert "truncated" not in outline_result, (
+            "Precondition failed: Config root must not be truncated at default bounds; "
+            f"got keys={list(outline_result.keys())!r}"
+        )
+        assert (
+            "children" in outline_result
+        ), "Precondition failed: Config root must have 'children' at default bounds"
+
+        outline_children_count = len(outline_result["children"])
+
+        assert outline_children_count == inspect_members_count, (
+            f"Count-consistency failure (spec §6.4): "
+            f"outline.children={outline_children_count} != "
+            f"inspect.edge_counts.members={inspect_members_count}. "
+            "Both derive from resolve_members — a divergence indicates a bug."
+        )
+
+    @pytest.mark.asyncio
+    async def test_config_children_are_fully_walked_leaves(self) -> None:
+        """Config's children (debug, host) are attribute leaves — each carries children: [].
+
+        Contract 1 verification: the attribute nodes are fully walked and have
+        children: [] (measured-empty, not-truncated genuine leaves).
+        """
+        from pyeye.mcp.server import outline as mcp_outline
+
+        result = await mcp_outline(
+            handle="mypackage._core.widgets.Config",
+            project_path=str(_FIXTURE),
+        )
+
+        for i, child in enumerate(result["children"]):
+            assert "children" in child, (
+                f"Config.children[{i}] must have 'children' present (fully walked); "
+                f"node={child['node']!r}"
+            )
+            assert child["children"] == [], (
+                f"Config.children[{i}] must be a genuine leaf (children=[]); "
+                f"node={child['node']!r}; got children={child['children']!r}"
+            )
+            assert (
+                "truncated" not in child
+            ), f"Config.children[{i}] must not be truncated; node={child['node']!r}"
+
+    @pytest.mark.asyncio
+    async def test_count_consistency_result_is_json_serialisable(self) -> None:
+        """The Config outline round-trips through json.dumps without error."""
+        from pyeye.mcp.server import outline as mcp_outline
+
+        result = await mcp_outline(
+            handle="mypackage._core.widgets.Config",
+            project_path=str(_FIXTURE),
+        )
+
+        serialised = json.dumps(result)
+        roundtripped = json.loads(serialised)
+        assert isinstance(roundtripped, dict)
+        assert "node" in roundtripped
+        assert "children" in roundtripped
+        # Children survive round-trip.
+        assert isinstance(roundtripped["children"], list)

--- a/tests/unit/mcp/operations/test_outline.py
+++ b/tests/unit/mcp/operations/test_outline.py
@@ -1,0 +1,719 @@
+"""Tests for the ``outline(handle, ...)`` operation — Phase 1 (Tasks 1.1 + 1.2).
+
+``outline`` returns the structural skeleton of a module or class as a nested
+tree of ``(node, children?)`` entries, with two load-bearing absence contracts
+(spec §4.2):
+
+  Contract 1 — ``children`` absent ⇔ not expanded (a cap fired).
+    ``children: []`` = measured genuine leaf.  Missing ``children`` = "unknown."
+
+  Contract 2 — ``truncated`` absent-not-false.
+    ``truncated: true`` only on a cut-off node, always with ``truncation_reason``
+    and absent ``children``.  Fully-walked nodes omit ``truncated`` entirely.
+
+Fixture layout
+--------------
+nested_class_inspect (primary — has the nesting the outline tests need)::
+
+    pkg.mod               ← module
+      top_level_function  ← function (line 12) — genuine leaf
+      Outer               ← class (line 17) — has members
+        outer_method      ← method (line 20) — genuine leaf
+        Inner             ← nested class (line 24) — has members
+          inner_method    ← method (line 27) — genuine leaf
+
+resolve_project (supplementary — Widget has alphabetically-out-of-source-order
+members, needed for the source-ordering test)::
+
+    mypackage._core.widgets.Widget
+      __init__   (line 34)   — method
+      greet      (line 37)   — method
+      slow_greet (line 41)   — method
+      display_name (line 45) — property
+      default    (line 50)   — method
+      normalize  (line 55)   — method
+      color      (line 29)   — attribute  ← alphabetically-earlier, line-earlier
+
+Note: source order diverges from alphabetical (e.g. ``color`` at line 29 comes
+first in source but "c" sorts before "__"), so the ordering test verifies the
+``(line_start, handle)`` key rather than alphabetical or definition order.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+
+# Fixtures — real committed directories (no tmp-dir symlinks; Jedi degrades on
+# macOS symlinked temp paths, see feedback_jedi_macos_tmp_symlink.md).
+_FIXTURE_NESTED = Path(__file__).parent.parent.parent.parent / "fixtures" / "nested_class_inspect"
+_FIXTURE_RESOLVE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
+
+# Canonical handles — nested_class_inspect
+_MOD_HANDLE = "pkg.mod"
+_TOP_LEVEL_FUNC_HANDLE = "pkg.mod.top_level_function"
+_OUTER_HANDLE = "pkg.mod.Outer"
+_OUTER_METHOD_HANDLE = "pkg.mod.Outer.outer_method"
+_INNER_HANDLE = "pkg.mod.Outer.Inner"
+_INNER_METHOD_HANDLE = "pkg.mod.Outer.Inner.inner_method"
+
+# Canonical handles — resolve_project (for source-order test)
+_WIDGET_HANDLE = "mypackage._core.widgets.Widget"
+_WIDGETS_MODULE_HANDLE = "mypackage._core.widgets"
+
+# External stdlib handle — scope="external"
+_PATHLIB_PATH_HANDLE = "pathlib.Path"
+
+
+@pytest.fixture
+def nested_analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at nested_class_inspect fixture."""
+    return JediAnalyzer(str(_FIXTURE_NESTED))
+
+
+@pytest.fixture
+def resolve_analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at resolve_project fixture."""
+    return JediAnalyzer(str(_FIXTURE_RESOLVE))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_STUB_REQUIRED_KEYS = frozenset({"handle", "kind", "scope", "line_start", "line_end"})
+_SOURCE_CONTENT_KEYS = frozenset({"body", "source", "code", "snippet", "text"})
+
+
+def _assert_is_stub(stub: dict[str, Any]) -> None:
+    """Assert *stub* conforms to the spec §4.1 Stub shape."""
+    assert isinstance(stub, dict), f"node must be a dict, got {type(stub)}"
+    missing = _STUB_REQUIRED_KEYS - set(stub)
+    assert not missing, f"stub missing required keys {missing}: {stub}"
+    for forbidden in _SOURCE_CONTENT_KEYS:
+        assert forbidden not in stub, f"stub leaked source content via {forbidden!r}: {stub}"
+
+
+def _assert_contract1(tree: dict[str, Any]) -> None:
+    """Assert the §4.2 Contract-1 and Contract-2 absence invariants hold,
+    recursively on *tree* and all descendants.
+
+    - ``truncated`` present ⇒ value is exactly ``True``, ``truncation_reason``
+      present, ``children`` ABSENT.
+    - ``truncated`` absent ⇒ ``truncation_reason`` absent.
+    - A fully-walked node never carries ``truncated: False``.
+    - ``children`` present ⇒ a list; each element is an ``OutlineTree``.
+    """
+    assert "node" in tree, f"OutlineTree missing 'node': {tree.keys()}"
+    _assert_is_stub(tree["node"])
+
+    if "truncated" in tree:
+        # Contract 2: truncated is always exactly true, co-occurs with reason,
+        # and the node has no children.
+        assert (
+            tree["truncated"] is True
+        ), f"truncated must be True (never False, never a string): {tree['truncated']!r}"
+        assert "truncation_reason" in tree, "truncated node must carry truncation_reason"
+        assert "children" not in tree, "truncated node MUST NOT carry children (absence contract)"
+    else:
+        # Contract 2: truncation_reason absent when truncated absent.
+        assert "truncation_reason" not in tree, "truncation_reason present without truncated"
+
+    if "children" in tree:
+        assert isinstance(
+            tree["children"], list
+        ), f"children must be a list, got {type(tree['children'])}"
+        for child in tree["children"]:
+            _assert_contract1(child)  # recursive
+
+
+def _find_child(tree: dict[str, Any], handle: str) -> dict[str, Any] | None:
+    """Return the direct child of *tree* whose node.handle == *handle*, or None."""
+    for child in tree.get("children", []):
+        if child["node"]["handle"] == handle:
+            return child
+    return None
+
+
+def _count_nodes(tree: dict[str, Any]) -> int:
+    """Count all nodes in the tree (root + all descendants)."""
+    total = 1
+    for child in tree.get("children", []):
+        total += _count_nodes(child)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Tests are placed in classes per concern so we can run subsets by class name.
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineImport:
+    """The module ``outline`` must be importable from
+    ``pyeye.mcp.operations.outline`` before any functionality can be tested.
+
+    Task 1.1: these tests are expected to FAIL with ImportError until
+    Task 1.2 creates the module.
+    """
+
+    def test_outline_importable(self) -> None:
+        """Import should succeed once the module is created (Task 1.2)."""
+        from pyeye.mcp.operations.outline import outline  # noqa: F401  # type: ignore[import]
+
+        assert callable(outline)
+
+
+class TestOutlineModuleRoot:
+    """Module handle → tree whose ``node`` is the module stub and whose
+    ``children`` are the module's top-level definitions (functions + classes)."""
+
+    @pytest.mark.asyncio
+    async def test_module_root_node_is_module_stub(self, nested_analyzer: JediAnalyzer) -> None:
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        assert tree["node"]["handle"] == _MOD_HANDLE
+        assert tree["node"]["kind"] == "module"
+
+    @pytest.mark.asyncio
+    async def test_module_children_are_top_level_definitions(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        assert "children" in tree, "module root must have children (was walked)"
+        child_handles = {c["node"]["handle"] for c in tree["children"]}
+        # Both top-level definitions must appear as direct children.
+        assert (
+            _TOP_LEVEL_FUNC_HANDLE in child_handles
+        ), f"top_level_function missing from module children: {child_handles}"
+        assert (
+            _OUTER_HANDLE in child_handles
+        ), f"Outer class missing from module children: {child_handles}"
+
+    @pytest.mark.asyncio
+    async def test_module_children_all_have_valid_stubs(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        for child in tree["children"]:
+            _assert_is_stub(child["node"])
+
+
+class TestOutlineClassRoot:
+    """Class handle → tree whose ``children`` are its methods and nested classes."""
+
+    @pytest.mark.asyncio
+    async def test_class_root_node_is_class_stub(self, nested_analyzer: JediAnalyzer) -> None:
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_OUTER_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        assert tree["node"]["handle"] == _OUTER_HANDLE
+        assert tree["node"]["kind"] == "class"
+
+    @pytest.mark.asyncio
+    async def test_class_children_are_methods_and_nested_classes(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_OUTER_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        assert "children" in tree, "class root must have children"
+        child_handles = {c["node"]["handle"] for c in tree["children"]}
+        assert (
+            _OUTER_METHOD_HANDLE in child_handles
+        ), f"outer_method missing from Outer children: {child_handles}"
+        assert (
+            _INNER_HANDLE in child_handles
+        ), f"Inner nested class missing from Outer children: {child_handles}"
+
+
+class TestOutlineLeafNodes:
+    """Methods and functions are genuine leaves: ``children: []``."""
+
+    @pytest.mark.asyncio
+    async def test_method_is_genuine_leaf(self, nested_analyzer: JediAnalyzer) -> None:
+        """A method node must carry ``children: []`` — measured empty, not missing."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_OUTER_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        method_node = _find_child(tree, _OUTER_METHOD_HANDLE)
+        assert method_node is not None, "outer_method child not found"
+        assert (
+            "children" in method_node
+        ), "method must carry children (was walked — resolve_members returns [] for methods)"
+        assert method_node["children"] == [], "method children must be empty list (genuine leaf)"
+        assert "truncated" not in method_node, "a genuine leaf must not carry truncated"
+
+    @pytest.mark.asyncio
+    async def test_function_is_genuine_leaf(self, nested_analyzer: JediAnalyzer) -> None:
+        """A top-level function node must carry ``children: []``."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        func_node = _find_child(tree, _TOP_LEVEL_FUNC_HANDLE)
+        assert func_node is not None, "top_level_function child not found"
+        assert "children" in func_node, "function must carry children (was walked)"
+        assert func_node["children"] == [], "function children must be empty list"
+        assert "truncated" not in func_node, "a genuine leaf must not carry truncated"
+
+
+class TestOutlineNestedClassRecursion:
+    """Nested classes recurse — ``members`` hierarchy, not function bodies."""
+
+    @pytest.mark.asyncio
+    async def test_nested_class_inner_is_present_in_tree(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """module outline walks: mod → Outer → Inner (nested class)."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        outer_node = _find_child(tree, _OUTER_HANDLE)
+        assert outer_node is not None, "Outer not in module children"
+        assert "children" in outer_node, "Outer must have walked children"
+        inner_node = _find_child(outer_node, _INNER_HANDLE)
+        assert inner_node is not None, "Inner nested class not found in Outer children"
+        assert inner_node["node"]["kind"] == "class"
+
+    @pytest.mark.asyncio
+    async def test_inner_class_method_is_leaf(self, nested_analyzer: JediAnalyzer) -> None:
+        """inner_method inside Inner is a leaf (``children: []``)."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        outer_node = _find_child(tree, _OUTER_HANDLE)
+        assert outer_node is not None
+        inner_node = _find_child(outer_node, _INNER_HANDLE)
+        assert inner_node is not None
+        assert "children" in inner_node, "Inner must have walked children"
+        inner_method_node = _find_child(inner_node, _INNER_METHOD_HANDLE)
+        assert inner_method_node is not None, "inner_method not found in Inner children"
+        assert inner_method_node["children"] == [], "inner_method is a genuine leaf"
+        assert "truncated" not in inner_method_node
+
+
+class TestOutlineMaxDepth:
+    """``max_depth`` bounds recursion; the frontier peek distinguishes genuine
+    empty containers from cut-off ones — the load-bearing §4.2 Contract 1 test.
+
+    Both sides must be asserted explicitly so an implementation that skips the
+    peek (emitting ``children: []`` for both cases) fails loudly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_max_depth_0_module_has_children_key_absent_for_top_level_defs(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """At max_depth=0, root is depth 0 and is the frontier; its non-empty
+        children are cut off → ``truncated: "max_depth"``, NO ``children`` key."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_depth=0)
+        _assert_contract1(tree)
+        # The module root itself is depth 0; the peek finds its children (non-empty),
+        # so it must be marked truncated, NOT carry children: [].
+        assert (
+            "truncated" in tree
+        ), "module at max_depth=0 has non-empty members → must be truncated"
+        assert tree["truncated"] is True
+        assert tree["truncation_reason"] == "max_depth"
+        assert "children" not in tree, "truncated node must NOT carry children (absence contract)"
+
+    @pytest.mark.asyncio
+    async def test_max_depth_1_outer_children_walked_inner_cut_off(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """At max_depth=1: mod's children are depth 1 (walked); Outer at depth 1
+        is ON the frontier; its children (including Inner) are peeked but not walked.
+        Outer has non-empty members → truncated.
+        top_level_function is a genuine leaf at depth 1 → children: [].
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_depth=1)
+        _assert_contract1(tree)
+        # Module root must have walked children (depth 0, within limit).
+        assert "children" in tree
+        func_node = _find_child(tree, _TOP_LEVEL_FUNC_HANDLE)
+        outer_node = _find_child(tree, _OUTER_HANDLE)
+        assert func_node is not None, "top_level_function must be a child"
+        assert outer_node is not None, "Outer must be a child"
+
+        # top_level_function is at depth 1 on the frontier; peek finds no members →
+        # genuine leaf → children: [].
+        assert (
+            "children" in func_node
+        ), "top_level_function: peek finds no members → genuine leaf (children: [])"
+        assert (
+            func_node["children"] == []
+        ), "top_level_function must have children: [] (genuine leaf, not truncated)"
+        assert "truncated" not in func_node
+
+        # Outer is at depth 1 on the frontier; peek finds non-empty members →
+        # cut off → truncated: "max_depth", NO children key.
+        assert (
+            "truncated" in outer_node
+        ), "Outer at max_depth=1 frontier has non-empty members → must be truncated"
+        assert outer_node["truncated"] is True
+        assert outer_node["truncation_reason"] == "max_depth"
+        assert "children" not in outer_node, "Outer truncated node must NOT carry children"
+
+    @pytest.mark.asyncio
+    async def test_max_depth_none_walks_fully(self, nested_analyzer: JediAnalyzer) -> None:
+        """max_depth=None (default) walks to all leaves; no truncated nodes."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+
+        # No truncated nodes anywhere in the tree.
+        def _has_truncated(t: dict[str, Any]) -> bool:
+            if "truncated" in t:
+                return True
+            return any(_has_truncated(c) for c in t.get("children", []))
+
+        assert not _has_truncated(tree), "unbounded outline must not truncate"
+        # Inner.inner_method is accessible without truncation.
+        outer_node = _find_child(tree, _OUTER_HANDLE)
+        assert outer_node is not None
+        inner_node = _find_child(outer_node, _INNER_HANDLE)
+        assert inner_node is not None
+        inner_method_node = _find_child(inner_node, _INNER_METHOD_HANDLE)
+        assert inner_method_node is not None
+
+
+class TestOutlineMaxNodes:
+    """``max_nodes`` bounds total node count; hitting it marks not-yet-expanded
+    containers ``truncated: "max_nodes"`` with NO ``children`` and NO peek."""
+
+    @pytest.mark.asyncio
+    async def test_max_nodes_1_only_root_expanded(self, nested_analyzer: JediAnalyzer) -> None:
+        """max_nodes=1: root counts as node 1; no children expanded.
+        The module root has non-empty members but the budget is already full →
+        children absent (NOT peeked), truncated: "max_nodes"."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_nodes=1)
+        _assert_contract1(tree)
+        assert _count_nodes(tree) == 1
+        assert "truncated" in tree, "root with budget=1 and non-empty members must be truncated"
+        assert tree["truncated"] is True
+        assert tree["truncation_reason"] == "max_nodes"
+        assert "children" not in tree
+
+    @pytest.mark.asyncio
+    async def test_max_nodes_respects_budget(self, nested_analyzer: JediAnalyzer) -> None:
+        """Total node count never exceeds max_nodes."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        for budget in (2, 3, 4):
+            tree = await outline(_MOD_HANDLE, nested_analyzer, max_nodes=budget)
+            actual = _count_nodes(tree)
+            assert actual <= budget, f"max_nodes={budget} violated: got {actual} nodes"
+
+    @pytest.mark.asyncio
+    async def test_max_nodes_marks_containers_not_peeked(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """When the budget is exhausted, not-yet-expanded containers carry
+        ``truncated: "max_nodes"`` with ``children`` absent (no peek)."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        # Budget 2: root (1) + first child (2). Second child must be cut off.
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_nodes=2)
+        _assert_contract1(tree)
+
+        # Find any truncated-by-max_nodes node — must have no children key.
+        def _find_max_nodes_truncated(t: dict[str, Any]) -> list[dict[str, Any]]:
+            found = []
+            if t.get("truncation_reason") == "max_nodes":
+                found.append(t)
+            for c in t.get("children", []):
+                found.extend(_find_max_nodes_truncated(c))
+            return found
+
+        cut_off = _find_max_nodes_truncated(tree)
+        assert cut_off, "expected at least one max_nodes-truncated node"
+        for node in cut_off:
+            assert "children" not in node, "max_nodes truncated node must NOT carry children"
+
+
+class TestOutlineMaxNodesTiebreaker:
+    """When both a depth/external cap AND the node budget could fire on the same
+    node, ``truncation_reason`` must be ``"max_nodes"`` (spec §5.4 tiebreaker).
+
+    This pins a specific implementation choice — the budget is the harder global
+    bound and wins the reporting tiebreaker.  An implementation that reverses the
+    priority (reports ``"max_depth"`` when the budget also applies) fails here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_max_nodes_wins_over_max_depth_tiebreaker(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """Set max_depth=1 (Outer would be truncated "max_depth") AND max_nodes=2
+        so the budget fires first on the same node.
+
+        Structure at budget=2, depth=1:
+          root (node 1): walked
+          top_level_function (node 2): admitted — budget now full
+
+        Outer would be cut off by BOTH max_depth (it's at depth 1, the frontier,
+        and has non-empty members) AND max_nodes (budget is full). The tiebreaker
+        rule says max_nodes wins in truncation_reason.
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        # Budget 2: root + top_level_function fills the budget (BFS level order).
+        # Outer is the second sibling; by BFS it's at the same level. The
+        # implementation may expand top_level_function first (source order within
+        # BFS) — either top_level_function or Outer gets the second slot; the other
+        # is cut off by the budget.
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_depth=1, max_nodes=2)
+        _assert_contract1(tree)
+        assert _count_nodes(tree) == 2
+
+        # The child that was cut off (whichever one didn't get the budget slot)
+        # must report max_nodes (not max_depth) as truncation_reason.
+        all_children = tree.get("children", [])
+        # There will be one walked child and potentially more that are cut.
+        # All truncated children must have max_nodes as reason.
+        for child in all_children:
+            if "truncated" in child:
+                assert child["truncation_reason"] == "max_nodes", (
+                    f"budget+depth tiebreaker: expected 'max_nodes', "
+                    f"got {child['truncation_reason']!r}"
+                )
+
+
+class TestOutlineExternalCap:
+    """External-scope handles are capped at one level; deeper external containers
+    are ``truncated: "external"`` with ``children`` absent (no peek)."""
+
+    @pytest.mark.asyncio
+    async def test_external_root_gets_one_level(self, resolve_analyzer: JediAnalyzer) -> None:
+        """The external root itself always gets one level of members (the asymmetry:
+        root is walked, but deeper external containers are not)."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_PATHLIB_PATH_HANDLE, resolve_analyzer)
+        _assert_contract1(tree)
+        assert tree["node"]["scope"] == "external"
+        # The root must have been walked (``children`` present, not truncated).
+        assert "children" in tree, "external root must have children walked (one level)"
+        assert "truncated" not in tree, (
+            "the root itself must not be truncated — the external cap only applies "
+            "to nodes BELOW the root"
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_nested_containers_truncated(
+        self, resolve_analyzer: JediAnalyzer
+    ) -> None:
+        """Children of the external root that are themselves containers are capped:
+        ``truncated: "external"``, no ``children`` key."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_PATHLIB_PATH_HANDLE, resolve_analyzer)
+        _assert_contract1(tree)
+        # Any child of pathlib.Path that is a class/module (container) must be
+        # truncated with reason "external".
+        children = tree.get("children", [])
+        assert children, "pathlib.Path must have at least one child"
+        container_children = [c for c in children if c["node"]["kind"] in ("class", "module")]
+        for container in container_children:
+            assert "truncated" in container, (
+                f"external nested container {container['node']['handle']!r} " f"must be truncated"
+            )
+            assert container["truncation_reason"] == "external"
+            assert "children" not in container
+
+
+class TestOutlineSourceOrder:
+    """Sibling ``children`` are ordered by ``(line_start, handle)`` — source order.
+
+    Verified with a class whose members are alphabetically-out-of-source-order,
+    confirming that the implementation sorts by line number not by name.
+    """
+
+    @pytest.mark.asyncio
+    async def test_children_ordered_by_line_start(self, resolve_analyzer: JediAnalyzer) -> None:
+        """Widget's methods appear in source order, not alphabetical order.
+
+        Widget members (widgets.py line numbers):
+          color      line 29  (attribute)
+          name       line 32  (attribute)
+          visible    line 33  (attribute)
+          __init__   line 34  (method)
+          greet      line 37  (method)
+          slow_greet line 41  (method)
+          display_name line 45 (property)
+          default    line 50  (method)
+          normalize  line 55  (method)
+
+        Source order (ascending line_start) is NOT alphabetical order.
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_WIDGET_HANDLE, resolve_analyzer)
+        _assert_contract1(tree)
+        assert "children" in tree, "Widget must have walked children"
+        children = tree["children"]
+        assert children, "Widget must have at least one child"
+
+        line_starts = [c["node"]["line_start"] for c in children]
+        # Source order: each successive line_start >= previous.
+        for i in range(1, len(line_starts)):
+            assert line_starts[i] >= line_starts[i - 1], (
+                f"children not in source order at index {i}: "
+                f"{line_starts[i-1]} > {line_starts[i]} "
+                f"(handles: {children[i-1]['node']['handle']!r}, "
+                f"{children[i]['node']['handle']!r})"
+            )
+
+        # The handles must NOT be in alphabetical order (confirming we're using
+        # source order, not alpha order).
+        handles = [c["node"]["handle"] for c in children]
+        assert handles != sorted(handles), (
+            "children unexpectedly in alphabetical order — source order and "
+            "alphabetical order are the same, which means this fixture is unsuitable "
+            "for this test. Choose a fixture whose source order != alpha order."
+        )
+
+    @pytest.mark.asyncio
+    async def test_children_ordered_by_handle_when_same_line(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """When two children share the same line_start, the handle tiebreaker
+        ensures a stable, deterministic sort.  This test pins the sort key but
+        ONLY fires when a fixture actually has equal line numbers; otherwise it
+        simply verifies source order is monotone (non-decreasing)."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        _assert_contract1(tree)
+        children = tree.get("children", [])
+        for i in range(1, len(children)):
+            a = children[i - 1]["node"]
+            b = children[i]["node"]
+            assert (a["line_start"], a["handle"]) <= (
+                b["line_start"],
+                b["handle"],
+            ), f"children not in (line_start, handle) order: {a['handle']!r} > {b['handle']!r}"
+
+
+class TestOutlineTruncatedAbsenceContracts:
+    """Explicit two-sided tests for the §4.2 absence contracts.
+
+    These are the tests that fail loudly if an implementation skips the
+    frontier peek or emits ``truncated: false`` on fully-walked nodes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fully_walked_nodes_never_carry_truncated_false(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """No node in an unbounded outline may carry ``truncated: false``."""
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        def _find_truncated_false(t: dict[str, Any]) -> list[dict[str, Any]]:
+            """Return all nodes where truncated is False."""
+            bad = []
+            if t.get("truncated") is False:
+                bad.append(t)
+            for c in t.get("children", []):
+                bad.extend(_find_truncated_false(c))
+            return bad
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer)
+        bad = _find_truncated_false(tree)
+        assert bad == [], f"found nodes with truncated=False: {bad}"
+
+    @pytest.mark.asyncio
+    async def test_genuine_leaf_carries_empty_children_not_truncated(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """A method (genuine leaf) carries ``children: []`` — NOT
+        ``truncated: "max_depth"`` — even when at the depth frontier.
+
+        This is the load-bearing §4.2 distinction test: an implementation
+        that skips the peek would emit ``truncated: "max_depth"`` here instead.
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        # max_depth=1 puts outer_method AT the frontier.
+        tree = await outline(_OUTER_HANDLE, nested_analyzer, max_depth=1)
+        _assert_contract1(tree)
+        method_node = _find_child(tree, _OUTER_METHOD_HANDLE)
+        assert method_node is not None, "outer_method must be a child of Outer"
+        # The peek must determine it has no members → genuine leaf.
+        assert "children" in method_node, (
+            "outer_method at the depth frontier: peek finds no members → "
+            "must carry children: [] (genuine leaf), NOT be truncated"
+        )
+        assert method_node["children"] == []
+        assert (
+            "truncated" not in method_node
+        ), "a genuine leaf at the frontier must NOT be truncated"
+
+    @pytest.mark.asyncio
+    async def test_non_empty_container_at_frontier_is_truncated_not_empty(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """A non-empty container at the depth frontier carries
+        ``truncated: "max_depth"`` — NOT ``children: []``.
+
+        Complement to the test above: together they pin BOTH sides of the
+        peek distinction so an implementation that always emits ``[]`` or
+        always emits ``truncated`` fails loudly.
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        # max_depth=1 puts Outer at depth 1 (the frontier). Outer has members.
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_depth=1)
+        _assert_contract1(tree)
+        outer_node = _find_child(tree, _OUTER_HANDLE)
+        assert outer_node is not None
+        assert (
+            "truncated" in outer_node
+        ), "Outer at max_depth=1 frontier with non-empty members must be truncated"
+        assert outer_node["truncation_reason"] == "max_depth"
+        assert "children" not in outer_node, "truncated node must NOT have children key"
+
+
+class TestOutlineUnresolvableHandle:
+    """An unresolvable handle yields a minimal single-node tree with
+    ``children: []`` (mirrors ``inspect``'s minimal-node fallback)."""
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_handle_returns_minimal_tree(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        bad_handle = "definitely.not.a.real.symbol.in.any.fixture"
+        tree = await outline(bad_handle, nested_analyzer)
+        # Must not raise; must return a dict with a node.
+        assert isinstance(tree, dict), "outline must return a dict even for bad handles"
+        assert "node" in tree, "minimal fallback must have a node"
+        # Must carry children: [] (minimal measured empty) — NOT be truncated.
+        assert "children" in tree, "fallback tree must carry children: []"
+        assert tree["children"] == [], "fallback tree children must be empty"
+        assert "truncated" not in tree, "fallback tree must not be truncated"

--- a/tests/unit/mcp/operations/test_outline.py
+++ b/tests/unit/mcp/operations/test_outline.py
@@ -433,11 +433,17 @@ class TestOutlineMaxNodes:
         self, nested_analyzer: JediAnalyzer
     ) -> None:
         """When the budget is exhausted, not-yet-expanded containers carry
-        ``truncated: "max_nodes"`` with ``children`` absent (no peek)."""
+        ``truncated: "max_nodes"`` with ``children`` absent (no peek).
+
+        Budget=3: root (1) + top_level_function (2) + Outer (3). When Outer is
+        processed, the budget is full → Outer is truncated: "max_nodes" without
+        any peek into its members.
+        """
         from pyeye.mcp.operations.outline import outline  # type: ignore[import]
 
-        # Budget 2: root (1) + first child (2). Second child must be cut off.
-        tree = await outline(_MOD_HANDLE, nested_analyzer, max_nodes=2)
+        # Budget 3 puts Outer in the tree (node 3) but exhausts the budget before
+        # Outer can be expanded — so Outer gets truncated: "max_nodes", no peek.
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_nodes=3)
         _assert_contract1(tree)
 
         # Find any truncated-by-max_nodes node — must have no children key.
@@ -450,7 +456,7 @@ class TestOutlineMaxNodes:
             return found
 
         cut_off = _find_max_nodes_truncated(tree)
-        assert cut_off, "expected at least one max_nodes-truncated node"
+        assert cut_off, "expected at least one max_nodes-truncated node at budget=3"
         for node in cut_off:
             assert "children" not in node, "max_nodes truncated node must NOT carry children"
 
@@ -468,39 +474,46 @@ class TestOutlineMaxNodesTiebreaker:
     async def test_max_nodes_wins_over_max_depth_tiebreaker(
         self, nested_analyzer: JediAnalyzer
     ) -> None:
-        """Set max_depth=1 (Outer would be truncated "max_depth") AND max_nodes=2
-        so the budget fires first on the same node.
+        """Set max_depth=1 (Outer would be truncated "max_depth") AND max_nodes=3
+        so both caps apply to Outer simultaneously.
 
-        Structure at budget=2, depth=1:
-          root (node 1): walked
-          top_level_function (node 2): admitted — budget now full
+        Structure at budget=3, depth=1:
+          root (node 1): walked (depth 0)
+          top_level_function (node 2): depth 1 = frontier, non-container → children: []
+          Outer (node 3): depth 1 = frontier, container, budget now full
 
-        Outer would be cut off by BOTH max_depth (it's at depth 1, the frontier,
-        and has non-empty members) AND max_nodes (budget is full). The tiebreaker
-        rule says max_nodes wins in truncation_reason.
+        Outer is at the depth frontier (has non-empty members → would be
+        truncated: "max_depth") AND the budget is full (node_count == max_nodes →
+        would be truncated: "max_nodes").  Both caps could fire.  The tiebreaker
+        rule (spec §5.4) says max_nodes wins: truncation_reason must be "max_nodes".
         """
         from pyeye.mcp.operations.outline import outline  # type: ignore[import]
 
-        # Budget 2: root + top_level_function fills the budget (BFS level order).
-        # Outer is the second sibling; by BFS it's at the same level. The
-        # implementation may expand top_level_function first (source order within
-        # BFS) — either top_level_function or Outer gets the second slot; the other
-        # is cut off by the budget.
-        tree = await outline(_MOD_HANDLE, nested_analyzer, max_depth=1, max_nodes=2)
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_depth=1, max_nodes=3)
         _assert_contract1(tree)
-        assert _count_nodes(tree) == 2
+        assert _count_nodes(tree) == 3
 
-        # The child that was cut off (whichever one didn't get the budget slot)
-        # must report max_nodes (not max_depth) as truncation_reason.
-        all_children = tree.get("children", [])
-        # There will be one walked child and potentially more that are cut.
-        # All truncated children must have max_nodes as reason.
-        for child in all_children:
-            if "truncated" in child:
-                assert child["truncation_reason"] == "max_nodes", (
-                    f"budget+depth tiebreaker: expected 'max_nodes', "
-                    f"got {child['truncation_reason']!r}"
-                )
+        # Both func and Outer are children of root (3 nodes total).
+        func_node = _find_child(tree, _TOP_LEVEL_FUNC_HANDLE)
+        outer_node = _find_child(tree, _OUTER_HANDLE)
+        assert func_node is not None, "top_level_function must be a child"
+        assert outer_node is not None, "Outer must be a child"
+
+        # func (non-container, depth frontier): genuine leaf.
+        assert func_node.get("children") == [], "top_level_function must be a genuine leaf"
+        assert "truncated" not in func_node
+
+        # Outer: BOTH depth-frontier (has members → would be max_depth) AND
+        # budget-full (node 3 = max_nodes → would be max_nodes).
+        # Tiebreaker: max_nodes must win.
+        assert (
+            "truncated" in outer_node
+        ), "Outer at depth frontier with full budget must be truncated"
+        assert outer_node["truncation_reason"] == "max_nodes", (
+            f"budget+depth tiebreaker: expected 'max_nodes', "
+            f"got {outer_node['truncation_reason']!r}"
+        )
+        assert "children" not in outer_node
 
 
 class TestOutlineExternalCap:

--- a/tests/unit/mcp/operations/test_outline.py
+++ b/tests/unit/mcp/operations/test_outline.py
@@ -21,9 +21,11 @@ nested_class_inspect (primary — has the nesting the outline tests need)::
         outer_method      ← method (line 20) — genuine leaf
         Inner             ← nested class (line 24) — has members
           inner_method    ← method (line 27) — genuine leaf
+      Empty               ← class (line 35) — no members at all
 
 resolve_project (supplementary — Widget has alphabetically-out-of-source-order
-members, needed for the source-ordering test)::
+members, needed for the source-ordering test; xml.etree.ElementTree is used for
+the external nested-container truncation test)::
 
     mypackage._core.widgets.Widget
       __init__   (line 34)   — method
@@ -33,6 +35,11 @@ members, needed for the source-ordering test)::
       default    (line 50)   — method
       normalize  (line 55)   — method
       color      (line 29)   — attribute  ← alphabetically-earlier, line-earlier
+
+    xml.etree.ElementTree  ← external module with nested class children
+      ParseError            ← external class child → truncated: "external"
+      Element               ← external class child → truncated: "external"
+      … (9 container children total, all truncated: "external")
 
 Note: source order diverges from alphabetical (e.g. ``color`` at line 29 comes
 first in source but "c" sorts before "__"), so the ordering test verifies the
@@ -60,13 +67,17 @@ _OUTER_HANDLE = "pkg.mod.Outer"
 _OUTER_METHOD_HANDLE = "pkg.mod.Outer.outer_method"
 _INNER_HANDLE = "pkg.mod.Outer.Inner"
 _INNER_METHOD_HANDLE = "pkg.mod.Outer.Inner.inner_method"
+_EMPTY_HANDLE = "pkg.mod.Empty"
 
 # Canonical handles — resolve_project (for source-order test)
 _WIDGET_HANDLE = "mypackage._core.widgets.Widget"
-_WIDGETS_MODULE_HANDLE = "mypackage._core.widgets"
 
-# External stdlib handle — scope="external"
+# External stdlib handles — scope="external"
 _PATHLIB_PATH_HANDLE = "pathlib.Path"
+# xml.etree.ElementTree is an external module whose direct children include
+# several classes (ParseError, Element, QName, …) — container children that
+# must be truncated: "external" at depth ≥ 1 (spec §5.4).
+_XML_ET_HANDLE = "xml.etree.ElementTree"
 
 
 @pytest.fixture
@@ -557,6 +568,174 @@ class TestOutlineExternalCap:
             )
             assert container["truncation_reason"] == "external"
             assert "children" not in container
+
+
+class TestOutlineEmptyContainerPeek:
+    """At the ``max_depth`` frontier, the peek distinguishes a genuine-empty
+    container (→ ``children: []``) from a non-empty cut-off one (→ truncated).
+
+    This test exercises outline.py line 192 — the branch that fires when
+    ``resolve_members`` returns [] for a container at the depth frontier.
+
+    The Empty class in the nested_class_inspect fixture has no members;
+    top_level_function is a non-container; Outer has members.  At max_depth=1:
+    - top_level_function: non-container → short-circuits before peek → children: []
+    - Outer: container, peek finds members → truncated: "max_depth"
+    - Empty: container, peek finds NO members → children: []  ← line 192
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_class_at_frontier_receives_children_not_truncated(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """Empty at the max_depth frontier must carry ``children: []`` (genuine
+        empty container), NOT ``truncated: "max_depth"``.
+
+        An implementation that skips the peek and always emits ``truncated`` for
+        container nodes at the frontier would fail this test.
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        # max_depth=1 puts all module children (including Empty) at the frontier.
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_depth=1)
+        _assert_contract1(tree)
+        empty_node = _find_child(tree, _EMPTY_HANDLE)
+        assert empty_node is not None, (
+            f"Empty class not found as direct child of {_MOD_HANDLE}; "
+            f"available: {[c['node']['handle'] for c in tree.get('children', [])]}"
+        )
+        # Empty is a class (container) with zero members — peek finds []:
+        # it must receive children: [], NOT be truncated.
+        assert "children" in empty_node, (
+            "Empty at max_depth frontier: peek finds no members → "
+            "must carry children: [] (genuine empty container), NOT be truncated"
+        )
+        assert (
+            empty_node["children"] == []
+        ), "Empty has no members — children must be the empty list"
+        assert (
+            "truncated" not in empty_node
+        ), "Empty is a genuine empty container — must NOT carry truncated"
+
+    @pytest.mark.asyncio
+    async def test_empty_container_peek_both_sides_at_once(
+        self, nested_analyzer: JediAnalyzer
+    ) -> None:
+        """Simultaneous check: at max_depth=1, Outer (non-empty container at
+        frontier) is truncated AND Empty (empty container at frontier) carries
+        children: [].
+
+        This pins both sides of the spec §5.3 peek distinction in one test so
+        neither side can pass vacuously.
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_MOD_HANDLE, nested_analyzer, max_depth=1)
+        _assert_contract1(tree)
+        outer_node = _find_child(tree, _OUTER_HANDLE)
+        empty_node = _find_child(tree, _EMPTY_HANDLE)
+        assert outer_node is not None, "Outer must be a child of the module"
+        assert empty_node is not None, "Empty must be a child of the module"
+
+        # Non-empty container at frontier: truncated.
+        assert "truncated" in outer_node
+        assert outer_node["truncation_reason"] == "max_depth"
+        assert "children" not in outer_node
+
+        # Empty container at frontier: genuine empty (children: []).
+        assert "children" in empty_node
+        assert empty_node["children"] == []
+        assert "truncated" not in empty_node
+
+
+class TestOutlineExternalNestedContainerTruncation:
+    """External nested containers (depth ≥ 1) are truncated: "external" with
+    no ``children`` key (outline.py lines 182-184).
+
+    This test exercises the branch that fires when an external container is
+    encountered at depth ≥ 1 during the BFS walk.
+
+    ``xml.etree.ElementTree`` is an external module whose direct members
+    include several class children (ParseError, Element, QName, ElementTree,
+    …).  When we outline the module, those class children are at depth 1 with
+    scope="external" → they must each be truncated: "external", no children.
+
+    The root module itself (depth 0) must NOT be truncated — the external cap
+    only applies at depth ≥ 1 (spec §5.4 asymmetry).
+    """
+
+    @pytest.mark.asyncio
+    async def test_external_module_root_walked_container_children_truncated(
+        self, resolve_analyzer: JediAnalyzer
+    ) -> None:
+        """The external module root (depth 0) is walked; its class children
+        (depth 1, scope=external) are each truncated: "external", no children.
+
+        This directly exercises lines 182-184 of outline.py.
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_XML_ET_HANDLE, resolve_analyzer)
+        _assert_contract1(tree)
+
+        # Root: external module, depth 0 — must be walked (one level).
+        assert tree["node"]["scope"] == "external"
+        assert "children" in tree, "external module root must have its children walked"
+        assert "truncated" not in tree, "root at depth 0 must NOT be truncated by external cap"
+
+        # Collect children whose kind is a container.
+        children = tree["children"]
+        assert children, "xml.etree.ElementTree must have at least one child"
+        container_children = [c for c in children if c["node"]["kind"] in ("class", "module")]
+
+        # xml.etree.ElementTree has at least 4 class children (ParseError, Element,
+        # QName, ElementTree) — we assert there are some so the loop below runs.
+        assert container_children, (
+            "xml.etree.ElementTree must have at least one class/module child "
+            "so that the external-cap branch (outline.py 182-184) is exercised"
+        )
+
+        # Each external container child at depth 1 must be truncated: "external",
+        # with no children key (absence contract).
+        for container in container_children:
+            node = container["node"]
+            assert "truncated" in container, (
+                f"external nested container {node['handle']!r} at depth 1 "
+                f"must be truncated (scope={node['scope']!r})"
+            )
+            assert container["truncated"] is True
+            assert container["truncation_reason"] == "external", (
+                f"{node['handle']!r}: expected truncation_reason='external', "
+                f"got {container['truncation_reason']!r}"
+            )
+            assert "children" not in container, (
+                f"truncated external container {node['handle']!r} "
+                f"must NOT carry children (absence contract)"
+            )
+
+    @pytest.mark.asyncio
+    async def test_external_root_vs_nested_asymmetry(self, resolve_analyzer: JediAnalyzer) -> None:
+        """Assert the root-vs-nested asymmetry explicitly: root is walked,
+        nested containers are not.  This pins spec §5.4 in a single focused test.
+        """
+        from pyeye.mcp.operations.outline import outline  # type: ignore[import]
+
+        tree = await outline(_XML_ET_HANDLE, resolve_analyzer)
+        _assert_contract1(tree)
+
+        # Root: walked (children present, no truncated key).
+        assert "children" in tree
+        assert "truncated" not in tree
+
+        # At least one container child exists and is truncated: "external".
+        container_children = [
+            c for c in tree["children"] if c["node"]["kind"] in ("class", "module")
+        ]
+        assert container_children, "need at least one container child for asymmetry test"
+        first = container_children[0]
+        assert first.get("truncated") is True
+        assert first.get("truncation_reason") == "external"
+        assert "children" not in first
 
 
 class TestOutlineSourceOrder:


### PR DESCRIPTION
## Summary

Builds `outline` — the last unbuilt progressive-disclosure primitive (Phase 2 of the outline/expand/trace plan). `outline(handle)` returns the **structural skeleton** of a module or class: a tree of `(name, kind, signature, line span)` with **no source content**, in a single call. Completes the primitive set (`resolve`/`inspect`/`outline`/`expand`/`trace`).

`outline` is a pure *consumer* of the existing `members` edge (`edges.resolve_members`) — like `trace`, it adds traversal/bookkeeping but **no new edge logic and no change to `edges.py`**.

## Design

Reviewer-approved spec: `docs/superpowers/specs/2026-06-13-outline-design.md` (refines the 2026-05-02 parent design with the honesty conventions `expand`/`trace` established). Plan: `docs/superpowers/plans/2026-06-13-outline.md`.

Key decisions:
- **Two absence contracts** (the honesty backbone): `children` absent ⇔ not-walked (`children: []` = measured-empty); `truncated` is absent-not-false, co-occurring with `truncation_reason` ∈ {`max_depth`, `max_nodes`, `external`} and absent `children`. Stops a cut-off container from impersonating a genuine leaf (the #332 absence-vs-zero trap).
- **BFS inclusion, source-order presentation**: the `max_nodes` budget is spent breadth-first so truncation degrades gracefully; siblings are sorted `(line_start, handle)` so the skeleton reads top-to-bottom like the file.
- **Bounds**: `max_depth` (default unbounded within scope), `max_nodes=200`, and an external-scope cap (`min(max_depth, 1)` for third-party code). The depth frontier *peeks* to distinguish a genuine leaf from a cut-off container; budget/external cutoffs do not.

## Changes

- `src/pyeye/mcp/operations/outline.py` — the operation (iterative BFS over `resolve_members`).
- `src/pyeye/mcp/server.py` — registers the `outline` `@mcp.tool` (mirrors `trace`).
- `tests/conformance/response_linter.py` — Check O validates `OutlineTree` (layering + the §4.2 invariants, recursive); a **separate** `_VALID_OUTLINE_TRUNCATION_REASONS` constant (trace's untouched, so trace validation is not loosened).
- Unit, integration (wire-level), and adversarial-linter tests; one fixture addition.

## Test plan

- [x] Full suite green (2001 passed) at the 85% coverage threshold; conformance 235/235
- [x] `outline.py` at 100% line coverage; both load-bearing branches (empty-container peek, external-cap) genuinely exercised
- [x] Integration tests assert absence-of-`children` survives the JSON wire, and `len(children) == inspect(...).edge_counts.members` (spec §6.4)
- [x] No `get_references`/`find_references` on the `outline` path; no change to `edges.py`/`resolve_members`

Closes #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)