### PR TITLE
docs(inspect): drop internal phase jargon from shipped inspect docstrings (#379)

### DIFF
--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -18,9 +18,11 @@ Design notes
   project-scoped).  ``callers`` and ``references`` are intentionally OMITTED —
   they are deferred to the Pyright reference backend (#333) per the
   absence-vs-zero invariant.  Unmeasured edge types are ABSENT (not 0).
-- ``re_exports`` is present (possibly ``[]``) for non-module kinds and ABSENT
-  for module kind.  ``highlights``, ``tags``, ``properties`` are not currently
-  computed and are therefore ABSENT.
+- ``re_exports`` (non-module kinds): present when measured (``[]`` = measured,
+  none found), or ABSENT if collection failed (couldn't measure).  ABSENT for
+  module kind (not computed for this kind).  Per the absence-vs-zero invariant,
+  absence never means "none".  ``highlights``, ``tags``, ``properties`` are not
+  currently computed and are therefore ABSENT.
 - ``Param.kind`` values: lowercase 5-value enum
   (``"positional"``, ``"positional_or_keyword"``, ``"keyword_only"``,
   ``"var_positional"``, ``"var_keyword"``).
@@ -895,10 +897,11 @@ async def inspect(handle: str, analyzer: JediAnalyzer) -> dict[str, Any]:
     subclasses — for relevant kinds).  ``callers`` and ``references`` are
     intentionally OMITTED (deferred to the Pyright reference backend, #333).
     Edges that exceed their per-measurement budget are OMITTED, not zero.
-    ``re_exports`` is present (possibly ``[]``) for non-module kinds (class,
-    function, method, property, variable, attribute) and ABSENT for module kind
-    — for modules, absence means "not computed for this kind" per the
-    absence-vs-zero invariant.
+    ``re_exports`` — for non-module kinds (class, function, method, property,
+    variable, attribute): present when measured (``[]`` = measured, no
+    re-exports), or ABSENT if collection failed (couldn't measure).  ABSENT for
+    module kind (not computed for this kind).  Per the absence-vs-zero
+    invariant, absence never means "none".
     ``highlights``, ``tags``, and ``properties`` are not currently computed and
     are therefore ABSENT.
 

--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -18,7 +18,9 @@ Design notes
   project-scoped).  ``callers`` and ``references`` are intentionally OMITTED —
   they are deferred to the Pyright reference backend (#333) per the
   absence-vs-zero invariant.  Unmeasured edge types are ABSENT (not 0).
-- ``re_exports``, ``highlights``, ``tags``, ``properties`` are ABSENT in Phase 4.
+- ``re_exports`` is present (possibly ``[]``) for non-module kinds and ABSENT
+  for module kind.  ``highlights``, ``tags``, ``properties`` are not currently
+  computed and are therefore ABSENT.
 - ``Param.kind`` values: lowercase 5-value enum
   (``"positional"``, ``"positional_or_keyword"``, ``"keyword_only"``,
   ``"var_positional"``, ``"var_keyword"``).
@@ -893,11 +895,12 @@ async def inspect(handle: str, analyzer: JediAnalyzer) -> dict[str, Any]:
     subclasses — for relevant kinds).  ``callers`` and ``references`` are
     intentionally OMITTED (deferred to the Pyright reference backend, #333).
     Edges that exceed their per-measurement budget are OMITTED, not zero.
-    Phase 6 adds ``re_exports`` for non-module kinds (class, function, method,
-    property, variable, attribute).  For module kind, ``re_exports`` is ABSENT
-    (not computed in Phase 6 — per the absence-vs-zero spec invariant: absent
-    means "we don't compute re_exports for this kind").
-    ``highlights``, ``tags``, and ``properties`` remain absent (later phases).
+    ``re_exports`` is present (possibly ``[]``) for non-module kinds (class,
+    function, method, property, variable, attribute) and ABSENT for module kind
+    — for modules, absence means "not computed for this kind" per the
+    absence-vs-zero invariant.
+    ``highlights``, ``tags``, and ``properties`` are not currently computed and
+    are therefore ABSENT.
 
     Args:
         handle: Canonical Python dotted-name string (from resolve/resolve_at).


### PR DESCRIPTION
## Summary
- The `inspect()` docstring ships as the MCP tool description that agents/users see. It (and the module docstring header) carried pyeye-internal phase-number jargon — "ABSENT in **Phase 4**", "**Phase 6** adds `re_exports`", "remain absent (**later phases**)" — which means nothing to a consumer.
- Reworded both shipped surfaces to describe **current behavior** in user-facing terms, with no internal phase numbers.
- Also corrected a stale claim surfaced while rewording: `re_exports` was said to be "ABSENT in Phase 4", but it is now **present (possibly `[]`) for non-module kinds** and ABSENT only for module kind. The user-meaningful absence-vs-zero semantics are preserved.

Internal code comments and helper docstrings that reference phase numbers were intentionally left untouched — they're implementation notes, not the shipped tool description (out of #379 scope).

Docs-only change (docstrings); no behavior change.

## Test plan
- [x] `uv run pytest tests/unit/mcp/operations/test_inspect.py tests/conformance/` — 314 passed
- [x] Pre-commit hooks (black, ruff, mypy, pydocstyle, conformance linter) passed clean

Fixes #379