### PR TITLE
feat(enclosing_scope): promote enclosing_scope to a supported edge (#370)

### DIFF
--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -8,19 +8,19 @@ This module is the **single source of truth** for which traversal edges
    string ``expand`` emits for unsupported edges.
 2. :data:`EDGE_RESOLVERS` / the resolver registry — maps *implemented* edge
    names (``members``, ``callees``, ``imported_by``, ``subclasses``,
-   ``superclasses``) to their resolver callables.  ``members``/``callees``/
-   ``superclasses``/``imports`` are synchronous and always return an
+   ``superclasses``, ``imports``, ``enclosing_scope``) to their resolver
+   callables.  ``members``/``callees``/``superclasses``/``imports``/
+   ``enclosing_scope`` are synchronous and always return an
    :class:`EdgeResult` or ``None``; ``imported_by`` and ``subclasses`` are
    **async**.  ``imported_by`` and ``imports`` return ``EdgeResult | None``
    — ``None`` is their wrong-kind signal (the handle is not a module).
-   ``subclasses`` and ``superclasses`` ALWAYS return an :class:`EdgeResult`
-   (never ``None``): a non-class handle yields ``EdgeResult([])`` because
-   only a class CAN be subclassed/have superclasses, so ``[]`` for the wrong
-   kind is true by definition (the ``members``/``callees`` case), not the
-   absence-vs-zero lie that forces ``imported_by``'s and ``imports``'s
-   ``None`` paths.  An :class:`EdgeResult` carries the adjacent canonical
-   handles plus, for ``callees`` only, the count of unresolved call sites.
-   ``expand`` awaits any awaitable resolver result.
+   ``subclasses``, ``superclasses``, and ``enclosing_scope`` ALWAYS return an
+   :class:`EdgeResult` (never ``None``): a module handle yields
+   ``EdgeResult([])`` for ``enclosing_scope`` because modules have no lexical
+   enclosing scope; non-class handles yield ``EdgeResult([])`` for
+   ``subclasses``/``superclasses``.  An :class:`EdgeResult` carries the
+   adjacent canonical handles plus, for ``callees`` only, the count of
+   unresolved call sites.  ``expand`` awaits any awaitable resolver result.
 
 Status model (spec §4.3)
 ------------------------
@@ -29,8 +29,9 @@ status                          edges
 ==============================  =========================================
 ``"implemented"``               ``members``, ``callees``, ``imported_by``,
                                 ``subclasses``, ``superclasses``,
-                                ``imports``
-``"not_yet_implemented"``       ``enclosing_scope``
+                                ``imports``, ``enclosing_scope``
+``"not_yet_implemented"``       *(currently empty — all recognised edges
+                                are implemented)*
 ``"deferred_reference_backend"``  ``callers``, ``references``, ``read_by``,
                                 ``written_by``, ``passed_by``,
                                 ``overrides``, ``overridden_by``,
@@ -125,11 +126,21 @@ STATUS_UNKNOWN_EDGE = "unknown_edge"
 
 #: Edges with a working (or Phase-3-bound) resolver.
 _IMPLEMENTED_EDGES = frozenset(
-    {"members", "callees", "imported_by", "subclasses", "superclasses", "imports"}
+    {
+        "members",
+        "callees",
+        "imported_by",
+        "subclasses",
+        "superclasses",
+        "imports",
+        "enclosing_scope",
+    }
 )
 
 #: Edges recognised by the matrix but not yet built (no reference backend needed).
