### PR TITLE
docs(worktree-hook): document git-repo hook firing, session loading, manual removal (#372)

### DIFF
--- a/plugins/worktree-hook/README.md
+++ b/plugins/worktree-hook/README.md
@@ -63,3 +63,42 @@ minimal built-in parser otherwise.
 > exact command string. If you previously registered `worktree_create.py` in
 > `~/.claude/settings.json`, remove that `WorktreeCreate` block when adopting
 > this plugin — otherwise both run and conflict.
+
+## Notes
+
+These behaviours were verified empirically during testing of the installed
+plugin. They are non-obvious — each one caused real confusion — so they are
+captured here to save the next person the same debugging.
+
+### This hook fires inside git repositories
+
+Claude Code's published docs suggest `WorktreeCreate` hooks apply only to
+non-git version control (SVN, Perforce, Mercurial). In practice — verified by
+testing — `EnterWorktree` *does* route through a registered `WorktreeCreate`
+hook inside a normal git repository, and the hook's stdout path fully overrides
+the native default (`.claude/worktrees/<name>` on a `worktree-<name>` branch).
+This override is the entire basis for the plugin working, so without it the
+plugin would be dead code. Because this contradicts the published docs, treat it
+as observed behaviour that could change across Claude Code versions rather than a
+guarantee.
+
+### Restart your session after installing/enabling
+
+Plugin hooks load at session start, not retroactively. If you `/plugin install`
+(or enable) this plugin in a session that began *before* the install,
+`EnterWorktree` falls back to native behaviour (a flat `worktree-<name>`
+directory and branch) because the plugin's hook isn't loaded yet. Start a fresh
+session before the hook takes effect. (Hooks defined directly in `settings.json`
+are auto-reloaded mid-session via the file watcher; only plugin hooks need the
+restart.)
+
+### Removing a worktree this hook created
+
+Because the worktree is created out-of-band by the hook, `ExitWorktree` may
+refuse to remove it ("could not verify worktree state"). Remove it with git
+directly:
+
+```bash
+git worktree remove --force .claude/worktrees/<type>/<name>
+git branch -D <type>/<name>
+```


### PR DESCRIPTION
## Summary
- Add a `## Notes` section to `plugins/worktree-hook/README.md` capturing three empirically-verified, non-obvious behaviours of the worktree-hook plugin that surfaced during end-to-end testing:
  - **WorktreeCreate hooks fire inside git repos** — contrary to Claude Code's published docs (which imply non-git VCS only). The hook's stdout path fully overrides the native default; this override is the entire basis for the plugin working. Phrased as "verified by testing" since it contradicts the docs and could change across versions.
  - **Plugin hooks load only at session start** — a fresh session is required after install/enable (unlike `settings.json` hooks, which auto-reload mid-session).
  - **Hook-created worktrees need manual removal** — `ExitWorktree` may refuse; use `git worktree remove --force` + `git branch -D`.

## Test plan
- [x] Docs-only change (1 file, +39 lines) — no code, no tests
- [x] Pre-commit hooks pass (markdownlint, detect-secrets, PyEye conformance linter, commitizen)
- [x] Both acceptance criteria met: all three behaviours documented; docs-discrepancy phrased as "verified by testing"

Addresses #372