### PR TITLE
feat(superclasses): promote superclasses to a supported expand/trace edge (#361)

### DIFF
--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -7,18 +7,19 @@ This module is the **single source of truth** for which traversal edges
    machine-distinguishable statuses.  The status string IS the ``reason``
    string ``expand`` emits for unsupported edges.
 2. :data:`EDGE_RESOLVERS` / the resolver registry — maps *implemented* edge
-   names (``members``, ``callees``, ``imported_by``, ``subclasses``) to their
-   resolver callables.  ``members``/``callees`` are synchronous and always
-   return an :class:`EdgeResult`; ``imported_by`` and ``subclasses`` are
-   **async**.  ``imported_by`` returns ``EdgeResult | None`` — ``None`` is its
-   wrong-kind signal (the handle is not a module).  ``subclasses`` ALWAYS
-   returns an :class:`EdgeResult` (never ``None``): a non-class handle yields
-   ``EdgeResult([])`` because only a class CAN be subclassed, so ``[]`` for the
-   wrong kind is true by definition (the ``members``/``callees`` case), not the
-   absence-vs-zero lie that forces ``imported_by``'s ``None`` path.  An
-   :class:`EdgeResult` carries the adjacent canonical handles plus, for
-   ``callees`` only, the count of unresolved call sites.  ``expand`` awaits any
-   awaitable resolver result.
+   names (``members``, ``callees``, ``imported_by``, ``subclasses``,
+   ``superclasses``) to their resolver callables.  ``members``/``callees``/
+   ``superclasses`` are synchronous and always return an :class:`EdgeResult`;
+   ``imported_by`` and ``subclasses`` are **async**.  ``imported_by`` returns
+   ``EdgeResult | None`` — ``None`` is its wrong-kind signal (the handle is
+   not a module).  ``subclasses`` and ``superclasses`` ALWAYS return an
+   :class:`EdgeResult` (never ``None``): a non-class handle yields
+   ``EdgeResult([])`` because only a class CAN be subclassed/have superclasses,
+   so ``[]`` for the wrong kind is true by definition (the
+   ``members``/``callees`` case), not the absence-vs-zero lie that forces
+   ``imported_by``'s ``None`` path.  An :class:`EdgeResult` carries the
+   adjacent canonical handles plus, for ``callees`` only, the count of
+   unresolved call sites.  ``expand`` awaits any awaitable resolver result.
 
 Status model (spec §4.3)
 ------------------------
@@ -26,9 +27,8 @@ Status model (spec §4.3)
 status                          edges
 ==============================  =========================================
 ``"implemented"``               ``members``, ``callees``, ``imported_by``,
-                                ``subclasses``
-``"not_yet_implemented"``       ``superclasses``, ``imports``,
-                                ``enclosing_scope``
+                                ``subclasses``, ``superclasses``
+``"not_yet_implemented"``       ``imports``, ``enclosing_scope``
 ``"deferred_reference_backend"``  ``callers``, ``references``, ``read_by``,
                                 ``written_by``, ``passed_by``,
                                 ``overrides``, ``overridden_by``,
@@ -40,11 +40,10 @@ Architectural constraint
 -------------------------
 This module MUST NOT import from ``inspect.py``.  ``inspect`` imports
 :func:`resolve_members` to derive ``edge_counts.members`` (landed in Phase 5)
-— importing back from ``inspect`` here would create a circular import.
-``resolve_members`` is therefore the **sole** member-enumeration source;
-``inspect._count_class_members`` and ``inspect._count_module_members`` are now
-thin delegators into it (the duplication that existed before Phase 5 has been
-removed).
+and :func:`resolve_superclasses` to derive ``edge_counts.superclasses``
+(landed in Phase 6 / #361) — importing back from ``inspect`` here would
+create a circular import.  ``resolve_members`` and ``resolve_superclasses``
+are therefore the **sole** enumeration sources for their respective edges.
 
 The ``members`` resolver is pure structural enumeration — it never calls
 ``get_references`` / ``find_references``.  The module path uses Jedi
@@ -123,10 +122,10 @@ STATUS_DEFERRED_REFERENCE_BACKEND = "deferred_reference_backend"
 STATUS_UNKNOWN_EDGE = "unknown_edge"
 
 #: Edges with a working (or Phase-3-bound) resolver.
-_IMPLEMENTED_EDGES = frozenset({"members", "callees", "imported_by", "subclasses"})
+_IMPLEMENTED_EDGES = frozenset({"members", "callees", "imported_by", "subclasses", "superclasses"})
 
 #: Edges recognised by the matrix but not yet built (no reference backend needed).
-_NOT_YET_IMPLEMENTED_EDGES = frozenset({"superclasses", "imports", "enclosing_scope"})
+_NOT_YET_IMPLEMENTED_EDGES = frozenset({"imports", "enclosing_scope"})
 
 #: Inbound / reference edges deferred until an indexed reference backend lands.
 _DEFERRED_REFERENCE_BACKEND_EDGES = frozenset(
@@ -754,17 +753,150 @@ async def resolve_subclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResu
 
 
 # ---------------------------------------------------------------------------
+# superclasses resolver (#361) — direct-base AST walk + forward goto, sync
+# ---------------------------------------------------------------------------
+
+
+def resolve_superclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult:
+    """Return the DIRECT superclasses of a class as canonical handles.
+
+    The inbound-but-reliably-static ``superclasses`` edge for a **class**
+    handle.  Returns only DIRECT bases (no MRO closure), mirroring the count
+    in ``inspect.edge_counts.superclasses``.  This is a deliberate asymmetry
+    with ``subclasses``, which returns the full project closure.
+
+    Mechanics:
+
+    1. Walk the class's cached AST to locate its ``ClassDef.bases`` — the
+       declared direct bases (source order).
+    2. For each base expression, call ``script.goto(line, col,
+       follow_imports=True)`` with the position from
+       :func:`attr_target_position`, preferring ``class``-kind results, so
+       ``pkg.sub.ClassName`` resolves to the class, not the package.
+    3. Keep the first goto def that has a ``full_name`` and builds a valid
+       :class:`Handle`.  The goto ``Name`` is carried directly as the
+       adjacent's ``Name`` (no re-resolution).
+    4. Dedup by canonical handle string; sort by handle string for
+       deterministic order (like ``resolve_subclasses``).
+    5. Bases that produce no goto result with a ``full_name`` are DROPPED
+       (can't build a valid stub without a ``Name``).  This is intentional —
+       the count derives from this resolver (see ``inspect._count_superclasses``)
+       so ``len(stubs) == inspect.edge_counts.superclasses`` is guaranteed by
+       construction.
+
+    Kind gate (the defining decision of this edge):
+
+    - **class** → measured: ``EdgeResult`` with the direct-base handles
+      (possibly empty if the class has no explicit bases — a genuine measured
+      "none").
+    - **non-class** (function / variable / module / …) → ``EdgeResult([])``,
+      NEVER ``None``.  Only a class CAN have superclasses, so ``[]`` for the
+      wrong kind is true by definition (exactly the ``members``/``callees``
+      case) — NOT the absence-vs-zero lie that forces ``imported_by``'s
+      ``None`` path.  Because this resolver never returns ``None``,
+      ``expand.py`` needs no change.
+
+    Synchronous: AST walk + per-base Jedi ``goto`` + ``Handle`` construction
+    are all sync, like ``resolve_members``/``resolve_callees``.  No
+    ``get_references`` / ``find_references`` is ever called.
+
+    Args:
+        jedi_name: Resolved Jedi ``Name`` for the target.  Class-ness is
+            derived from its normalised kind; ``module_path`` and ``line``
+            are used to locate the ``ClassDef`` node.
+        analyzer: Active analyzer (for the Jedi project used by
+            ``get_script``).
+
+    Returns:
+        An :class:`EdgeResult` whose ``adjacents`` are the direct base-class
+        ``(canonical Handle, Jedi Name)`` pairs for a class target, sorted by
+        handle string; or ``EdgeResult([])`` for any non-class target.
+        ``unresolved_call_sites`` is always ``None`` — that notion is
+        callees-only.
+    """
+    if _normalise_kind(getattr(jedi_name, "type", None)) != "class":
+        return EdgeResult(adjacents=[])
+
+    file_path = getattr(jedi_name, "module_path", None)
+    line = getattr(jedi_name, "line", None)
+    if file_path is None or line is None:
+        return EdgeResult(adjacents=[])
+
+    try:
+        tree = file_artifact_cache.get_ast(file_path)
+        script = file_artifact_cache.get_script(file_path, analyzer.project)
+    except Exception:
+        return EdgeResult(adjacents=[])
+
+    # Locate the ClassDef at the class's definition line.
+    class_node: ast.ClassDef | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.lineno == line:
+            class_node = node
+            break
+    if class_node is None or not class_node.bases:
+        return EdgeResult(adjacents=[])
+
+    seen: set[str] = set()
+    adjacents: list[tuple[Handle, Any]] = []
+
+    for base in class_node.bases:
+        # Resolve the base AST node to a (line, col) position for goto.
+        # attr_target_position returns the rightmost identifier in an
+        # attribute chain (e.g. pkg.sub.ClassName → ClassName), so goto
+        # lands on the class definition, not the package.
+        try:
+            base_line, base_col = attr_target_position(base)
+        except Exception:
+            # Unresolvable base expression (e.g. complex subscript) — drop.
+            continue
+
+        try:
+            defs = script.goto(base_line, base_col, follow_imports=True)
+        except Exception:
+            continue
+
+        # Prefer class-kind results; fall back to any named result.
+        # This matches _resolve_base_class_via_jedi in inspect.py.
+        class_defs = [d for d in defs if d.type == "class" and d.full_name]
+        named_defs = [d for d in defs if d.full_name]
+        candidates = class_defs if class_defs else named_defs
+
+        for candidate in candidates:
+            full_name = candidate.full_name
+            if not full_name:
+                continue
+            h = _try_handle(full_name)
+            if h is None:
+                continue
+            key = str(h)
+            if key in seen:
+                break  # dedup: first occurrence wins; skip remaining candidates
+            seen.add(key)
+            adjacents.append((h, candidate))
+            break  # first valid candidate for this base is sufficient
+
+    # Sort by canonical handle string for deterministic order across runs
+    # (mirrors resolve_subclasses — set iteration order is PYTHONHASHSEED-
+    # dependent, but here we walk bases in source order, which IS deterministic;
+    # sorting is still applied for consistency with the subclasses contract).
+    adjacents.sort(key=lambda pair: str(pair[0]))
+
+    return EdgeResult(adjacents=adjacents)
+
+
+# ---------------------------------------------------------------------------
 # Resolver registry
 # ---------------------------------------------------------------------------
 
-#: Maps *implemented* edge names → resolver callables.  ``members``/``callees``
-#: are synchronous and always return an :class:`EdgeResult`; ``imported_by`` and
-#: ``subclasses`` are async.  ``imported_by`` may return ``None`` (its wrong-kind
-#: signal); ``subclasses`` always returns an :class:`EdgeResult` (non-class →
-#: ``EdgeResult([])``, never ``None``).  The value type therefore admits a
-#: sync-or-async resolver returning ``EdgeResult | None`` so ``expand`` can stay
-#: edge-agnostic (awaiting awaitable results, treating ``None`` as
-#: not-yet-implemented).
+#: Maps *implemented* edge names → resolver callables.  ``members``/``callees``/
+#: ``superclasses`` are synchronous and always return an :class:`EdgeResult`;
+#: ``imported_by`` and ``subclasses`` are async.  ``imported_by`` may return
+#: ``None`` (its wrong-kind signal); ``subclasses`` and ``superclasses`` always
+#: return an :class:`EdgeResult`` (non-class → ``EdgeResult([])``, never ``None``).
+#: The value type therefore admits a sync-or-async resolver returning
+#: ``EdgeResult | None`` so ``expand`` can stay edge-agnostic (awaiting
+#: awaitable results, treating ``None`` as not-yet-implemented).
 EDGE_RESOLVERS: dict[
     str, Callable[[Any, JediAnalyzer], EdgeResult | None | Awaitable[EdgeResult | None]]
 ] = {
@@ -772,4 +904,5 @@ EDGE_RESOLVERS: dict[
     "callees": resolve_callees,
     "imported_by": resolve_imported_by,
     "subclasses": resolve_subclasses,
+    "superclasses": resolve_superclasses,
 }

--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -429,6 +429,12 @@ def _get_superclasses(jedi_name: Any, analyzer: JediAnalyzer) -> list[str]:
     then jedi script.goto() per base to resolve to canonical handles.
     Falls back to ast.unparse of the base expression when goto fails.
 
+    NOTE — field-vs-count divergence: this function keeps ALL declared bases
+    (including raw ``ast.unparse`` fallback strings when goto fails).  Such
+    fallback entries appear in the ``superclasses`` field but are EXCLUDED from
+    ``edge_counts.superclasses``, which counts only goto-resolvable bases
+    (see ``_count_superclasses``).
+
     Args:
         jedi_name: A Jedi ``Name`` object for a class.
         analyzer: Active analyzer for file-level Jedi access.
@@ -734,7 +740,7 @@ async def _count_superclasses(
     with the expandable edge, at the cost of a rare class with an unresolvable
     base showing that base in the ``superclasses`` FIELD but not in
     ``edge_counts.superclasses``.  This intentional divergence is acceptable
-    (and documented in ``_build_class_fields`` / ``_get_superclasses``).
+    (documented here, and in the ``_get_superclasses`` docstring).
 
     The ``superclasses`` parameter is RETAINED for call-site stability:
     ``_build_edge_counts`` passes it positionally as
@@ -949,9 +955,12 @@ async def inspect(handle: str, analyzer: JediAnalyzer) -> dict[str, Any]:
     # ------------------------------------------------------------------
     kind_fields: dict[str, Any] = {}
 
-    # Issue #339: resolve a class's superclasses once and reuse the same list for
-    # the `superclasses` field and `edge_counts.superclasses` (each resolution
-    # is read+parse + a Jedi goto() per base).
+    # The resolved-bases list feeds the `superclasses` FIELD only.
+    # `edge_counts.superclasses` is derived independently via `resolve_superclasses`
+    # (delegated through `_count_superclasses`) — changed in #361 so that the count
+    # matches the expandable edge (which drops unresolvable bases) rather than the
+    # field (which keeps them as ast.unparse fallbacks).  The two values can therefore
+    # diverge for classes whose bases cannot be resolved via goto.
     superclasses: list[str] | None = None
     if kind == "class":
         superclasses = _get_superclasses(jedi_name, analyzer)
@@ -978,7 +987,8 @@ async def inspect(handle: str, analyzer: JediAnalyzer) -> dict[str, Any]:
     }
     node.update(kind_fields)
     # Phase 4: edge_counts populated with per-measurement budgeted counts.
-    # Reuse the already-resolved superclasses list (issue #339).
+    # `superclasses` is passed for call-site stability but is unused by
+    # `_count_superclasses` (which derives the count from `resolve_superclasses`).
     node["edge_counts"] = await _build_edge_counts(
         handle, kind, jedi_name, analyzer, superclasses=superclasses
     )

--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -47,7 +47,7 @@ from pyeye._jedi_location import location_from_name
 from pyeye._module_sentinel import ModuleSentinel
 from pyeye.canonicalization import collect_re_exports, find_module_file
 from pyeye.handle import Handle
-from pyeye.mcp.operations.edges import resolve_members
+from pyeye.mcp.operations.edges import resolve_members, resolve_superclasses
 from pyeye.mcp.operations.resolve import _normalise_kind  # reuse kind table
 from pyeye.mcp.operations.typeref import build_typeref
 from pyeye.scope import classify_scope
@@ -719,25 +719,44 @@ async def _count_module_members(jedi_name: Any, analyzer: JediAnalyzer) -> int:
 async def _count_superclasses(
     jedi_name: Any, analyzer: JediAnalyzer, superclasses: list[str] | None = None
 ) -> int:
-    """Count direct superclasses of a class.
+    """Count direct superclasses of a class (resolvable via goto only).
 
-    Re-uses ``_get_superclasses`` (the AST + Jedi goto approach already
-    implemented for the ``superclasses`` kind-dependent field) and returns
-    the count of the resolved list.
+    Delegates to :func:`edges.resolve_superclasses` — the single enumeration
+    source for the ``superclasses`` expand edge since #361.  This guarantees
+    the progressive-disclosure contract:
+    ``len(expand(h, "superclasses").stubs) == inspect(h).edge_counts.superclasses``.
+
+    WHY count now derives from the resolver rather than ``_get_superclasses``:
+    The resolver drops bases that cannot be resolved to a valid Jedi ``Name``
+    via ``goto`` (no ``full_name`` → can't build a stub without a Name), while
+    ``_get_superclasses`` keeps ALL declared bases (incl. raw-string fallbacks).
+    Routing the count through the resolver guarantees equality BY CONSTRUCTION
+    with the expandable edge, at the cost of a rare class with an unresolvable
+    base showing that base in the ``superclasses`` FIELD but not in
+    ``edge_counts.superclasses``.  This intentional divergence is acceptable
+    (and documented in ``_build_class_fields`` / ``_get_superclasses``).
+
+    The ``superclasses`` parameter is RETAINED for call-site stability:
+    ``_build_edge_counts`` passes it positionally as
+    ``_count_superclasses(jedi_name, analyzer, superclasses)``.  The parameter
+    is no longer used by the implementation (the count is now derived from the
+    resolver, not the pre-resolved list), but removing it would require touching
+    all callers with no safety benefit — the compiler/type-checker will simply
+    ignore the unused argument.
 
     Args:
         jedi_name: Jedi ``Name`` for the class.
         analyzer: Active analyzer.
-        superclasses: Pre-resolved superclass list, when the caller already
-            computed it for the ``superclasses`` field — avoids resolving the
-            bases a second time (issue #339).  Resolved on demand when omitted.
+        superclasses: Pre-resolved superclass list (retained for call-site
+            stability; no longer used by this implementation — the count is
+            derived from ``resolve_superclasses`` instead).
 
     Returns:
-        Count of direct superclasses.
+        Count of direct superclasses resolvable via goto (the same count as
+        the ``superclasses`` expand edge will return as stubs).
     """
-    if superclasses is None:
-        superclasses = _get_superclasses(jedi_name, analyzer)
-    return len(superclasses)
+    _ = superclasses  # retained for call-site stability; unused by this impl
+    return len(resolve_superclasses(jedi_name, analyzer).handles)
 
 
 async def _count_subclasses(handle: str, analyzer: JediAnalyzer) -> int:

--- a/tests/fixtures/superclasses_edge/pkg/__init__.py
+++ b/tests/fixtures/superclasses_edge/pkg/__init__.py
@@ -1,0 +1,6 @@
+"""Package init for the superclasses-edge fixture (issue #361).
+
+Exposes nothing — the fixture's classes are addressed by their definition-site
+FQNs (``pkg.bases.Base``, ``pkg.derived.Child`` etc.) so the ``superclasses``
+expand resolver can be exercised against a known topology.
+"""

--- a/tests/fixtures/superclasses_edge/pkg/bases.py
+++ b/tests/fixtures/superclasses_edge/pkg/bases.py
@@ -1,0 +1,27 @@
+"""Base classes for the superclasses-edge fixture (issue #361).
+
+Canonical handles:
+- ``pkg.bases.Base``      — a project-defined base class (no own superclasses)
+- ``pkg.bases.Mixin``     — a second project-defined base class (no own superclasses)
+- ``pkg.bases.Loner``     — a class with NO superclasses (measured-empty case)
+
+Topology exercised by the superclasses resolver tests:
+
+- ``pkg.derived.Child``        → DIRECT superclass: ``pkg.bases.Base``
+- ``pkg.derived.MultiChild``   → TWO direct superclasses: ``pkg.bases.Base``,
+                                 ``pkg.bases.Mixin``
+- ``pkg.derived.ExternalChild``→ DIRECT superclass: external (``pathlib.PurePosixPath``)
+- ``pkg.bases.Base``           → no superclasses (measured-empty case for the base itself)
+"""
+
+
+class Base:
+    """Top-level project base class with no superclasses."""
+
+    name: str = "base"
+
+
+class Mixin:
+    """A second project-level base class used for multiple-inheritance tests."""
+
+    value: int = 0

--- a/tests/fixtures/superclasses_edge/pkg/bases.py
+++ b/tests/fixtures/superclasses_edge/pkg/bases.py
@@ -3,7 +3,6 @@
 Canonical handles:
 - ``pkg.bases.Base``      — a project-defined base class (no own superclasses)
 - ``pkg.bases.Mixin``     — a second project-defined base class (no own superclasses)
-- ``pkg.bases.Loner``     — a class with NO superclasses (measured-empty case)
 
 Topology exercised by the superclasses resolver tests:
 

--- a/tests/fixtures/superclasses_edge/pkg/derived.py
+++ b/tests/fixtures/superclasses_edge/pkg/derived.py
@@ -48,6 +48,17 @@ class GrandChild(Child):
     extra2: str = "grandchild"
 
 
+class Weird(
+    NotDefinedAnywhere  # noqa: F821 — intentionally undefined to test goto-failure drop path
+):  # base intentionally undefined — exercises the drop-and-diverge path
+    # This file is only statically analyzed, never executed, so an undefined
+    # name in the class header is safe.  The class tests that `resolve_superclasses`
+    # drops unresolvable bases (edge_counts.superclasses == 0) while
+    # `_get_superclasses` still records them as ast.unparse fallback strings
+    # (superclasses field contains "NotDefinedAnywhere").
+    pass
+
+
 def function_in_module() -> None:
     """A plain function — non-class, wrong-kind case for superclasses tests."""
 

--- a/tests/fixtures/superclasses_edge/pkg/derived.py
+++ b/tests/fixtures/superclasses_edge/pkg/derived.py
@@ -37,6 +37,17 @@ class ExternalChild(PurePosixPath):
         return super().__new__(cls, *args)
 
 
+class GrandChild(Child):
+    """Has exactly one direct superclass: ``pkg.derived.Child``.
+
+    Exercises the direct-bases-not-MRO contract: ``resolve_superclasses`` must
+    return only ``Child`` (the immediate parent), NOT the transitive ancestor
+    ``pkg.bases.Base``.  The chain is ``GrandChild -> Child -> Base``.
+    """
+
+    extra2: str = "grandchild"
+
+
 def function_in_module() -> None:
     """A plain function — non-class, wrong-kind case for superclasses tests."""
 

--- a/tests/fixtures/superclasses_edge/pkg/derived.py
+++ b/tests/fixtures/superclasses_edge/pkg/derived.py
@@ -1,0 +1,44 @@
+"""Derived classes for the superclasses-edge fixture (issue #361).
+
+Exercises the topology the ``superclasses`` expand resolver must handle:
+
+- ``Child``         — one project superclass (``pkg.bases.Base``)
+- ``MultiChild``    — two project superclasses (``pkg.bases.Base``, ``pkg.bases.Mixin``)
+- ``ExternalChild`` — one external (stdlib) superclass (``pathlib.PurePosixPath``)
+- ``function_in_module`` — a plain function (non-class, wrong-kind case)
+- ``VAR_IN_MODULE`` — a module-level variable (non-class, wrong-kind case)
+"""
+
+from pathlib import PurePosixPath
+
+from pkg.bases import Base, Mixin
+
+
+class Child(Base):
+    """Has exactly one project-internal superclass: ``pkg.bases.Base``."""
+
+    extra: str = "child"
+
+
+class MultiChild(Base, Mixin):
+    """Has two project-internal superclasses: ``pkg.bases.Base`` and ``pkg.bases.Mixin``."""
+
+    combined: str = "multi"
+
+
+class ExternalChild(PurePosixPath):
+    """Has one external (stdlib) superclass: ``pathlib.PurePosixPath``.
+
+    Tests that external bases are included in the ``superclasses`` edge result.
+    """
+
+    def __new__(cls, *args: str) -> "ExternalChild":
+        """Required for PurePosixPath subclassing."""
+        return super().__new__(cls, *args)
+
+
+def function_in_module() -> None:
+    """A plain function — non-class, wrong-kind case for superclasses tests."""
+
+
+VAR_IN_MODULE: int = 42

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -99,6 +99,7 @@ _MIXIN_HANDLE = "pkg.bases.Mixin"  # second project base (measured-empty supercl
 _CHILD_HANDLE = "pkg.derived.Child"  # one project superclass: pkg.bases.Base
 _MULTI_CHILD_HANDLE = "pkg.derived.MultiChild"  # two project superclasses
 _EXTERNAL_CHILD_HANDLE = "pkg.derived.ExternalChild"  # one external superclass
+_GRANDCHILD_HANDLE = "pkg.derived.GrandChild"  # one direct superclass: Child (not Base)
 _FUNCTION_HANDLE = "pkg.derived.function_in_module"  # function (wrong-kind)
 _VAR_HANDLE = "pkg.derived.VAR_IN_MODULE"  # variable (wrong-kind)
 
@@ -1090,3 +1091,107 @@ class TestResolveSuperclassesCountConsistency:
         assert (
             resolver_count == counter_count == 0
         ), f"resolver={resolver_count}, counter={counter_count}; expected both == 0"
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — direct-bases-not-MRO regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSuperclassesDirectNotMRO:
+    """``resolve_superclasses`` returns DIRECT bases only — NOT the full MRO/ancestor closure.
+
+    Topology: ``GrandChild(Child)`` → ``Child(Base)`` → ``Base``
+
+    When ``resolve_superclasses(GrandChild)`` is called it MUST return only
+    ``Child`` (the one direct parent).  ``Base`` is an ancestor via the MRO but
+    is NOT a direct base of ``GrandChild`` and therefore MUST NOT appear.
+
+    This test class is the load-bearing guard against a future regression that
+    accidentally walks the full MRO instead of reading ``ast.ClassDef.bases``.
+    """
+
+    def test_grandchild_direct_base_is_child(self, superclasses_analyzer: JediAnalyzer) -> None:
+        """``GrandChild`` has exactly one direct superclass: ``pkg.derived.Child``."""
+        handles = {
+            str(h) for h in _superclasses_for(_GRANDCHILD_HANDLE, superclasses_analyzer).handles
+        }
+        assert (
+            _CHILD_HANDLE in handles
+        ), f"direct base Child missing from GrandChild superclasses; got {handles}"
+
+    def test_grandchild_does_not_include_grandparent(
+        self, superclasses_analyzer: JediAnalyzer
+    ) -> None:
+        """``Base`` is a transitive ancestor but NOT a direct base — must be absent."""
+        handles = {
+            str(h) for h in _superclasses_for(_GRANDCHILD_HANDLE, superclasses_analyzer).handles
+        }
+        assert (
+            _BASE_HANDLE not in handles
+        ), f"transitive ancestor Base must NOT appear in GrandChild superclasses; got {handles}"
+
+    def test_grandchild_exact_superclass_set(self, superclasses_analyzer: JediAnalyzer) -> None:
+        """Exact set check: ``GrandChild`` → exactly ``{pkg.derived.Child}``."""
+        handles = {
+            str(h) for h in _superclasses_for(_GRANDCHILD_HANDLE, superclasses_analyzer).handles
+        }
+        assert handles == {_CHILD_HANDLE}, f"expected exactly {{pkg.derived.Child}}; got {handles}"
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — count-consistency through the full public inspect() path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSuperclassesCountConsistencyViaInspect:
+    """Count-consistency via the FULL public ``inspect()`` API (not just the helper).
+
+    This exercises the real production path:
+        ``inspect(handle, analyzer)`` → ``_build_edge_counts``
+        → ``_count_superclasses`` → ``resolve_superclasses``
+
+    The assertion is non-vacuous: it uses a class with a positive base count
+    (``Child`` has 1 base, ``MultiChild`` has 2) so an accidentally zero count
+    would be caught.  The private-helper tests in
+    ``TestResolveSuperclassesCountConsistency`` already cover the helpers in
+    isolation; these tests cover the public surface.
+    """
+
+    @pytest.mark.asyncio
+    async def test_child_count_via_inspect_matches_resolver(
+        self, superclasses_analyzer: JediAnalyzer
+    ) -> None:
+        """``Child`` has 1 direct base: inspect edge_counts and resolver agree."""
+        from pyeye.mcp.operations.inspect import inspect
+
+        jedi_name = _find_jedi_name_for_handle(_CHILD_HANDLE, superclasses_analyzer)
+        assert jedi_name is not None
+        resolver_count = len(resolve_superclasses(jedi_name, superclasses_analyzer).handles)
+        node = await inspect(_CHILD_HANDLE, superclasses_analyzer)
+        inspect_count = node["edge_counts"]["superclasses"]
+        assert resolver_count == inspect_count, (
+            f"resolver={resolver_count}, inspect.edge_counts.superclasses={inspect_count}; "
+            "must agree"
+        )
+        assert (
+            inspect_count > 0
+        ), "non-vacuous: Child has bases, so the count must be > 0 for this test to be meaningful"
+
+    @pytest.mark.asyncio
+    async def test_multi_child_count_via_inspect_matches_resolver(
+        self, superclasses_analyzer: JediAnalyzer
+    ) -> None:
+        """``MultiChild`` has 2 direct bases: inspect edge_counts and resolver agree."""
+        from pyeye.mcp.operations.inspect import inspect
+
+        jedi_name = _find_jedi_name_for_handle(_MULTI_CHILD_HANDLE, superclasses_analyzer)
+        assert jedi_name is not None
+        resolver_count = len(resolve_superclasses(jedi_name, superclasses_analyzer).handles)
+        node = await inspect(_MULTI_CHILD_HANDLE, superclasses_analyzer)
+        inspect_count = node["edge_counts"]["superclasses"]
+        assert resolver_count == inspect_count, (
+            f"resolver={resolver_count}, inspect.edge_counts.superclasses={inspect_count}; "
+            "must agree"
+        )
+        assert inspect_count > 0, "non-vacuous: MultiChild has bases, so the count must be > 0"

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -95,13 +95,16 @@ _SUPERCLASSES_FIXTURE = (
     Path(__file__).parent.parent.parent.parent / "fixtures" / "superclasses_edge"
 )
 _BASE_HANDLE = "pkg.bases.Base"  # class with NO superclasses (measured-empty)
-_MIXIN_HANDLE = "pkg.bases.Mixin"  # second project base (measured-empty superclasses)
+_MIXIN_HANDLE = (
+    "pkg.bases.Mixin"  # second project-internal base; used for multiple-inheritance tests
+)
 _CHILD_HANDLE = "pkg.derived.Child"  # one project superclass: pkg.bases.Base
 _MULTI_CHILD_HANDLE = "pkg.derived.MultiChild"  # two project superclasses
 _EXTERNAL_CHILD_HANDLE = "pkg.derived.ExternalChild"  # one external superclass
 _GRANDCHILD_HANDLE = "pkg.derived.GrandChild"  # one direct superclass: Child (not Base)
 _FUNCTION_HANDLE = "pkg.derived.function_in_module"  # function (wrong-kind)
 _VAR_HANDLE = "pkg.derived.VAR_IN_MODULE"  # variable (wrong-kind)
+_WEIRD_HANDLE = "pkg.derived.Weird"  # class with unresolvable base (drop-and-diverge path)
 
 
 # ---------------------------------------------------------------------------
@@ -1195,3 +1198,67 @@ class TestResolveSuperclassesCountConsistencyViaInspect:
             "must agree"
         )
         assert inspect_count > 0, "non-vacuous: MultiChild has bases, so the count must be > 0"
+
+
+# ---------------------------------------------------------------------------
+# Gap 3 — unresolvable-base field-vs-count divergence
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSuperclassesUnresolvableBaseDivergence:
+    """``Weird(NotDefinedAnywhere)`` exercises the drop-and-diverge path.
+
+    ``resolve_superclasses`` drops bases that goto cannot resolve (no
+    ``full_name`` → can't build an expand stub), so ``edge_counts.superclasses``
+    is 0.  ``_get_superclasses`` / the ``superclasses`` field keeps ALL declared
+    bases via ``ast.unparse`` fallback, so ``"NotDefinedAnywhere"`` still appears
+    in the field.
+
+    This is the intentional field-vs-count divergence documented in
+    ``_get_superclasses`` and ``_count_superclasses``.
+    """
+
+    def test_unresolvable_base_dropped_by_resolver(
+        self, superclasses_analyzer: JediAnalyzer
+    ) -> None:
+        """``resolve_superclasses(Weird)`` must return an empty handle list.
+
+        Confirms that goto genuinely cannot resolve ``NotDefinedAnywhere`` in
+        this fixture, making the test non-vacuous.
+        """
+        jedi_name = _find_jedi_name_for_handle(_WEIRD_HANDLE, superclasses_analyzer)
+        assert jedi_name is not None, f"Could not find Jedi name for {_WEIRD_HANDLE!r}"
+        result = resolve_superclasses(jedi_name, superclasses_analyzer)
+        assert result.handles == [], (
+            f"unresolvable base must be dropped; got {result.handles}. "
+            "If Jedi resolves NotDefinedAnywhere, use a more unresolvable construct."
+        )
+
+    @pytest.mark.asyncio
+    async def test_field_vs_count_divergence_end_to_end(
+        self, superclasses_analyzer: JediAnalyzer
+    ) -> None:
+        """``Weird`` divergence via the full public ``inspect()`` path.
+
+        Asserts all three aspects of the documented divergence:
+        - ``edge_counts.superclasses == 0``  (resolver dropped the unresolvable base)
+        - ``"NotDefinedAnywhere" in node["superclasses"]``  (field kept the fallback string)
+        - ``len(node["superclasses"]) >= 1``  (non-vacuous: the field is not empty)
+        """
+        from pyeye.mcp.operations.inspect import inspect
+
+        node = await inspect(_WEIRD_HANDLE, superclasses_analyzer)
+        edge_count = node["edge_counts"]["superclasses"]
+        field = node["superclasses"]
+
+        assert edge_count == 0, (
+            f"edge_counts.superclasses must be 0 for Weird (unresolvable base dropped); "
+            f"got {edge_count}"
+        )
+        assert "NotDefinedAnywhere" in field, (
+            f"superclasses field must contain the ast.unparse fallback 'NotDefinedAnywhere'; "
+            f"got {field!r}"
+        )
+        assert (
+            len(field) >= 1
+        ), "non-vacuous: the superclasses field must be non-empty (contains the fallback string)"

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -3,8 +3,9 @@
 The edge registry is the single source of truth for which edges ``expand``
 supports.  Every edge name MUST classify into exactly one status:
 
-- ``"implemented"`` — ``members``, ``callees``, ``imported_by``, ``subclasses``
-- ``"not_yet_implemented"`` — ``superclasses``, ``imports``, ``enclosing_scope``
+- ``"implemented"`` — ``members``, ``callees``, ``imported_by``, ``subclasses``,
+  ``superclasses``
+- ``"not_yet_implemented"`` — ``imports``, ``enclosing_scope``
 - ``"deferred_reference_backend"`` — the inbound / reference edges
   (``callers``, ``references``, ``read_by``, ``written_by``, ``passed_by``,
   ``overrides``, ``overridden_by``, ``decorated_by``, ``decorates``)
@@ -53,6 +54,7 @@ from pyeye.mcp.operations.edges import (
     resolve_imported_by,
     resolve_members,
     resolve_subclasses,
+    resolve_superclasses,
 )
 from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
 
@@ -86,6 +88,19 @@ _LONER_HANDLE = "pkg.base.Loner"
 _MAMMAL_HANDLE = "pkg.middle.Mammal"  # direct subclass (importable module)
 _DOG_HANDLE = "pkg.middle.Dog"  # indirect (grandchild) subclass
 _LIZARD_HANDLE = "script_animal.Lizard"  # direct subclass in a non-importable script
+
+# superclasses fixtures (issue #361): a dedicated fixture project with a known
+# direct-base topology. Tests cover single/multiple/external/no-base class cases.
+_SUPERCLASSES_FIXTURE = (
+    Path(__file__).parent.parent.parent.parent / "fixtures" / "superclasses_edge"
+)
+_BASE_HANDLE = "pkg.bases.Base"  # class with NO superclasses (measured-empty)
+_MIXIN_HANDLE = "pkg.bases.Mixin"  # second project base (measured-empty superclasses)
+_CHILD_HANDLE = "pkg.derived.Child"  # one project superclass: pkg.bases.Base
+_MULTI_CHILD_HANDLE = "pkg.derived.MultiChild"  # two project superclasses
+_EXTERNAL_CHILD_HANDLE = "pkg.derived.ExternalChild"  # one external superclass
+_FUNCTION_HANDLE = "pkg.derived.function_in_module"  # function (wrong-kind)
+_VAR_HANDLE = "pkg.derived.VAR_IN_MODULE"  # variable (wrong-kind)
 
 
 # ---------------------------------------------------------------------------
@@ -136,9 +151,15 @@ class TestEdgeStatusModel:
         # Phase 3 — status and resolver-registry are deliberately separate.
         assert edge_status("callees") == "implemented"
 
+    def test_superclasses_is_implemented(self) -> None:
+        # superclasses moves from not_yet_implemented to implemented (#361): its
+        # resolver (resolve_superclasses) uses AST ClassDef.bases + forward goto —
+        # no reverse symbol search, so it belongs with members/callees/subclasses.
+        assert edge_status("superclasses") == "implemented"
+
     @pytest.mark.parametrize(
         "edge",
-        ["superclasses", "imports", "enclosing_scope"],
+        ["imports", "enclosing_scope"],
     )
     def test_not_yet_implemented_edges(self, edge: str) -> None:
         assert edge_status(edge) == "not_yet_implemented"
@@ -838,3 +859,234 @@ class TestResolveSubclassesNeverReverseSearch:
             result = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
         assert _MAMMAL_HANDLE in {str(h) for h in result.handles}
         spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #361 — superclasses resolver: direct-base AST + forward goto
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def superclasses_analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at the dedicated superclasses_edge fixture."""
+    return JediAnalyzer(str(_SUPERCLASSES_FIXTURE))
+
+
+def _superclasses_for(handle: str, analyzer: JediAnalyzer) -> EdgeResult:
+    """Resolve *handle* to a Jedi name and return its ``superclasses`` result.
+
+    ``superclasses`` is synchronous (AST walk + goto are sync) and NEVER
+    returns ``None`` — a non-class handle yields a measured-empty
+    ``EdgeResult([])`` (only a class CAN have superclasses, so ``[]`` for the
+    wrong kind is true by definition — the ``members``/``callees`` case).
+    """
+    jedi_name = _find_jedi_name_for_handle(handle, analyzer)
+    assert jedi_name is not None, f"Could not find Jedi name for handle {handle!r}"
+    return resolve_superclasses(jedi_name, analyzer)
+
+
+class TestResolveSuperclassesSingleProjectBase:
+    """``superclasses`` = the DIRECT base classes of a class, as canonical handles.
+
+    ``Child`` has exactly one project-internal superclass: ``pkg.bases.Base``.
+    """
+
+    def test_returns_edgeresult(self, superclasses_analyzer: JediAnalyzer) -> None:
+        result = _superclasses_for(_CHILD_HANDLE, superclasses_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert all(isinstance(h, Handle) for h in result.handles)
+
+    def test_project_base_present(self, superclasses_analyzer: JediAnalyzer) -> None:
+        handles = {str(h) for h in _superclasses_for(_CHILD_HANDLE, superclasses_analyzer).handles}
+        assert _BASE_HANDLE in handles, f"expected {_BASE_HANDLE!r} in superclasses; got {handles}"
+
+    def test_exact_superclass_set_single(self, superclasses_analyzer: JediAnalyzer) -> None:
+        handles = {str(h) for h in _superclasses_for(_CHILD_HANDLE, superclasses_analyzer).handles}
+        assert handles == {_BASE_HANDLE}, f"expected exactly {{Base}}; got {handles}"
+
+    def test_adjacents_are_handle_name_pairs(self, superclasses_analyzer: JediAnalyzer) -> None:
+        # Each adjacent is a (Handle, Jedi Name) pair whose Name is the goto def.
+        result = _superclasses_for(_CHILD_HANDLE, superclasses_analyzer)
+        assert result.adjacents, "Child should have superclasses"
+        for handle, name in result.adjacents:
+            assert isinstance(handle, Handle)
+            # The goto def has a full_name matching the handle
+            assert name.full_name == str(handle)
+
+    def test_unresolved_call_sites_is_none(self, superclasses_analyzer: JediAnalyzer) -> None:
+        # The unresolved-call-site notion is callees-only; superclasses never reports it.
+        result = _superclasses_for(_CHILD_HANDLE, superclasses_analyzer)
+        assert result.unresolved_call_sites is None
+
+
+class TestResolveSuperclassesMultipleBases:
+    """``MultiChild`` has two project-internal superclasses: ``Base`` and ``Mixin``."""
+
+    def test_both_bases_present(self, superclasses_analyzer: JediAnalyzer) -> None:
+        handles = {
+            str(h) for h in _superclasses_for(_MULTI_CHILD_HANDLE, superclasses_analyzer).handles
+        }
+        assert _BASE_HANDLE in handles, f"Base missing from MultiChild superclasses: {handles}"
+        assert _MIXIN_HANDLE in handles, f"Mixin missing from MultiChild superclasses: {handles}"
+
+    def test_exact_superclass_set_multiple(self, superclasses_analyzer: JediAnalyzer) -> None:
+        handles = {
+            str(h) for h in _superclasses_for(_MULTI_CHILD_HANDLE, superclasses_analyzer).handles
+        }
+        assert handles == {_BASE_HANDLE, _MIXIN_HANDLE}, f"got {handles}"
+
+    def test_deduplicated(self, superclasses_analyzer: JediAnalyzer) -> None:
+        # No handle should appear twice, even if the AST has a duplicate base (edge case).
+        handles = [
+            str(h) for h in _superclasses_for(_MULTI_CHILD_HANDLE, superclasses_analyzer).handles
+        ]
+        assert len(handles) == len(set(handles)), f"duplicates found: {handles}"
+
+    def test_deterministic_order(self, superclasses_analyzer: JediAnalyzer) -> None:
+        # Order must be stable across repeated calls (sorted by handle string).
+        first = _superclasses_for(_MULTI_CHILD_HANDLE, superclasses_analyzer)
+        second = _superclasses_for(_MULTI_CHILD_HANDLE, superclasses_analyzer)
+        assert [str(h) for h in first.handles] == [str(h) for h in second.handles]
+        # Verify it's the sorted order (the resolver sorts by handle string).
+        handles = [str(h) for h in first.handles]
+        assert handles == sorted(handles), f"not sorted by handle string: {handles}"
+
+
+class TestResolveSuperclassesExternalBase:
+    """``ExternalChild`` extends ``pathlib.PurePosixPath`` — an external stdlib class.
+
+    External bases must be INCLUDED in the ``superclasses`` edge result.
+    The handle is the resolved canonical dotted name of the external class.
+    """
+
+    def test_external_base_present(self, superclasses_analyzer: JediAnalyzer) -> None:
+        handles = {
+            str(h) for h in _superclasses_for(_EXTERNAL_CHILD_HANDLE, superclasses_analyzer).handles
+        }
+        # pathlib.PurePosixPath is the external superclass
+        assert any(
+            "PurePosixPath" in h for h in handles
+        ), f"PurePosixPath external base missing; got {handles}"
+
+    def test_external_base_is_handle_instance(self, superclasses_analyzer: JediAnalyzer) -> None:
+        result = _superclasses_for(_EXTERNAL_CHILD_HANDLE, superclasses_analyzer)
+        assert result.handles, "ExternalChild must have at least one superclass"
+        assert all(isinstance(h, Handle) for h in result.handles)
+
+
+class TestResolveSuperclassesMeasuredEmpty:
+    """A class with NO bases → ``EdgeResult([])`` (measured none).
+
+    ``pkg.bases.Base`` has no explicit superclasses — the empty list is the
+    correct measured result (NOT wrong-kind ``None``).
+    """
+
+    def test_class_with_no_bases_is_measured_empty(
+        self, superclasses_analyzer: JediAnalyzer
+    ) -> None:
+        result = _superclasses_for(_BASE_HANDLE, superclasses_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert result.handles == [], f"Base has no superclasses; got {result.handles}"
+
+    def test_measured_empty_is_not_none(self, superclasses_analyzer: JediAnalyzer) -> None:
+        result = _superclasses_for(_BASE_HANDLE, superclasses_analyzer)
+        assert result is not None
+        assert result == EdgeResult(adjacents=[])
+
+
+class TestResolveSuperclassesNonClass:
+    """A non-class handle → measured-empty ``EdgeResult([])`` — NEVER ``None``.
+
+    Only a class CAN have superclasses, so ``[]`` for a function/variable is
+    true BY DEFINITION (the ``members``/``callees`` case, NOT the
+    absence-vs-zero lie that forced ``imported_by``'s ``None`` path).
+    Because this resolver never returns ``None``, ``expand.py`` needs no change.
+    """
+
+    def test_function_handle_is_measured_empty(self, superclasses_analyzer: JediAnalyzer) -> None:
+        result = _superclasses_for(_FUNCTION_HANDLE, superclasses_analyzer)
+        assert result is not None, "non-class must NOT be wrong-kind None"
+        assert isinstance(result, EdgeResult)
+        assert result.handles == []
+
+    def test_variable_handle_is_measured_empty(self, superclasses_analyzer: JediAnalyzer) -> None:
+        result = _superclasses_for(_VAR_HANDLE, superclasses_analyzer)
+        assert result is not None
+        assert result.handles == []
+
+    def test_non_class_is_not_none(self, superclasses_analyzer: JediAnalyzer) -> None:
+        # The load-bearing distinction: superclasses never uses the None wrong-kind
+        # signal, so expand.py's hardcoded module-only None branch stays correct.
+        result = _superclasses_for(_FUNCTION_HANDLE, superclasses_analyzer)
+        assert result is not None
+        assert result == EdgeResult(adjacents=[])
+
+
+class TestResolveSuperclassesNeverReverseSearch:
+    """superclasses NEVER calls Jedi reverse search (it is forward AST + goto only).
+
+    Mirrors the callees/subclasses spies: patch ``get_references`` to explode if
+    touched, run the resolver over the fixture, then assert it completed (real
+    superclass present) AND the spy was never called.
+    """
+
+    def test_get_references_not_called(self, superclasses_analyzer: JediAnalyzer) -> None:
+        assert hasattr(jedi.Script, "get_references")
+        spy = Mock(side_effect=AssertionError("get_references called on superclasses path"))
+        with patch.object(jedi.Script, "get_references", spy):
+            result = _superclasses_for(_CHILD_HANDLE, superclasses_analyzer)
+        assert _BASE_HANDLE in {str(h) for h in result.handles}
+        spy.assert_not_called()
+
+
+class TestResolveSuperclassesCountConsistency:
+    """Count-consistency: ``len(expand stubs) == inspect.edge_counts.superclasses``.
+
+    The progressive-disclosure contract requires the edge resolver count and the
+    ``inspect`` edge_counts value to agree.  ``_count_superclasses`` now delegates
+    to ``resolve_superclasses`` so equality holds BY CONSTRUCTION (the same
+    resolver runs for both).  This test pins that contract as an integration check.
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_base_count_equals_resolve_count(
+        self, superclasses_analyzer: JediAnalyzer
+    ) -> None:
+        """``Child`` has one resolvable base: resolver count == 1."""
+        from pyeye.mcp.operations.inspect import _count_superclasses
+
+        jedi_name = _find_jedi_name_for_handle(_CHILD_HANDLE, superclasses_analyzer)
+        assert jedi_name is not None
+        resolver_count = len(resolve_superclasses(jedi_name, superclasses_analyzer).handles)
+        counter_count = await _count_superclasses(jedi_name, superclasses_analyzer)
+        assert (
+            resolver_count == counter_count == 1
+        ), f"resolver={resolver_count}, counter={counter_count}; expected both == 1"
+
+    @pytest.mark.asyncio
+    async def test_multi_base_count_equals_resolve_count(
+        self, superclasses_analyzer: JediAnalyzer
+    ) -> None:
+        """``MultiChild`` has two resolvable bases: resolver count == 2."""
+        from pyeye.mcp.operations.inspect import _count_superclasses
+
+        jedi_name = _find_jedi_name_for_handle(_MULTI_CHILD_HANDLE, superclasses_analyzer)
+        assert jedi_name is not None
+        resolver_count = len(resolve_superclasses(jedi_name, superclasses_analyzer).handles)
+        counter_count = await _count_superclasses(jedi_name, superclasses_analyzer)
+        assert (
+            resolver_count == counter_count == 2
+        ), f"resolver={resolver_count}, counter={counter_count}; expected both == 2"
+
+    @pytest.mark.asyncio
+    async def test_no_base_count_is_zero(self, superclasses_analyzer: JediAnalyzer) -> None:
+        """``Base`` has no superclasses: both resolver count and counter are 0."""
+        from pyeye.mcp.operations.inspect import _count_superclasses
+
+        jedi_name = _find_jedi_name_for_handle(_BASE_HANDLE, superclasses_analyzer)
+        assert jedi_name is not None
+        resolver_count = len(resolve_superclasses(jedi_name, superclasses_analyzer).handles)
+        counter_count = await _count_superclasses(jedi_name, superclasses_analyzer)
+        assert (
+            resolver_count == counter_count == 0
+        ), f"resolver={resolver_count}, counter={counter_count}; expected both == 0"

--- a/tests/unit/mcp/operations/test_expand.py
+++ b/tests/unit/mcp/operations/test_expand.py
@@ -252,10 +252,12 @@ class TestExpandUnsupported:
 
     @pytest.mark.asyncio
     async def test_not_yet_implemented(self, analyzer: JediAnalyzer) -> None:
-        result = await expand(_WIDGET_HANDLE, "superclasses", analyzer)
+        # Use ``imports`` — the remaining not_yet_implemented structural edge
+        # (superclasses moved to implemented in #361).
+        result = await expand(_WIDGET_HANDLE, "imports", analyzer)
         assert result["unsupported"] is True
         assert result["reason"] == "not_yet_implemented"
-        assert result["edge"] == "superclasses"
+        assert result["edge"] == "imports"
         assert result["source"] == _WIDGET_HANDLE
         assert isinstance(result["detail"], str) and result["detail"]
         # Mutually exclusive: an unsupported result NEVER carries stubs.
@@ -315,7 +317,9 @@ class TestExpandBranchesMutuallyExclusive:
     @pytest.mark.parametrize(
         ("handle", "edge"),
         [
-            (_WIDGET_HANDLE, "superclasses"),
+            # superclasses is now implemented (#361) — replaced with ``imports``
+            # as the representative not_yet_implemented structural edge.
+            (_WIDGET_HANDLE, "imports"),
             (_ORCHESTRATE_HANDLE, "callers"),
             (_WIDGET_HANDLE, "bogus_edge"),
         ],


### PR DESCRIPTION
## Summary

Promotes `superclasses` from `not_yet_implemented` to a **supported** `expand`/`trace` edge — the next reliably-static slice after `subclasses` (#348). `expand(class_handle, "superclasses")` now returns a class's **direct base classes**, and `trace` traverses the edge automatically.

## Design

- **Direct bases only** (not full MRO/ancestor closure) — matches `inspect.edge_counts.superclasses` (the direct-base count). Deliberate asymmetry vs `subclasses`, which returns the full project closure to match *its* count.
- **Wrong-kind → `EdgeResult([])`, never `None`** — only a class CAN have superclasses, so `[]` is true-by-definition (the `subclasses`/`members`/`callees` case, not `imported_by`'s `None`). So `expand.py` needs no change.
- **External bases included** (e.g. extending `pathlib.PurePosixPath` / `pydantic.BaseModel`); resolved to canonical handles.
- Resolution is forward `goto(follow_imports=True)` per AST base, carrying the Jedi `Name` so `build_stub` needs no re-resolution — **no `get_references`** (the load-bearing trust constraint shared by callees/subclasses/imported_by).
- Unresolvable bases (goto yields no def/`full_name`) are dropped (can't build a stub without a Name).

## Count-consistency

`inspect._count_superclasses` now delegates to `resolve_superclasses` (mirroring how `_count_class_members` delegates to `resolve_members`), so `len(expand stubs) == inspect.edge_counts.superclasses` **by construction**. The inspect `superclasses` *field* (declared bases, incl. unresolvable-as-strings) is unchanged; the rare field-vs-count divergence for an unresolvable base is intentional, documented at `_count_superclasses`/`_get_superclasses`, and covered by an end-to-end test.

## Changes

- `edges.py`: `resolve_superclasses` + registry promotion (`_IMPLEMENTED_EDGES`, `EDGE_RESOLVERS`).
- `inspect.py`: `_count_superclasses` delegation (+ corrected comments).
- Tests: `test_edges.py` (single/multiple/external/no-base/wrong-kind/direct-not-MRO/unresolvable-divergence/count-consistency-via-inspect), a `not_yet_implemented` example swap in `test_expand.py`, and a new `tests/fixtures/superclasses_edge/` fixture.

## Test plan

- [x] Full suite green (2028 passed) at the 85% coverage gate
- [x] Direct-bases (not MRO) proven via a 3-level chain (`GrandChild → Child`, excludes `Base`)
- [x] Count-consistency asserted through the full public `inspect()` path
- [x] Wrong-kind → `[]`; external base included; unresolvable-base divergence covered end-to-end
- [x] No `get_references`/`find_references` on the path; `expand.py`/linter untouched

Closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)