-_NOT_YET_IMPLEMENTED_EDGES = frozenset({"enclosing_scope"})
+#: Currently empty — all recognised structural edges are implemented.  The set
+#: is retained so the 4-status taxonomy remains consistent for future additions.
+_NOT_YET_IMPLEMENTED_EDGES: frozenset[str] = frozenset()
 
 #: Inbound / reference edges deferred until an indexed reference backend lands.
 _DEFERRED_REFERENCE_BACKEND_EDGES = frozenset(
@@ -1020,20 +1031,90 @@ def resolve_imports(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult | None
 
 
 # ---------------------------------------------------------------------------
+# enclosing_scope resolver (#370) — Jedi parent() navigation, sync
+# ---------------------------------------------------------------------------
+
+
+def resolve_enclosing_scope(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult:  # noqa: ARG001
+    """Return the immediate lexical enclosing scope of a symbol as a canonical handle.
+
+    The inverse of ``members``: where ``members`` enumerates a container's
+    direct children, ``enclosing_scope`` returns the one parent scope.  At most
+    ONE adjacent is returned:
+
+    - **method** → its class.
+    - **nested class** → its enclosing class.
+    - **nested function** → its enclosing function.
+    - **top-level def/class/variable** → its module.
+    - **module** → ``EdgeResult([])`` (a module has no enclosing LEXICAL scope;
+      Python packages are NOT lexical scopes — that is the ``package`` concept).
+
+    Resolution uses ``jedi_name.parent()`` — the Jedi ``Name`` for the adjacent
+    scope — NOT dotted-name string arithmetic.  String arithmetic cannot see
+    class nesting (the #337 lesson applied here): for ``pkg.Outer.Inner.method``
+    the arithmetic would mis-identify ``Outer`` as a module, failing to find it.
+    ``parent()`` returns the true lexical parent at any nesting depth.
+
+    Synchronous: ``parent()`` is a pure Jedi API call (no file I/O); ``Handle``
+    construction is synchronous.  No ``get_references`` / ``find_references`` is
+    ever called.
+
+    Args:
+        jedi_name: Resolved Jedi ``Name`` (or :class:`ModuleSentinel`) for the
+            target.  Module-ness is derived from its normalised kind; for a
+            module the resolver returns immediately with ``EdgeResult([])``.
+        analyzer: Active analyzer (unused except for structural consistency with
+            all other resolver signatures — the parent() API is self-contained).
+
+    Returns:
+        An :class:`EdgeResult` whose ``adjacents`` is a single-element list
+        ``[(Handle, parent_Name)]`` for any non-module symbol, or ``[]`` for a
+        module handle or any symbol whose parent cannot be resolved (defensive
+        empty — callers can rely on the absence-vs-zero invariant).
+        ``unresolved_call_sites`` is always ``None`` — that notion is
+        callees-only.  NEVER returns ``None``.
+    """
+    # Module gate: a module has no lexical enclosing scope.  Gate on kind BEFORE
+    # calling parent() — a ModuleSentinel may not have a parent() method at all.
+    if _normalise_kind(getattr(jedi_name, "type", None)) == "module":
+        return EdgeResult(adjacents=[])
+
+    # Retrieve the parent Jedi Name via the Jedi API (not dotted-name arithmetic).
+    try:
+        parent = jedi_name.parent()
+    except Exception:
+        return EdgeResult(adjacents=[])
+
+    if parent is None:
+        return EdgeResult(adjacents=[])
+
+    # Build the Handle from the parent's full_name.
+    full_name = getattr(parent, "full_name", None)
+    if not full_name:
+        return EdgeResult(adjacents=[])
+
+    h = _try_handle(full_name)
+    if h is None:
+        return EdgeResult(adjacents=[])
+
+    return EdgeResult(adjacents=[(h, parent)])
+
+
+# ---------------------------------------------------------------------------
 # Resolver registry
 # ---------------------------------------------------------------------------
 
 #: Maps *implemented* edge names → resolver callables.  ``members``/``callees``/
-#: ``superclasses``/``imports`` are synchronous; ``members``/``callees``/
-#: ``superclasses`` always return an :class:`EdgeResult`; ``imports`` returns
-#: ``EdgeResult | None`` (``None`` for non-module handles, mirroring
-#: ``imported_by``).  ``imported_by`` and ``subclasses`` are async.
-#: ``imported_by`` may return ``None`` (its wrong-kind signal); ``subclasses``
-#: and ``superclasses`` always return an :class:`EdgeResult` (non-class →
-#: ``EdgeResult([])``, never ``None``).  The value type therefore admits a
-#: sync-or-async resolver returning ``EdgeResult | None`` so ``expand`` can
-#: stay edge-agnostic (awaiting awaitable results, treating ``None`` as
-#: not-yet-implemented).
+#: ``superclasses``/``imports``/``enclosing_scope`` are synchronous;
+#: ``members``/``callees``/``superclasses``/``enclosing_scope`` always return an
+#: :class:`EdgeResult`; ``imports`` returns ``EdgeResult | None`` (``None`` for
+#: non-module handles, mirroring ``imported_by``).  ``imported_by`` and
+#: ``subclasses`` are async.  ``imported_by`` may return ``None`` (its
+#: wrong-kind signal); ``subclasses``, ``superclasses``, and ``enclosing_scope``
+#: always return an :class:`EdgeResult` (non-applicable kind → ``EdgeResult([])``,
+#: never ``None``).  The value type therefore admits a sync-or-async resolver
+#: returning ``EdgeResult | None`` so ``expand`` can stay edge-agnostic
+#: (awaiting awaitable results, treating ``None`` as not-yet-implemented).
 EDGE_RESOLVERS: dict[
     str, Callable[[Any, JediAnalyzer], EdgeResult | None | Awaitable[EdgeResult | None]]
 ] = {
@@ -1043,4 +1124,5 @@ EDGE_RESOLVERS: dict[
     "subclasses": resolve_subclasses,
     "superclasses": resolve_superclasses,
     "imports": resolve_imports,
+    "enclosing_scope": resolve_enclosing_scope,
 }

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -1035,7 +1035,7 @@ def resolve_imports(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult | None
 # ---------------------------------------------------------------------------
 
 
-def resolve_enclosing_scope(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult:  # noqa: ARG001
+def resolve_enclosing_scope(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult:
     """Return the immediate lexical enclosing scope of a symbol as a canonical handle.
 
     The inverse of ``members``: where ``members`` enumerates a container's
@@ -1054,6 +1054,9 @@ def resolve_enclosing_scope(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResul
     class nesting (the #337 lesson applied here): for ``pkg.Outer.Inner.method``
     the arithmetic would mis-identify ``Outer`` as a module, failing to find it.
     ``parent()`` returns the true lexical parent at any nesting depth.
+
+    See also: ``inspect._is_method`` uses the same ``jedi_name.parent()`` Jedi
+    API for method-vs-function classification (method detection, #337).
 
     Synchronous: ``parent()`` is a pure Jedi API call (no file I/O); ``Handle``
     construction is synchronous.  No ``get_references`` / ``find_references`` is
@@ -1074,6 +1077,7 @@ def resolve_enclosing_scope(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResul
         ``unresolved_call_sites`` is always ``None`` — that notion is
         callees-only.  NEVER returns ``None``.
     """
+    _ = analyzer  # unused: kept for the EDGE_RESOLVERS (jedi_name, analyzer) signature contract
     # Module gate: a module has no lexical enclosing scope.  Gate on kind BEFORE
     # calling parent() — a ModuleSentinel may not have a parent() method at all.
     if _normalise_kind(getattr(jedi_name, "type", None)) == "module":

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -523,9 +523,9 @@ async def expand(
       - Inbound/reference edges (``callers``, ``references``,
         ``overrides``, …) require the Pyright reference backend (#333) and return
         ``unsupported: true, reason: "deferred_reference_backend"``.
-      - Other structural edges (``superclasses``, ``imports``,
-        ``enclosing_scope``) are planned but not yet implemented in this slice;
-        they return ``reason: "not_yet_implemented"``.
+      - Wrong-kind handles for certain edges (e.g. ``imported_by`` on a
+        non-module) return ``reason: "not_yet_implemented"`` via their ``None``
+        resolver signal.
       - Unrecognised edge names return ``reason: "unknown_edge"``.
 
     Response shape — discriminated union:

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -523,9 +523,8 @@ async def expand(
       - Inbound/reference edges (``callers``, ``references``,
         ``overrides``, …) require the Pyright reference backend (#333) and return
         ``unsupported: true, reason: "deferred_reference_backend"``.
-      - Wrong-kind handles for certain edges (e.g. ``imported_by`` on a
-        non-module) return ``reason: "not_yet_implemented"`` via their ``None``
-        resolver signal.
+      - Wrong-kind handles (e.g. ``imported_by`` on a non-module) return the
+        unsupported branch with ``reason: "not_yet_implemented"``.
       - Unrecognised edge names return ``reason: "unknown_edge"``.
 
     Response shape — discriminated union:

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -495,7 +495,7 @@ async def expand(
     returns adjacent symbols as lightweight Stubs.  Use resolve()/inspect()
     first to obtain a canonical handle, then call expand() to traverse.
 
-    Supported edges in this slice:
+    Supported edges (the complete static/outbound set):
       - ``members``  — class/module → direct members (attributes, methods, nested
         classes).  ``stubs: []`` means the class/module was found but has no
         members; that is NOT the same as unsupported.
@@ -518,6 +518,19 @@ async def expand(
         subclasses (measured-none).  A non-class handle also returns the
         supported branch with ``stubs: []`` — only a class CAN be subclassed,
         so ``[]`` is true by definition, not an absence-vs-zero lie.
+      - ``superclasses``  — class → its base classes (class Stubs), resolved by
+        Jedi from the class definition (no reverse search).  A non-class handle
+        returns ``stubs: []`` (``[]`` true by definition, as with ``subclasses``).
+      - ``imports``  — module → the symbols/modules it imports (Stubs), computed
+        by static AST + forward ``goto``.  ``stubs: []`` is measured-none.  A
+        non-module handle returns the unsupported branch with
+        ``reason: "not_yet_implemented"`` (mirrors ``imported_by``).
+      - ``enclosing_scope``  — symbol → its immediate lexical enclosing scope
+        (the inverse of ``members``), resolved by Jedi ``parent()``: a method →
+        its class, a nested def/class → its enclosing def/class, a top-level
+        def/class/variable → its module.  At most ONE Stub.  A module returns
+        ``stubs: []`` (a module has no enclosing lexical scope — packages are not
+        lexical scopes); ``[]`` is therefore measured-empty, never unsupported.
 
     Unsupported edges return the unsupported branch (never raise):
       - Inbound/reference edges (``callers``, ``references``,
@@ -591,11 +604,12 @@ async def trace(
     canonical handles first, then trace() to see structure across hops (call
     chains, reverse-import closures, member trees).
 
-    Composes the same edge registry as ``expand``; only the implemented edges
-    (``members``, ``callees``, ``imported_by``) are traversed.  Any other edge
-    named in ``follow`` (deferred reference edges, not-yet-implemented structural
-    edges, unknown names) is reported in ``unsupported_edges`` rather than
-    silently dropped — a silent drop would falsely read as "no such neighbours".
+    Composes the same edge registry as ``expand``; the implemented edges
+    (``members``, ``callees``, ``imported_by``, ``subclasses``, ``superclasses``,
+    ``imports``, ``enclosing_scope``) are traversed.  Any other edge named in
+    ``follow`` (deferred reference edges, unknown names) is reported in
+    ``unsupported_edges`` rather than silently dropped — a silent drop would
+    falsely read as "no such neighbours".
 
     Response shape — ``Subgraph``::
 

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -4,8 +4,9 @@ The edge registry is the single source of truth for which edges ``expand``
 supports.  Every edge name MUST classify into exactly one status:
 
 - ``"implemented"`` — ``members``, ``callees``, ``imported_by``, ``subclasses``,
-  ``superclasses``, ``imports``
-- ``"not_yet_implemented"`` — ``enclosing_scope``
+  ``superclasses``, ``imports``, ``enclosing_scope``
+- ``"not_yet_implemented"`` — *(currently empty — all recognised edges are now
+  implemented, as of #370 / enclosing_scope)*
 - ``"deferred_reference_backend"`` — the inbound / reference edges
   (``callers``, ``references``, ``read_by``, ``written_by``, ``passed_by``,
   ``overrides``, ``overridden_by``, ``decorated_by``, ``decorates``)
@@ -168,12 +169,21 @@ class TestEdgeStatusModel:
         # goto — no reverse symbol search, so it belongs with the other implemented edges.
         assert edge_status("imports") == "implemented"
 
-    @pytest.mark.parametrize(
-        "edge",
-        ["enclosing_scope"],
-    )
-    def test_not_yet_implemented_edges(self, edge: str) -> None:
-        assert edge_status(edge) == "not_yet_implemented"
+    def test_enclosing_scope_is_implemented(self) -> None:
+        # enclosing_scope moves from not_yet_implemented to implemented (#370):
+        # its resolver (resolve_enclosing_scope) uses Jedi parent() — no reverse
+        # symbol search, so it belongs with the other implemented edges.
+        assert edge_status("enclosing_scope") == "implemented"
+
+    def test_not_yet_implemented_category_is_empty(self) -> None:
+        # All recognised structural edges are now implemented.  The
+        # _NOT_YET_IMPLEMENTED_EDGES set is retained for the 4-status taxonomy
+        # but is intentionally empty after #370.
+        from pyeye.mcp.operations.edges import _NOT_YET_IMPLEMENTED_EDGES
+
+        assert (
+            frozenset() == _NOT_YET_IMPLEMENTED_EDGES
+        ), f"_NOT_YET_IMPLEMENTED_EDGES must be empty; got {_NOT_YET_IMPLEMENTED_EDGES!r}"
 
     def test_imported_by_is_implemented(self) -> None:
         # imported_by moves from deferred_reference_backend to implemented in
@@ -1524,3 +1534,175 @@ class TestResolveImportsWildcard:
         assert result is not None
         handles = {str(h) for h in result.handles}
         assert _OS_MODULE_HANDLE in handles, f"ordinary import dropped; got {handles}"
+
+
+# ---------------------------------------------------------------------------
+# enclosing_scope resolver (#370) — Jedi parent() navigation, sync
+# ---------------------------------------------------------------------------
+
+# Fixture: nested_class_inspect/pkg/mod.py
+# Topology:
+#   pkg.mod (module)
+#   pkg.mod.top_level_function    → enclosing scope: pkg.mod (module)
+#   pkg.mod.Outer                 → enclosing scope: pkg.mod (module)
+#   pkg.mod.Outer.outer_method    → enclosing scope: pkg.mod.Outer (class)
+#   pkg.mod.Outer.Inner           → enclosing scope: pkg.mod.Outer (class)
+#   pkg.mod.Outer.Inner.inner_method → enclosing scope: pkg.mod.Outer.Inner (class)
+_NESTED_FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "nested_class_inspect"
+
+_TOP_LEVEL_FUNC_HANDLE = "pkg.mod.top_level_function"
+_OUTER_CLASS_HANDLE = "pkg.mod.Outer"
+_OUTER_METHOD_HANDLE = "pkg.mod.Outer.outer_method"
+_INNER_CLASS_HANDLE = "pkg.mod.Outer.Inner"
+_INNER_METHOD_HANDLE = "pkg.mod.Outer.Inner.inner_method"
+_NESTED_MODULE_HANDLE = "pkg.mod"
+
+
+@pytest.fixture
+def nested_analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at the nested_class_inspect fixture."""
+    return JediAnalyzer(str(_NESTED_FIXTURE))
+
+
+def _enclosing_scope_for(handle: str, analyzer: JediAnalyzer) -> EdgeResult:
+    """Resolve *handle* to a Jedi name and return its ``enclosing_scope`` result.
+
+    ``enclosing_scope`` is synchronous (Jedi ``parent()`` + ``Handle`` construction
+    are sync) and NEVER returns ``None`` — a non-module has a lexical enclosing
+    scope; a module has none (``EdgeResult([])``) but still not ``None``.
+    """
+    from pyeye.mcp.operations.edges import resolve_enclosing_scope
+
+    jedi_name = _find_jedi_name_for_handle(handle, analyzer)
+    assert jedi_name is not None, f"Could not find Jedi name for handle {handle!r}"
+    return resolve_enclosing_scope(jedi_name, analyzer)
+
+
+class TestResolveEnclosingScopeEdgeStatus:
+    """Edge-status model: enclosing_scope must be 'implemented' (#370)."""
+
+    def test_enclosing_scope_is_implemented(self) -> None:
+        """After #370, enclosing_scope is implemented — NOT not_yet_implemented."""
+        assert edge_status("enclosing_scope") == "implemented"
+
+    def test_not_yet_implemented_category_is_empty(self) -> None:
+        """_NOT_YET_IMPLEMENTED_EDGES is empty: all recognised edges are now handled.
+
+        The category is retained in the module for the 4-status taxonomy; it is
+        intentionally empty after #370 ships enclosing_scope.
+        """
+        from pyeye.mcp.operations.edges import _NOT_YET_IMPLEMENTED_EDGES
+
+        assert frozenset() == _NOT_YET_IMPLEMENTED_EDGES, (
+            "_NOT_YET_IMPLEMENTED_EDGES must be empty after enclosing_scope is promoted; "
+            f"got {_NOT_YET_IMPLEMENTED_EDGES!r}"
+        )
+
+
+class TestResolveEnclosingScopeMethod:
+    """A method → its enclosing class handle (the direct lexical parent)."""
+
+    def test_outer_method_scope_is_outer_class(self, nested_analyzer: JediAnalyzer) -> None:
+        """pkg.mod.Outer.outer_method → enclosing scope pkg.mod.Outer."""
+        result = _enclosing_scope_for(_OUTER_METHOD_HANDLE, nested_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert len(result.handles) == 1
+        assert str(result.handles[0]) == _OUTER_CLASS_HANDLE
+
+    def test_inner_method_scope_is_inner_class(self, nested_analyzer: JediAnalyzer) -> None:
+        """pkg.mod.Outer.Inner.inner_method → enclosing scope pkg.mod.Outer.Inner."""
+        result = _enclosing_scope_for(_INNER_METHOD_HANDLE, nested_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert len(result.handles) == 1
+        assert str(result.handles[0]) == _INNER_CLASS_HANDLE
+
+    def test_adjacent_is_handle_name_pair(self, nested_analyzer: JediAnalyzer) -> None:
+        """The adjacent must be a (Handle, Name) pair (not just a handle)."""
+        result = _enclosing_scope_for(_OUTER_METHOD_HANDLE, nested_analyzer)
+        assert len(result.adjacents) == 1
+        h, name = result.adjacents[0]
+        assert isinstance(h, Handle)
+        # The Jedi Name must carry a type attribute (it's a real Name, not a stub).
+        assert getattr(name, "type", None) is not None
+
+
+class TestResolveEnclosingScopeNestedClass:
+    """A nested class → its enclosing class handle."""
+
+    def test_inner_class_scope_is_outer_class(self, nested_analyzer: JediAnalyzer) -> None:
+        """pkg.mod.Outer.Inner → enclosing scope pkg.mod.Outer (its parent class)."""
+        result = _enclosing_scope_for(_INNER_CLASS_HANDLE, nested_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert len(result.handles) == 1
+        assert str(result.handles[0]) == _OUTER_CLASS_HANDLE
+
+
+class TestResolveEnclosingScopeTopLevel:
+    """A top-level def/class → its enclosing module handle."""
+
+    def test_top_level_function_scope_is_module(self, nested_analyzer: JediAnalyzer) -> None:
+        """pkg.mod.top_level_function → enclosing scope pkg.mod (the module)."""
+        result = _enclosing_scope_for(_TOP_LEVEL_FUNC_HANDLE, nested_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert len(result.handles) == 1
+        assert str(result.handles[0]) == _NESTED_MODULE_HANDLE
+
+    def test_outer_class_scope_is_module(self, nested_analyzer: JediAnalyzer) -> None:
+        """pkg.mod.Outer → enclosing scope pkg.mod (the module)."""
+        result = _enclosing_scope_for(_OUTER_CLASS_HANDLE, nested_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert len(result.handles) == 1
+        assert str(result.handles[0]) == _NESTED_MODULE_HANDLE
+
+
+class TestResolveEnclosingScopeModule:
+    """A module → EdgeResult([]) (no enclosing lexical scope)."""
+
+    def test_module_has_no_enclosing_scope(self, nested_analyzer: JediAnalyzer) -> None:
+        """pkg.mod has no lexical enclosing scope → EdgeResult([])."""
+        from pyeye._module_sentinel import ModuleSentinel
+        from pyeye.mcp.operations.edges import resolve_enclosing_scope
+
+        # Build a ModuleSentinel for the module handle — the resolver gates on
+        # _normalise_kind, which returns "module" for a sentinel.
+        fixture_file = _NESTED_FIXTURE / "pkg" / "mod.py"
+        sentinel = ModuleSentinel(fixture_file, _NESTED_MODULE_HANDLE, nested_analyzer)
+        result = resolve_enclosing_scope(sentinel, nested_analyzer)
+        assert isinstance(result, EdgeResult)
+        assert (
+            result.handles == []
+        ), f"module has no enclosing lexical scope → EdgeResult([]); got {result.handles}"
+
+    def test_module_returns_edgeresult_not_none(self, nested_analyzer: JediAnalyzer) -> None:
+        """resolver NEVER returns None — module yields EdgeResult([]), not None."""
+        from pyeye._module_sentinel import ModuleSentinel
+        from pyeye.mcp.operations.edges import resolve_enclosing_scope
+
+        fixture_file = _NESTED_FIXTURE / "pkg" / "mod.py"
+        sentinel = ModuleSentinel(fixture_file, _NESTED_MODULE_HANDLE, nested_analyzer)
+        result = resolve_enclosing_scope(sentinel, nested_analyzer)
+        assert result is not None, "resolver must never return None"
+
+
+class TestResolveEnclosingScopeNeverReverseSearch:
+    """enclosing_scope NEVER calls Jedi reverse search (parent() only).
+
+    Mirrors the callees/imported_by/subclasses/superclasses/imports spies:
+    patch ``get_references`` to explode if touched, run the resolver on a
+    method (which has a real enclosing scope), then assert it completed AND the
+    spy was never called.
+    """
+
+    def test_get_references_not_called(self, nested_analyzer: JediAnalyzer) -> None:
+        from pyeye.mcp.operations.edges import resolve_enclosing_scope
+
+        assert hasattr(jedi.Script, "get_references")
+        spy = Mock(side_effect=AssertionError("get_references called on enclosing_scope path"))
+        with patch.object(jedi.Script, "get_references", spy):
+            jedi_name = _find_jedi_name_for_handle(_OUTER_METHOD_HANDLE, nested_analyzer)
+            assert jedi_name is not None
+            result = resolve_enclosing_scope(jedi_name, nested_analyzer)
+        # The resolver must have run (method → its class) and never touched reverse search.
+        assert len(result.handles) == 1
+        assert str(result.handles[0]) == _OUTER_CLASS_HANDLE
+        spy.assert_not_called()

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -1578,27 +1578,6 @@ def _enclosing_scope_for(handle: str, analyzer: JediAnalyzer) -> EdgeResult:
     return resolve_enclosing_scope(jedi_name, analyzer)
 
 
-class TestResolveEnclosingScopeEdgeStatus:
-    """Edge-status model: enclosing_scope must be 'implemented' (#370)."""
-
-    def test_enclosing_scope_is_implemented(self) -> None:
-        """After #370, enclosing_scope is implemented — NOT not_yet_implemented."""
-        assert edge_status("enclosing_scope") == "implemented"
-
-    def test_not_yet_implemented_category_is_empty(self) -> None:
-        """_NOT_YET_IMPLEMENTED_EDGES is empty: all recognised edges are now handled.
-
-        The category is retained in the module for the 4-status taxonomy; it is
-        intentionally empty after #370 ships enclosing_scope.
-        """
-        from pyeye.mcp.operations.edges import _NOT_YET_IMPLEMENTED_EDGES
-
-        assert frozenset() == _NOT_YET_IMPLEMENTED_EDGES, (
-            "_NOT_YET_IMPLEMENTED_EDGES must be empty after enclosing_scope is promoted; "
-            f"got {_NOT_YET_IMPLEMENTED_EDGES!r}"
-        )
-
-
 class TestResolveEnclosingScopeMethod:
     """A method → its enclosing class handle (the direct lexical parent)."""
 
@@ -1614,7 +1593,9 @@ class TestResolveEnclosingScopeMethod:
         result = _enclosing_scope_for(_INNER_METHOD_HANDLE, nested_analyzer)
         assert isinstance(result, EdgeResult)
         assert len(result.handles) == 1
-        assert str(result.handles[0]) == _INNER_CLASS_HANDLE
+        assert (
+            str(result.handles[0]) == _INNER_CLASS_HANDLE
+        )  # immediate parent only — NOT the grandparent Outer
 
     def test_adjacent_is_handle_name_pair(self, nested_analyzer: JediAnalyzer) -> None:
         """The adjacent must be a (Handle, Name) pair (not just a handle)."""
@@ -1706,3 +1687,31 @@ class TestResolveEnclosingScopeNeverReverseSearch:
         assert len(result.handles) == 1
         assert str(result.handles[0]) == _OUTER_CLASS_HANDLE
         spy.assert_not_called()
+
+
+class TestResolveEnclosingScopeParentNoneDefensive:
+    """Defensive branch: ``parent()`` returning ``None`` yields ``EdgeResult([])``.
+
+    This test exercises the explicit ``if parent is None`` guard in
+    ``resolve_enclosing_scope`` (edges.py).  The guard is defensive — it handles
+    a Jedi API failure mode where ``parent()`` returns ``None`` for a non-module
+    symbol.  A Mock is used to force the branch deterministically; the happy
+    paths already use real fixtures.
+    """
+
+    def test_parent_returns_none_yields_empty_edgeresult(self) -> None:
+        """When ``parent()`` returns ``None``, resolver returns ``EdgeResult([])`` — never raises."""
+        from unittest.mock import MagicMock
+
+        from pyeye.mcp.operations.edges import resolve_enclosing_scope
+
+        # Construct a mock Jedi Name with a non-module kind so the module gate
+        # does not short-circuit before reaching the parent() call.
+        mock_jedi_name = MagicMock()
+        mock_jedi_name.type = "function"
+        mock_jedi_name.parent.return_value = None  # force the defensive branch
+
+        result = resolve_enclosing_scope(mock_jedi_name, analyzer=MagicMock())
+        assert isinstance(result, EdgeResult)
+        assert result.adjacents == []  # empty, not None
+        assert result is not None  # resolver NEVER returns None

--- a/tests/unit/mcp/operations/test_expand.py
+++ b/tests/unit/mcp/operations/test_expand.py
@@ -251,13 +251,16 @@ class TestExpandUnsupported:
     """Unsupported edges return the unsupported branch with the mapped reason."""
 
     @pytest.mark.asyncio
-    async def test_not_yet_implemented(self, analyzer: JediAnalyzer) -> None:
-        # Use ``enclosing_scope`` — the remaining not_yet_implemented structural edge
-        # (imports moved to implemented in #367, superclasses in #361).
-        result = await expand(_WIDGET_HANDLE, "enclosing_scope", analyzer)
+    async def test_not_yet_implemented_via_none_resolver(self, analyzer: JediAnalyzer) -> None:
+        # ``enclosing_scope`` is now implemented (#370) — the ``not_yet_implemented``
+        # category is empty for real edge names.  The ``not_yet_implemented`` reason
+        # can still be triggered by a resolver that returns ``None`` for a wrong-kind
+        # handle (e.g. ``imported_by`` on a non-module).  We test that path here so
+        # the not_yet_implemented branch in ``expand`` remains covered.
+        result = await expand(_WIDGET_HANDLE, "imported_by", analyzer)
         assert result["unsupported"] is True
         assert result["reason"] == "not_yet_implemented"
-        assert result["edge"] == "enclosing_scope"
+        assert result["edge"] == "imported_by"
         assert result["source"] == _WIDGET_HANDLE
         assert isinstance(result["detail"], str) and result["detail"]
         # Mutually exclusive: an unsupported result NEVER carries stubs.
@@ -317,11 +320,13 @@ class TestExpandBranchesMutuallyExclusive:
     @pytest.mark.parametrize(
         ("handle", "edge"),
         [
-            # imports is now implemented (#367), superclasses in #361 —
-            # use ``enclosing_scope`` as the representative not_yet_implemented edge.
-            (_WIDGET_HANDLE, "enclosing_scope"),
-            (_ORCHESTRATE_HANDLE, "callers"),
-            (_WIDGET_HANDLE, "bogus_edge"),
+            # enclosing_scope is now implemented (#370); imports in #367;
+            # superclasses in #361.  Use a deferred_reference_backend edge
+            # (``callers``) and a wrong-kind imported_by (returns None →
+            # not_yet_implemented) as representative unsupported cases.
+            (_WIDGET_HANDLE, "imported_by"),  # None resolver → not_yet_implemented
+            (_ORCHESTRATE_HANDLE, "callers"),  # deferred_reference_backend
+            (_WIDGET_HANDLE, "bogus_edge"),  # unknown_edge
         ],
     )
     async def test_unsupported_has_no_supported_markers(


### PR DESCRIPTION
## Summary

Promotes `enclosing_scope` from `not_yet_implemented` to a **supported** `expand`/`trace` edge — the **last** outbound/static edge. `expand(handle, "enclosing_scope")` returns a symbol's single immediate lexical enclosing scope (the inverse of `members`); `trace` traverses it.

With this, the entire reliably-static edge set is complete: `members`, `callees`, `imported_by`, `subclasses`, `superclasses`, `imports`, `enclosing_scope`. Only the Pyright-gated `callers`/`references` (#333) remain `deferred_reference_backend`, and **`not_yet_implemented` is now an empty category**.

## Design

- **Resolved via `jedi_name.parent()`** — the resolved-Name approach `inspect._is_method` already uses (NOT dotted-name arithmetic, which can't see class nesting, #337). Carries the parent `Name` so `build_stub` needs no re-resolution. **At most one adjacent** (method→class, top-level def/class→module, nested def→enclosing function, nested class→enclosing class).
- **Module → `EdgeResult([])`** — a module has no enclosing *lexical* scope (packages aren't lexical scopes). Gated on kind before calling `parent()` (a module handle may be a `ModuleSentinel` with no `parent()`).
- **Never `None`** (like subclasses/superclasses): every non-module has a parent scope → no deferred/kind-restricted case → no `None` path. Defensive empty on `parent()` failure. No `get_references` (pure local Jedi API).

## Scope

- **No `inspect.py`** change (not in `edge_counts`), **no `expand.py`/`trace.py`/linter** change.
- `_NOT_YET_IMPLEMENTED_EDGES` is now `frozenset()` — **kept** (the spec's 4-status taxonomy + `edge_status` machinery remain for future edges), with the status table noting it's currently empty.
- Empty-category test churn: the `edge_status` test asserts the set is empty; `test_enclosing_scope_is_implemented` added; the generic `not_yet_implemented`-reason test repointed to `expand(<non-module>, "imported_by")` (a real edge+kind that still yields that reason via its `None` resolver signal). `server.py` `expand` docstring: one-line clarification (docstring-only).

## Test plan

- [x] Full suite green (2059 passed) at the 85% coverage gate
- [x] method→class, top-level→module, nested→**immediate** parent (3-level test proves single-hop, not grandparent), module→`[]`, adjacent is `(Handle, Name)`
- [x] `parent()→None` defensive branch covered; `edge_status("enclosing_scope")=="implemented"`; `_NOT_YET_IMPLEMENTED_EDGES == frozenset()`
- [x] No `get_references` on the path (spy-tested); `inspect`/`expand`/`trace`/linter untouched

Closes #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)