### PR TITLE
docs(inspect): correct edge_counts docstrings to drop callers/references claim (#377)

### DIFF
--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -2,7 +2,7 @@
 
 The canonical "what is this?" operation.  Returns kind, signature, location,
 docstring, plus kind-dependent fields.  No source content.  No edge expansions
-beyond the 5 Phase 4 edge types in edge_counts.
+beyond the edge types measured in edge_counts.
 
 Public API
 ----------
@@ -13,10 +13,11 @@ Public API
 
 Design notes
 ------------
-- ``edge_counts`` is ALWAYS present.  Phase 4 populates 5 edge types:
-  ``members`` (class/module), ``superclasses`` (class), ``subclasses`` (class,
-  project-scoped), ``callers`` (function/method), ``references`` (all kinds,
-  excludes call sites).  Unmeasured edge types are ABSENT (not 0).
+- ``edge_counts`` is ALWAYS present.  It measures 3 edge types: ``members``
+  (class/module), ``superclasses`` (class), and ``subclasses`` (class,
+  project-scoped).  ``callers`` and ``references`` are intentionally OMITTED —
+  they are deferred to the Pyright reference backend (#333) per the
+  absence-vs-zero invariant.  Unmeasured edge types are ABSENT (not 0).
 - ``re_exports``, ``highlights``, ``tags``, ``properties`` are ABSENT in Phase 4.
 - ``Param.kind`` values: lowercase 5-value enum
   (``"positional"``, ``"positional_or_keyword"``, ``"keyword_only"``,
@@ -888,9 +889,10 @@ async def inspect(handle: str, analyzer: JediAnalyzer) -> dict[str, Any]:
     returns source content — signatures are single-line strings; ``location``
     is a pointer dict only; ``default`` fields are simple literals only.
 
-    Always includes ``edge_counts`` (Phase 4 measures: members, superclasses,
-    subclasses, callers, references — for relevant kinds).  Edges that exceed
-    their per-measurement budget are OMITTED, not zero.
+    Always includes ``edge_counts`` (measures: members, superclasses,
+    subclasses — for relevant kinds).  ``callers`` and ``references`` are
+    intentionally OMITTED (deferred to the Pyright reference backend, #333).
+    Edges that exceed their per-measurement budget are OMITTED, not zero.
     Phase 6 adds ``re_exports`` for non-module kinds (class, function, method,
     property, variable, attribute).  For module kind, ``re_exports`` is ABSENT
     (not computed in Phase 6 — per the absence-vs-zero spec invariant: absent


### PR DESCRIPTION
## Summary
- Two docstrings in `src/pyeye/mcp/operations/inspect.py` claimed `edge_counts` measures `callers` and `references`, but `_build_edge_counts` deliberately omits them (deferred to the Pyright reference backend, #333, per the absence-vs-zero invariant).
- Corrected the **module docstring** and the **`inspect()` docstring** (the latter ships as the MCP tool description users see) to list only the actually-measured edges — `members`, `superclasses`, `subclasses` — and to state `callers`/`references` are intentionally omitted.
- Also fixed the related stale "5 Phase 4 edge types" phrasing in the module docstring header.

Docs-only change (docstrings); no behavior change. Verified the corrected text against `_build_edge_counts`, which measures only those three edges.

## Test plan
- [x] `uv run pytest tests/unit/mcp/operations/test_inspect.py tests/conformance/` — 314 passed
- [x] Pre-commit hooks (black, ruff, mypy, pydocstyle, conformance linter) passed clean

## Note (out of scope)
Several stale comments in test files still reference "callers, references" as measured (`test_inspect.py`, `test_linter_adversarial.py`, `response_linter.py`). These are test-internal comments — assertions are correct and don't break. Deliberately left out per #377's user-facing-docstrings-only scope; a follow-up issue can clean them up.

Fixes #377