### PR TITLE
docs(python-explore): rewrite skill around progressive-disclosure API (#374)

### DIFF
--- a/.claude/instructions/03-mcp-dogfooding.md
+++ b/.claude/instructions/03-mcp-dogfooding.md
@@ -1,240 +1,61 @@
 <!--
 Audience: Claude Code
 Purpose: Enforce MCP-first development workflow for Python code analysis
-When to update: When new MCP tools are added or patterns discovered
+When to update: When the dogfooding stance changes. Tool MECHANICS (which
+primitive, which edges, the honest-limits rule) live in the python-explore
+skill — update there, not here, so the two never drift (the bug that
+prompted #374).
 -->
 
 # MCP-First Development Workflow (Dogfooding Our Own Tools)
 
-**CRITICAL**: We build PyEye - we MUST use it for our own development!
+**CRITICAL**: We build PyEye — we MUST use it for our own development!
 
-## Preferred operations (Phases 1-4 + 6 + 7 done)
-
-For NEW Python code analysis, prefer the redesigned API surface:
-
-- `resolve(identifier)` instead of `find_symbol` — returns canonical handle with ambiguity surfaced
-- `resolve_at(file, line, column)` instead of `goto_definition` — position to canonical handle
-- `inspect(handle)` instead of `get_type_info` — richer structural Node with edge counts
-
-Why prefer these:
-
-- Cheap by default — small structural responses, no source content
-- Absence-vs-zero invariant — `edge_counts` distinguishes "measured zero" from "didn't measure"
-- Canonical handles — re-exported paths collapse to the definition site, deduplicating across import aliases
-
-The legacy tools (`find_symbol`, `goto_definition`, etc.) remain for backwards compat
-but are marked deprecated. They will be removed once the migration completes.
-
-See `docs/api-redesign.md` for full documentation of the new operations.
-
-## Why MCP-First?
-
-We're developing a powerful semantic code analysis tool but have been falling back to basic grep/glob patterns. This is like building a sports car and pushing it instead of driving it. From now on, ALL Python development in this project MUST prioritize MCP tools over traditional text search.
+We're developing a powerful semantic code analysis tool. Falling back to raw
+grep/glob for Python is like building a sports car and pushing it. ALL Python
+work in this project MUST prioritise pyeye's semantic operations over text search.
 
 ## Core Principle: Semantic Over Text
 
 **Always choose semantic understanding over text matching:**
 
-- Understand code structure, not just text patterns
-- Navigate by meaning, not by string search
-- Leverage type information and relationships
-- Use framework-specific intelligence when available
+- Understand code structure, not just text patterns.
+- Navigate by meaning (canonical handles), not by string search.
+- Leverage type information and relationships.
 
-## Required Workflow for Python Code Analysis
+## The Tool Surface (redesigned API)
 
-Before working on ANY Python code:
+For Python code analysis, use the progressive-disclosure operations:
+`resolve` / `resolve_at` / `inspect` / `outline` / `expand` / `trace`. They are
+cheap by default (small structural responses, no source content), honour the
+absence-vs-zero invariant, and operate on canonical handles that collapse
+re-exported paths to the definition site.
 
-### 1. Discovery Phase - Understanding the codebase
+The old Jedi-shaped tools (`find_symbol`, `goto_definition`, `get_type_info`,
+`find_references`, etc.) remain only for backwards compatibility and are
+**deprecated** — do not reach for them, and never use the reverse-reference
+tools to answer "who calls / references this" (see the honest-limits rule in the
+skill). See `docs/api-redesign.md` for the redesign background.
 
-```bash
-mcp__pyeye__list_packages        # See package structure
-mcp__pyeye__list_modules         # Understand module organization
-mcp__pyeye__list_project_structure  # Get project layout
-```
+## Tool mechanics live in the `python-explore` skill
 
-### 2. Navigation Phase - Finding code
+**Single source of truth.** Which primitive to call, the supported edges, the
+honest-limits rule (callers/references are deferred to the Pyright backend, #333
+— don't fake them), the worked examples — all of that lives in the
+`python-explore` skill (`skills/python-explore/SKILL.md`), which ships to users.
 
-```bash
-mcp__pyeye__find_symbol         # Find definitions (not grep!)
-mcp__pyeye__goto_definition     # Jump to definitions
-mcp__pyeye__find_references     # Find all usages
-mcp__pyeye__get_type_info       # Understand types
-```
-
-### 3. Analysis Phase - Understanding relationships
-
-```bash
-mcp__pyeye__analyze_dependencies  # Module dependencies
-mcp__pyeye__get_call_hierarchy   # Function call chains
-mcp__pyeye__find_subclasses      # Inheritance trees
-mcp__pyeye__find_imports         # Import tracking
-```
-
-### 4. Framework-Specific Intelligence (when applicable)
-
-```bash
-# Pydantic projects:
-mcp__pyeye__find_models
-mcp__pyeye__get_model_schema
-
-# Flask projects:
-mcp__pyeye__find_routes
-mcp__pyeye__find_blueprints
-
-# Django projects:
-mcp__pyeye__find_django_models
-mcp__pyeye__find_django_views
-```
-
-## Pattern Replacements (MANDATORY)
-
-These replacements are REQUIRED - using the old patterns is considered a workflow violation:
-
-### Finding Code
-
-- ❌ **WRONG**: `grep -r "class MyClass"` or `Grep("class MyClass")`
-- ✅ **RIGHT**: `mcp__pyeye__find_symbol("MyClass")`
-
-- ❌ **WRONG**: `grep -r "def function_name"`
-- ✅ **RIGHT**: `mcp__pyeye__find_symbol("function_name")`
-
-- ❌ **WRONG**: `find . -name "*.py" | xargs grep "import module"`
-- ✅ **RIGHT**: `mcp__pyeye__find_imports("module")`
-
-### Understanding Code Structure
-
-- ❌ **WRONG**: `ls -la src/` or `tree src/`
-- ✅ **RIGHT**: `mcp__pyeye__list_project_structure()`
-
-- ❌ **WRONG**: Reading entire file to understand exports
-- ✅ **RIGHT**: `mcp__pyeye__get_module_info("module.path")`
-
-- ❌ **WRONG**: Manually tracing function calls
-- ✅ **RIGHT**: `mcp__pyeye__get_call_hierarchy("function_name")`
-
-### Refactoring Preparation
-
-- ❌ **WRONG**: Grep for symbol before renaming
-- ✅ **RIGHT**: `mcp__pyeye__find_references()` at position
-
-- ❌ **WRONG**: Manually checking inheritance
-- ✅ **RIGHT**: `mcp__pyeye__find_subclasses("BaseClass")`
-
-- ❌ **WRONG**: Reading files to understand dependencies
-- ✅ **RIGHT**: `mcp__pyeye__analyze_dependencies("module")`
-
-## Real-World Usage Examples
-
-### Example 1: Adding a New Method to a Class
-
-```python
-# 1. Find the class definition
-result = mcp__pyeye__find_symbol("ProjectManager")
-
-# 2. Get type info to understand the class
-info = mcp__pyeye__get_type_info(
-    file=result[0]["file"],
-    line=result[0]["line"],
-    column=result[0]["column"]
-)
-
-# 3. Find all references to ensure compatibility
-refs = mcp__pyeye__find_references(
-    file=result[0]["file"],
-    line=result[0]["line"],
-    column=result[0]["column"]
-)
-
-# 4. Check subclasses that might be affected
-subclasses = mcp__pyeye__find_subclasses("ProjectManager")
-```
-
-### Example 2: Refactoring a Module
-
-```python
-# 1. Understand module structure
-module_info = mcp__pyeye__get_module_info("pyeye.cache")
-
-# 2. Analyze dependencies
-deps = mcp__pyeye__analyze_dependencies("pyeye.cache")
-
-# 3. Find all imports of this module
-imports = mcp__pyeye__find_imports("pyeye.cache")
-
-# 4. Check for circular dependencies
-# deps["circular_dependencies"] will list any found
-```
-
-### Example 3: Understanding Plugin Architecture
-
-```python
-# 1. Find base plugin class
-base = mcp__pyeye__find_symbol("BasePlugin")
-
-# 2. Find all plugin implementations
-plugins = mcp__pyeye__find_subclasses("BasePlugin", show_hierarchy=True)
-
-# 3. Understand each plugin's structure
-for plugin in plugins:
-    info = mcp__pyeye__get_module_info(plugin["module"])
-```
+Do **not** restate tool usage here. When you need the mechanics, use the skill —
+this is the repo dogfooding its own shipped guide, and keeping one copy is what
+stops the guidance from rotting (the failure that prompted #374). The skill's
+supported-edge list is conformance-tested against the live edge registry
+(`tests/test_python_explore_skill_conformance.py`).
 
 ## Measuring Success
 
-We track MCP tool usage vs traditional search methods. Target metrics:
+We track pyeye adoption vs traditional search to make sure we actually drive the
+car we build. The signal is simple: **Python navigation, discovery, and
+relationship questions go through pyeye, not grep.** Adoption metrics are
+surfaced by the `mcp-report` / `mcp-logs` commands documented in the root
+`CLAUDE.md` ("Dogfooding Metrics Tracking").
 
-- **>80% of Python navigation** should use MCP tools
-- **100% of refactoring** should use find_references first
-- **All inheritance checks** should use find_subclasses
-- **Zero grep usage** for Python symbol search
-
-## Troubleshooting Common Scenarios
-
-### "I can't find a symbol"
-
-1. First try exact match: `find_symbol("exact_name")`
-2. Then try fuzzy match: `find_symbol("partial", fuzzy=True)`
-3. Check if it's in a different project/package
-4. Use `find_symbol_multi` for multi-project search
-
-### "I need to understand how something works"
-
-1. Start with `get_type_info` for documentation
-2. Use `get_call_hierarchy` to trace execution
-3. Use `analyze_dependencies` to understand module relationships
-4. Check `find_references` to see usage patterns
-
-### "I'm refactoring and need to ensure nothing breaks"
-
-1. Always start with `find_references` - NEVER skip this
-2. Check `find_subclasses` for inheritance implications
-3. Run `analyze_dependencies` to understand impact
-4. Use `get_call_hierarchy` to trace call chains
-
-## Benefits We've Discovered
-
-Through dogfooding our own tool, we've found:
-
-1. **3x faster navigation** compared to grep
-2. **Catches more edge cases** during refactoring
-3. **Better understanding** of code relationships
-4. **Finds issues** that text search misses
-5. **Type-aware** navigation prevents mistakes
-
-## Performance Tips
-
-- MCP tools are cached for 5 minutes - repeated queries are instant
-- Use `list_modules` once at start for overview
-- Batch related queries together
-- Framework-specific tools are faster than generic ones
-
-## Contributing to MCP Tool Usage
-
-When you discover a new pattern or use case:
-
-1. Document it in this section
-2. Add it to troubleshooting if it was non-obvious
-3. Consider if we need a new MCP tool for the pattern
-4. Share performance comparisons with traditional methods
-
-Remember: **We build this tool - we must be its best users!**
+Remember: **We build this tool — we must be its best users!**

--- a/docs/superpowers/plans/2026-06-15-python-explore-skill-rewrite.md
+++ b/docs/superpowers/plans/2026-06-15-python-explore-skill-rewrite.md
@@ -103,6 +103,22 @@ def test_skill_name_is_stable() -> None:
 
 def test_skill_declares_a_description() -> None:
     assert re.search(r"^description:\s*\S", _skill_text(), re.MULTILINE)
+
+
+# Pure-legacy tools with NO legitimate reason to appear anywhere in the rewritten
+# skill. NOTE: find_references / get_call_hierarchy are deliberately NOT in this set —
+# they legitimately appear inside the honest-limits "do NOT use these to fake callers"
+# warning, so they cannot be blanket-banned. These four have no such excuse.
+_PURE_LEGACY_TOOLS = ("lookup", "find_symbol", "goto_definition", "get_type_info")
+
+
+def test_pure_legacy_tools_absent() -> None:
+    # Mechanical backstop for prose drift: catches a future "use find_symbol" sentence
+    # that the edge anchor alone would miss. Manual review remains the backstop for the
+    # contextual cases (find_references in the honest-limits warning).
+    text = _skill_text()
+    present = [t for t in _PURE_LEGACY_TOOLS if t in text]
+    assert not present, f"pure-legacy tools must not appear in the skill: {present}"
 ```
 
 **Constraints:**
@@ -140,11 +156,12 @@ def test_skill_declares_a_description() -> None:
 - IMPORTANT: do not recommend `lookup`, `find_symbol`, `find_references`, `get_call_hierarchy`, `find_subclasses`, `analyze_dependencies`, `goto_definition`, `get_type_info` as tools to use. The legacy reference tools (`find_references`, `get_call_hierarchy`) appear ONLY inside the honest-limits warning as "don't use these to fake callers".
 - Every edge named as supported must be in `_IMPLEMENTED_EDGES`; every deferred edge mentioned must be framed as NOT available.
 - Markdown must pass the repo's `markdownlint` pre-commit hook (mirror the formatting conventions of the existing skill — fenced code blocks, table syntax, heading levels).
+- **Confirm the `<!-- pyeye-supported-edges: … -->` anchor survives markdownlint EARLY** (the whole guard depends on it). Low risk — the repo already ships HTML comments in committed instruction files (e.g. `04-agent-triggers.md`) that lint clean — but run `uv run pre-commit run markdownlint --files skills/python-explore/SKILL.md` as soon as the anchor is in place rather than discovering a problem at commit time.
 - `dot` graph: keep it valid Graphviz like the current skill's block.
 
 **Acceptance criteria:**
 
-- `uv run pytest tests/test_python_explore_skill_conformance.py` passes (all five tests).
+- `uv run pytest tests/test_python_explore_skill_conformance.py` passes (all six tests, including `test_pure_legacy_tools_absent`).
 - Manual read-through confirms: no legacy tool recommended; honest-limits section present and prominent; examples localised; `resolve` location + ambiguity covered; `resolve_at` demonstrated.
 - Commit Task 1's test together with this rewrite (red+green in one commit), message scoped to the skill rewrite and `#374`.
 
@@ -161,7 +178,16 @@ def test_skill_declares_a_description() -> None:
 **Content contract (spec "`03-mcp-dogfooding.md` (internal) — slimmed shape"):**
 
 - **Keep:** "we build pyeye — we MUST use it" framing; semantic-over-text principle; the existing redesign "preferred operations" note (resolve/inspect/outline/expand/trace are the surface; legacy tools deprecated, backwards-compat only) — it already points at `docs/api-redesign.md`, which is confirmed present and current; metrics commands (`mcp-report`, `mcp-logs`, etc.) and a high-level "measuring success" note; repo-specific dogfooding context.
-- **Replace:** the entire "Pattern Replacements" legacy catalogue and the legacy "Required Workflow for Python Code Analysis" phases (`find_symbol`/`goto_definition`/`get_call_hierarchy`/`find_references`/…) and the legacy worked examples that call them, with a short pointer block: **"For tool mechanics — which primitive to call, the supported edges, and the honest-limits rule — the `python-explore` skill is the single canonical reference. Don't restate tool usage here."**
+- **Replace / remove — ALL sections that recommend legacy tools or the reverse-reference search, not just the obvious two.** IMPORTANT: a sweep of the *whole* file is required, because the legacy/honesty rot is spread across at least six sections (verified against `main`):
+  - "Required Workflow for Python Code Analysis" (the `find_symbol`/`goto_definition`/`get_call_hierarchy`/`find_references` phases)
+  - "Pattern Replacements (MANDATORY)" (the ❌grep→✅legacy-tool catalogue)
+  - "Real-World Usage Examples" (`find_symbol`/`get_type_info`/`find_references`/`find_subclasses`/`get_module_info` walkthroughs)
+  - "Troubleshooting Common Scenarios" (esp. *"I'm refactoring… Always start with `find_references` — NEVER skip this"*)
+  - "Measuring Success" (the metrics *"100% of refactoring should use `find_references` first"* and *"All inheritance checks should use `find_subclasses`"*)
+  - "Performance Tips" (`list_modules`/legacy-tool tips)
+
+  The Troubleshooting + Measuring-Success items are the **same honesty bug as #374 sitting internally** — they steer the agent to the exact unreliable reverse-reference search the redesign rejects; leaving them is not acceptable. Replace the removed mechanics with one short pointer block: **"For tool mechanics — which primitive to call, the supported edges, and the honest-limits rule — the `python-explore` skill is the single canonical reference. Don't restate tool usage here."** Where a section has reframeable value (e.g. a "measuring success" *idea* — we measure MCP adoption), keep the framing but drop the legacy-tool-specific metrics, or fold it into the kept metrics-commands note.
+- **Keep ONLY:** the framing + semantic-over-text principle + the redesign "preferred operations" note + metrics commands + the skill pointer. After the sweep, grep the file for `find_references`, `find_subclasses`, `get_call_hierarchy`, `find_symbol`, `goto_definition`, `get_type_info`, `lookup` — there should be **no remaining recommendation** of them (a single mention inside a "these are deprecated, use the skill" note is the only acceptable residue).
 
 **Constraints:**
 
@@ -169,7 +195,7 @@ def test_skill_declares_a_description() -> None:
 - Keep the file's numbered-instruction-file conventions and heading style; it's loaded via `CLAUDE.md`.
 - Must pass `markdownlint`.
 
-**Acceptance criteria:** `03-mcp-dogfooding.md` no longer presents legacy tools as the workflow; contains the deferral pointer to the skill; framing/metrics retained. Commit scoped to the `03` slim and `#374`.
+**Acceptance criteria:** `03-mcp-dogfooding.md` no longer presents legacy tools as the workflow **in any section** (Required Workflow, Pattern Replacements, Real-World Examples, Troubleshooting, Measuring Success, Performance Tips all swept); `grep -E 'find_references|find_subclasses|get_call_hierarchy|find_symbol|goto_definition|get_type_info|lookup' .claude/instructions/03-mcp-dogfooding.md` returns only deprecation-context residue, not recommendations; the deferral pointer to the skill is present; framing/metrics retained. Commit scoped to the `03` slim and `#374`.
 
 **Risks:** Accidentally removing the "preferred operations" redesign note (it's the bridge to the new API) — keep it.
 

--- a/docs/superpowers/plans/2026-06-15-python-explore-skill-rewrite.md
+++ b/docs/superpowers/plans/2026-06-15-python-explore-skill-rewrite.md
@@ -1,0 +1,199 @@
+# python-explore Skill Rewrite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite the shipped `python-explore` skill around pyeye's progressive-disclosure API (resolve/inspect/outline/expand/trace) with the honest-limits rule centred, slim the internal `03-mcp-dogfooding.md` to defer tool mechanics to the skill, and add a mechanical anti-drift guard so the skill can't silently rot against the edge registry again.
+
+**Architecture:** Three artifacts change — `skills/python-explore/SKILL.md` (full rewrite, ships to users), `.claude/instructions/03-mcp-dogfooding.md` (slim + defer, internal only), and a new dependency-free conformance test that pins the skill's documented edge set to `_IMPLEMENTED_EDGES`. The design of record is `docs/superpowers/specs/2026-06-15-python-explore-skill-rewrite-design.md` — read it before implementing; this plan pins the testable contracts and points at that spec for prose content.
+
+**Tech Stack:** Markdown (skill + instructions), Python stdlib (`re`, `pathlib`) for the conformance test, pytest.
+
+---
+
+## Spec reference
+
+Every prose decision (frontmatter triggers, section ordering, the honest-limits wording, the worked examples, what to keep/cut in `03`) lives in the spec. Read these spec sections before each task:
+
+- Skill body: spec "Skill structure (rewritten `skills/python-explore/SKILL.md`)" — sections 1–10.
+- `03` slim: spec "`03-mcp-dogfooding.md` (internal) — slimmed shape".
+- Guard: spec "Anti-drift conformance guard".
+- Verified ground truth (the facts the skill must state accurately) and "Out of scope".
+
+**Verified facts the skill MUST state (do not re-derive — copied from the spec's verified ground truth):**
+
+- Live primitives: `resolve`, `resolve_at`, `inspect`, `outline`, `expand`, `trace`.
+- Live `expand`/`trace` edges (= `_IMPLEMENTED_EDGES`): `members`, `callees`, `imported_by`, `subclasses`, `superclasses`, `imports`, `enclosing_scope`.
+- Deferred (= `_DEFERRED_REFERENCE_BACKEND_EDGES`, NOT available, #333): `callers`, `references`, `read_by`, `written_by`, `passed_by`, `overrides`, `overridden_by`, `decorated_by`, `decorates`.
+- `resolve` success returns `{found, handle, kind, scope, location}` (location included); ambiguous returns `{found, ambiguous, candidates: [...]}`.
+- `inspect.edge_counts` measures only: class → members+superclasses+subclasses; module → members; other kinds → empty. NOT callers/references.
+
+---
+
+## File Structure
+
+- `tests/test_python_explore_skill_conformance.py` — NEW. Dependency-free pytest module. Parses the skill's machine-readable edge anchor and pins it to the registry; checks frontmatter name stability. Single responsibility: prevent skill/registry drift.
+- `skills/python-explore/SKILL.md` — REWRITE. The shipped user-facing guide. Must satisfy the conformance test and encode spec sections 1–10.
+- `.claude/instructions/03-mcp-dogfooding.md` — SLIM. Internal-only. Keep framing/metrics; delete the duplicated legacy tool catalogue; point to the skill.
+
+---
+
+## Task 1 — Add the anti-drift conformance test (failing first)
+
+**Goal:** Encode the decision "the skill's documented supported-edge set is exactly the implemented registry, and the skill name is stable" as a test, so the skill rewrite has a mechanical target and future edge changes fail loudly. Written first (TDD) — it fails until Task 2 adds the anchor.
+
+**Files:** `tests/test_python_explore_skill_conformance.py` (new).
+
+**Interfaces consumed** (from `src/pyeye/mcp/operations/edges.py`, copy verbatim):
+
+```python
+from pyeye.mcp.operations.edges import (
+    _IMPLEMENTED_EDGES,             # frozenset[str]
+    _DEFERRED_REFERENCE_BACKEND_EDGES,  # frozenset[str]
+)
+```
+
+**Interface produced** (the anchor contract Task 2 must satisfy): the skill file contains exactly one line matching `<!-- pyeye-supported-edges: <space-separated edge names> -->`, and the whitespace-split token set of that list equals `set(_IMPLEMENTED_EDGES)`.
+
+**Tests:** This task *is* the tests. Pin these assertions (dependency-free — `re` + `pathlib` only; do NOT add a yaml dependency):
+
+```python
+import re
+from pathlib import Path
+
+from pyeye.mcp.operations.edges import (
+    _IMPLEMENTED_EDGES,
+    _DEFERRED_REFERENCE_BACKEND_EDGES,
+)
+
+SKILL = Path(__file__).resolve().parent.parent / "skills" / "python-explore" / "SKILL.md"
+_ANCHOR = re.compile(r"<!--\s*pyeye-supported-edges:\s*(.*?)\s*-->")
+
+
+def _skill_text() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def _documented_edges() -> set[str]:
+    m = _ANCHOR.search(_skill_text())
+    assert m is not None, (
+        "SKILL.md must embed a `<!-- pyeye-supported-edges: ... -->` anchor "
+        "listing the supported expand/trace edges"
+    )
+    return set(m.group(1).split())
+
+
+def test_skill_file_exists() -> None:
+    assert SKILL.is_file(), f"skill not found at {SKILL.as_posix()}"
+
+
+def test_documented_edges_equal_implemented_registry() -> None:
+    # Drift guard: the skill's supported-edge list must track edges.py exactly.
+    assert _documented_edges() == set(_IMPLEMENTED_EDGES)
+
+
+def test_no_deferred_edge_listed_as_supported() -> None:
+    # The #1 bug class: never present a reference-backend edge as available.
+    assert _documented_edges().isdisjoint(_DEFERRED_REFERENCE_BACKEND_EDGES)
+
+
+def test_skill_name_is_stable() -> None:
+    # The plugin resolves the skill by this name; a rename would unship it.
+    assert re.search(r"^name:\s*python-explore\s*$", _skill_text(), re.MULTILINE)
+
+
+def test_skill_declares_a_description() -> None:
+    assert re.search(r"^description:\s*\S", _skill_text(), re.MULTILINE)
+```
+
+**Constraints:**
+
+- Dependency-free: stdlib only. Do not import `yaml`.
+- `_IMPLEMENTED_EDGES` / `_DEFERRED_REFERENCE_BACKEND_EDGES` are module-private (leading underscore) but are the genuine source of truth; importing them in a test in the same project is acceptable and intentional (the test's whole point is to bind to them).
+- Path resolution must work when pytest is run from the repo root: `Path(__file__).resolve().parent.parent` is the repo root, then `skills/python-explore/SKILL.md`.
+
+**Acceptance criteria:** `uv run pytest tests/test_python_explore_skill_conformance.py` runs and **fails** on the edge/anchor assertions (because the current skill has no anchor and still lists legacy tools) — confirming the test exercises the contract. `test_skill_file_exists` passes (the file exists today). Do NOT commit yet — commit with Task 2 (red+green together).
+
+**Risks:** If the current skill happens to contain a coincidental `pyeye-supported-edges` string, the anchor test could behave unexpectedly — verify by reading the failing output; the current skill has no such anchor, so the anchor assertion should fail cleanly.
+
+---
+
+## Task 2 — Rewrite `skills/python-explore/SKILL.md`
+
+**Goal:** Replace the rotted skill with the progressive-disclosure guide so users get correct, honest guidance. Makes Task 1's test pass and encodes spec sections 1–10.
+
+**Files:** `skills/python-explore/SKILL.md` (full rewrite).
+
+**Interface produced:** the `<!-- pyeye-supported-edges: members callees imported_by subclasses superclasses imports enclosing_scope -->` anchor (the exact 7 edges, space-separated), placed adjacent to the human-readable supported-edges table so the two are edited together.
+
+**Content contract (from spec sections 1–10 — read the spec; key pinned decisions):**
+
+- **Frontmatter:** keep `name: python-explore` unchanged. Broaden `description` to understanding **and** change, with triggers and the do-NOT-trigger exclusions per spec section "Frontmatter". State "Requires the pyeye MCP server."
+- **Model + gates:** orient (`resolve` → `inspect`/`outline`) → drill (`expand`) → trace (`trace`); canonical handles are the currency. Two rigid gates (pyeye-before-blind-Read; don't re-explore in-context). Summary is softened to judgement (spec section 8), NOT a mandatory 4-field block.
+- **Primitives table:** all six, accurate returns. `resolve` returns handle+kind+scope+**location** (answers "where?" without a second call); cover the **ambiguous → `candidates`** path. No source content anywhere — Read is the content layer.
+- **Supported-edges table + anchor:** the 7 live edges with direction + meaning. Anchor matches exactly.
+- **⭐ Honest-limits rule:** `callers`/`references` + the rest of the deferred set are NOT available (#333); pyeye refuses. Do NOT fake them with grep OR the deprecated `find_references`/`get_call_hierarchy`/legacy tools. State what you CAN answer (forward callees, imported_by, sub/superclasses, members, imports, enclosing_scope). Absence-vs-zero note for `edge_counts`.
+- **Workflow flowchart** (dot) + **worked examples**: generic placeholders (`myapp.config.Settings`, `myapp.cache.Cache`) plus one stdlib scope demo (`inspect("pathlib.Path")` → `scope: external`; `expand("pathlib.Path", edge="subclasses")` → project-only). Include: inspect-a-class, ambiguity, `resolve_at` position→handle, outline-a-module, callees, imported_by, subclasses, a `trace` closure, and the **"who calls this → honest refusal"** case.
+- **Failure mode:** pyeye unavailable → note, degrade to Read, warn. **Red flags:** per spec section 10, including "faking callers via grep/legacy tools".
+
+**Constraints:**
+
+- IMPORTANT: do not recommend `lookup`, `find_symbol`, `find_references`, `get_call_hierarchy`, `find_subclasses`, `analyze_dependencies`, `goto_definition`, `get_type_info` as tools to use. The legacy reference tools (`find_references`, `get_call_hierarchy`) appear ONLY inside the honest-limits warning as "don't use these to fake callers".
+- Every edge named as supported must be in `_IMPLEMENTED_EDGES`; every deferred edge mentioned must be framed as NOT available.
+- Markdown must pass the repo's `markdownlint` pre-commit hook (mirror the formatting conventions of the existing skill — fenced code blocks, table syntax, heading levels).
+- `dot` graph: keep it valid Graphviz like the current skill's block.
+
+**Acceptance criteria:**
+
+- `uv run pytest tests/test_python_explore_skill_conformance.py` passes (all five tests).
+- Manual read-through confirms: no legacy tool recommended; honest-limits section present and prominent; examples localised; `resolve` location + ambiguity covered; `resolve_at` demonstrated.
+- Commit Task 1's test together with this rewrite (red+green in one commit), message scoped to the skill rewrite and `#374`.
+
+**Risks:** Over-trimming useful guidance — preserve the genuinely valuable behavioural gates and the failure-mode/red-flags framing from the original. Under-stating the honesty rule — it is the headline; give it visual prominence (its own `##` section, not a bullet).
+
+---
+
+## Task 3 — Slim `.claude/instructions/03-mcp-dogfooding.md`
+
+**Goal:** Remove the duplicated, stale legacy tool catalogue so there's one source of truth (the skill) and the repo dogfoods its own shipped skill. Internal-only file; lower risk but in scope per the issue's "no parallel copy that can drift".
+
+**Files:** `.claude/instructions/03-mcp-dogfooding.md`.
+
+**Content contract (spec "`03-mcp-dogfooding.md` (internal) — slimmed shape"):**
+
+- **Keep:** "we build pyeye — we MUST use it" framing; semantic-over-text principle; the existing redesign "preferred operations" note (resolve/inspect/outline/expand/trace are the surface; legacy tools deprecated, backwards-compat only) — it already points at `docs/api-redesign.md`, which is confirmed present and current; metrics commands (`mcp-report`, `mcp-logs`, etc.) and a high-level "measuring success" note; repo-specific dogfooding context.
+- **Replace:** the entire "Pattern Replacements" legacy catalogue and the legacy "Required Workflow for Python Code Analysis" phases (`find_symbol`/`goto_definition`/`get_call_hierarchy`/`find_references`/…) and the legacy worked examples that call them, with a short pointer block: **"For tool mechanics — which primitive to call, the supported edges, and the honest-limits rule — the `python-explore` skill is the single canonical reference. Don't restate tool usage here."**
+
+**Constraints:**
+
+- Do not delete the dogfooding philosophy or metrics sections — only the duplicated tool mechanics.
+- Keep the file's numbered-instruction-file conventions and heading style; it's loaded via `CLAUDE.md`.
+- Must pass `markdownlint`.
+
+**Acceptance criteria:** `03-mcp-dogfooding.md` no longer presents legacy tools as the workflow; contains the deferral pointer to the skill; framing/metrics retained. Commit scoped to the `03` slim and `#374`.
+
+**Risks:** Accidentally removing the "preferred operations" redesign note (it's the bridge to the new API) — keep it.
+
+---
+
+## Task 4 — Full validation and finalise
+
+**Goal:** Confirm nothing regressed and all gates pass before the work is declared done.
+
+**Files:** none (verification only).
+
+**Steps / acceptance criteria:**
+
+- `uv run pytest` — full suite green, including the new conformance test. (Per repo convention, run the whole suite, not just the new file.)
+- Pre-commit hooks pass on all touched files (markdownlint in particular) — already exercised by the Task 2/3 commits; re-confirm with `uv run pre-commit run --files skills/python-explore/SKILL.md .claude/instructions/03-mcp-dogfooding.md tests/test_python_explore_skill_conformance.py` if any doubt.
+- Frontmatter sanity: `name: python-explore` unchanged, `description` present and non-empty (covered by conformance tests).
+- `git status` clean (all intended files committed; nothing stray) — verify per `feedback_dispatch_git_verify`.
+
+**Risks:** A full-suite run surfaces an unrelated pre-existing failure — if so, confirm it reproduces on the base commit before attributing it to this work; do not mark complete with a genuinely new failure.
+
+---
+
+## Notes for execution
+
+- Work happens in the existing worktree `.claude/worktrees/docs/374-rewrite-python-explore-skill` on branch `docs/374-rewrite-python-explore-skill`. Env already synced (`uv sync --all-extras`).
+- This is a docs-mostly change; the one Python file is the conformance test. The repo's 85%-coverage gate is not the relevant bar here — markdownlint + the conformance test are.
+- PR body should reference `Closes #374` and mention follow-up `#377` (stale `inspect.py` docstrings).

--- a/docs/superpowers/specs/2026-06-15-python-explore-skill-rewrite-design.md
+++ b/docs/superpowers/specs/2026-06-15-python-explore-skill-rewrite-design.md
@@ -63,9 +63,18 @@ tool list and `src/pyeye/mcp/operations/`:
   (their only edges were the deferred reference ones). It does **NOT** measure
   `callers` / `references`. (Note: some `inspect.py` *docstrings* still claim it
   measures `callers`/`references` — those are stale; the implementation is the source of
-  truth. Out of scope to fix here.)
-- **`resolve` success returns** `{found, handle, kind, scope}` — handle + kind +
-  `project`/`external` scope. Location and structure come from `inspect`.
+  truth. Filed as follow-up issue #377; out of scope for this PR.)
+- **`resolve` success returns** `{found, handle, kind, scope, location}` — handle +
+  kind + `project`/`external` scope **and a `location` pointer** (verified against
+  `_SuccessResult`, `src/pyeye/mcp/operations/resolve.py:92`). So resolve already answers
+  "where is this defined?" — you do **not** need a follow-up `inspect` just for location;
+  `inspect` adds signature / docstring / `edge_counts`. (Note: resolve.py's own docstring
+  example omits `location`; the TypedDict is the source of truth.)
+- **`resolve` can return an ambiguous result.** `_AmbiguousResult`
+  (`resolve.py:100`) is `{found: true, ambiguous: true, candidates: [...]}`, each
+  candidate `{handle, kind, scope, location}`. A bare name (`"Config"`) matching several
+  symbols commonly returns this — the agent picks from `candidates` or re-resolves with
+  the full dotted handle.
 - **No source content** in any response — pyeye returns pointers (`file`,
   `line_start`, `line_end`) + structured facts; `Read` is the content layer.
 
@@ -123,8 +132,14 @@ tool list and `src/pyeye/mcp/operations/`:
 
 4. **The primitives (the toolkit).** Table of `resolve` / `resolve_at` / `inspect` /
    `outline` / `expand` / `trace` with one-line purpose, accurate return summary, and the
-   cheap→rich ordering. Emphasise: no source content — `Read` with the returned
-   `file:line` pointers when you need the actual code.
+   cheap→rich ordering. Emphasise: `resolve` returns `handle` + `kind` + `scope` +
+   `location` (so it answers "where?" without a second call); no source content anywhere
+   — `Read` with the returned `file:line` pointers when you need the actual code.
+   - **Resolving ambiguity.** A bare name can match several symbols — `resolve` then
+     returns `{ambiguous: true, candidates: [...]}`. The agent picks the right candidate
+     (each has `handle` / `kind` / `scope` / `location`) or re-resolves with the full
+     dotted handle. This replaces the old skill's "use the full dotted path" advice with
+     the canonical-handle version.
 
 5. **Supported edges.** Table of the seven live `expand`/`trace` edges with
    direction + meaning: `members`, `callees`, `imported_by`, `subclasses`,
@@ -150,6 +165,10 @@ tool list and `src/pyeye/mcp/operations/`:
      → use it) → orient → drill / trace as needed → act.
    - Examples use generic placeholders **plus one stdlib** scope example. Coverage:
      - "What is this class?" → `resolve` → `inspect` (kind, location, `edge_counts`).
+     - **Ambiguity** → `resolve("Settings")` returns `{ambiguous: true, candidates}`;
+       pick the candidate (or re-resolve with the full handle), then continue.
+     - **Position → handle** → `resolve_at(file, line, column)` for "I'm looking at this
+       line / stack-trace frame — what is it?" (the coordinate-first intake path).
      - "What's inside this module?" → `outline`.
      - "What does this function call?" → `expand(edge="callees")`.
      - "Who imports this module?" → `expand(edge="imported_by")`.
@@ -191,13 +210,42 @@ Replace:
   honest-limits rule — the `python-explore` skill is the single canonical reference.
   Don't restate tool usage here."**
 
+## Anti-drift conformance guard
+
+`03` happened because the skill drifted from the edge registry; "the skill is the single
+source of truth" is an organisational defence only. Add a **mechanical** guard so the
+next edge change can't silently re-rot the skill:
+
+- The skill embeds a machine-readable anchor — an HTML comment listing the edges it
+  documents as supported, e.g.
+  `<!-- pyeye-supported-edges: members callees imported_by subclasses superclasses imports enclosing_scope -->`
+  (kept adjacent to the human-readable supported-edges table so they're edited together).
+- A small test (`tests/test_python_explore_skill_conformance.py`) parses that anchor and
+  asserts the documented set **equals** `_IMPLEMENTED_EDGES` from
+  `src/pyeye/mcp/operations/edges.py`, and asserts the skill names **no**
+  `_DEFERRED_REFERENCE_BACKEND_EDGES` member as supported/recommended. If the registry
+  changes, this test fails until the skill is updated — converting drift from a silent
+  rot into a CI failure.
+
+This is the one piece of Python in an otherwise docs-only change; it exists specifically
+to prevent a recurrence of the bug this issue fixes.
+
 ## Out of scope
 
-- Any change to the pyeye Python implementation or the MCP tools themselves.
-- Fixing the stale `callers`/`references` docstrings inside `inspect.py` (noted above;
-  separate concern).
+- Any change to the pyeye Python implementation or the MCP tools themselves (the
+  conformance test above only *reads* the registry; it does not change behaviour).
+- Fixing the stale `callers`/`references` docstrings inside `inspect.py` — **filed as
+  #377**.
 - The `decision-log` skill.
 - Retiring the legacy tools (tracked elsewhere; the skill just stops recommending them).
+
+## Testing posture
+
+This is a docs-mostly change: the repo's "all code changes need tests / 85% coverage"
+gates don't meaningfully apply to the markdown. The relevant gates are **markdownlint**
+(pre-commit) and the **conformance guard** test above. Run the full suite
+(`uv run pytest`) before pushing anyway, per repo convention, to confirm the new test
+passes and nothing else regressed.
 
 ## Acceptance
 
@@ -209,5 +257,8 @@ Replace:
 - `03-mcp-dogfooding.md` defers tool mechanics to the skill (no parallel copy that can
   drift).
 - Skill description/triggers updated; the skill loads and triggers correctly.
+- `resolve` guidance is accurate: success returns `location`; the ambiguous-result path
+  (`candidates`) is covered with an example.
+- `resolve_at` (position → handle) is demonstrated, not just listed.
 - Every supported-edge and deferred-edge claim in the skill matches
-  `src/pyeye/mcp/operations/edges.py`.
+  `src/pyeye/mcp/operations/edges.py` — enforced mechanically by the conformance test.

--- a/docs/superpowers/specs/2026-06-15-python-explore-skill-rewrite-design.md
+++ b/docs/superpowers/specs/2026-06-15-python-explore-skill-rewrite-design.md
@@ -1,0 +1,213 @@
+# Rewrite the `python-explore` skill around the progressive-disclosure API
+
+**Issue:** #374
+**Date:** 2026-06-15
+**Status:** Design
+**Audience of the artifact:** end users of the `pyeye` Claude Code plugin (the skill ships to them)
+
+## Problem
+
+`skills/python-explore/SKILL.md` is a **shipped, user-facing** skill — the `pyeye`
+plugin's marketplace entry (`.claude-plugin/marketplace.json`) has `source: "./"`,
+so Claude Code bundles the repo's top-level `skills/` with the plugin. It is how
+every pyeye user learns to drive the tool, and its guidance is now a **shipped
+correctness bug**:
+
+1. It centres `lookup()` as the "primary entry point" — a superseded transitional
+   surface. It never mentions the live primitives `resolve` / `resolve_at` /
+   `inspect` / `outline` / `expand` / `trace`.
+2. Its toolkit is the **deprecated legacy API** (`find_symbol`, `find_references`,
+   `get_call_hierarchy`, `find_subclasses`, `analyze_dependencies`, `list_*`),
+   presented with no deprecation note.
+3. **Most serious:** it recommends `find_references` / `get_call_hierarchy` to answer
+   "who calls this" / "what references this", framed as *more reliable than grep*.
+   The redesign's central finding (#332/#333) is that Jedi's reverse-reference search
+   under-reports non-deterministically — which is exactly why `callers` / `references`
+   are **deferred** (gated on the Pyright backend, #333) and the new surface *refuses*
+   rather than returning wrong/empty data. The skill inverts the honesty invariant the
+   whole API is built on, and ships that to users.
+4. It is coordinate/`full_name`-centric, not canonical-handle-centric.
+5. Every example uses a foreign `aac.logical.patterns.common.cdis...` path users can't
+   relate to.
+
+The internal counterpart `.claude/instructions/03-mcp-dogfooding.md` (imported by this
+repo's `CLAUDE.md`; governs Claude when working *on* pyeye, never shipped) restates the
+same stale tool mechanics — the duplication is *why* the two drifted.
+
+## Goal
+
+Rebuild the skill as the **canonical user-facing "how to explore Python with pyeye"
+guide**, structured around the API's own model — orient cheap, drill on demand, trace
+across hops — with the **honest-limits rule front and centre**. Slim
+`03-mcp-dogfooding.md` to keep only its internal framing and **defer all tool mechanics
+to the skill**, so there is one source of truth and the repo literally dogfoods its own
+shipped skill.
+
+## Verified ground truth (as of 2026-06-15)
+
+Do not trust prose docs here over the source — these were verified against the live MCP
+tool list and `src/pyeye/mcp/operations/`:
+
+- **Live primitives (on the wire):** `resolve`, `resolve_at`, `inspect`, `outline`,
+  `expand`, `trace`.
+- **Live `expand` / `trace` edges** (`_IMPLEMENTED_EDGES` in
+  `src/pyeye/mcp/operations/edges.py`): `members`, `callees`, `imported_by`,
+  `subclasses`, `superclasses`, `imports`, `enclosing_scope`. The static edge set is
+  **complete**; `not_yet_implemented` is empty.
+- **Deferred until the Pyright reference backend (#333)** —
+  `_DEFERRED_REFERENCE_BACKEND_EDGES`: `callers`, `references`, `read_by`,
+  `written_by`, `passed_by`, `overrides`, `overridden_by`, `decorated_by`, `decorates`.
+- **`inspect.edge_counts` actually measures** (`_build_edge_counts` in
+  `inspect.py`): `class` → `members` + `superclasses` + `subclasses`;
+  `module` → `members`; function / method / attribute / property / variable → **empty**
+  (their only edges were the deferred reference ones). It does **NOT** measure
+  `callers` / `references`. (Note: some `inspect.py` *docstrings* still claim it
+  measures `callers`/`references` — those are stale; the implementation is the source of
+  truth. Out of scope to fix here.)
+- **`resolve` success returns** `{found, handle, kind, scope}` — handle + kind +
+  `project`/`external` scope. Location and structure come from `inspect`.
+- **No source content** in any response — pyeye returns pointers (`file`,
+  `line_start`, `line_end`) + structured facts; `Read` is the content layer.
+
+## Design decisions (settled at brainstorm)
+
+1. **Framing — understand + change.** Broaden from the current modify-only framing to
+   "understand any Python code with pyeye"; pure-comprehension Q&A ("how does X work")
+   is first-class, with change being one outcome.
+2. **Gates.** Keep two rigid behavioural gates — *pyeye before a blind `Read()` on
+   unfamiliar Python*, and *never re-explore what's already in context*. **Soften** the
+   mandatory 4-field summary to a judgement call ("state your mental model when it helps
+   the user"), reducing ceremony on pure-understanding queries.
+3. **Examples.** Generic placeholder handles (`myapp.config.Settings`,
+   `myapp.cache.Cache`) for the main walkthrough (project-scope realism), **plus one
+   stdlib** target (`inspect("pathlib.Path")`) to illustrate the project/external scope
+   distinction.
+4. **`03-mcp-dogfooding.md`.** Full slim + defer: keep internal framing only
+   (we-build-this-so-we-dogfood-it, semantic-over-text, the redesign "preferred
+   operations" note, metrics commands, a high-level "measuring success" note); delete
+   the duplicated legacy pattern-replacement catalogue and legacy workflow phases;
+   point to `python-explore` as the single canonical tool-mechanics reference.
+
+## Skill structure (rewritten `skills/python-explore/SKILL.md`)
+
+### Frontmatter
+
+`description` broadened to understanding + change:
+
+- **Triggers on:** "how does X work", "what does", "why is X doing", "trace", "add
+  feature", "implement", "refactor", "debug", "extend", **and** relationship questions
+  ("what does this call", "what imports this", "what subclasses this").
+- **Does NOT trigger for:** explicit "show me / print / read this file", "what's the
+  syntax for" (language question), single-line typo/string fix with exact location
+  given, adding a new test case only, or when pyeye output for the symbol is already in
+  conversation context.
+- States "Requires the pyeye MCP server."
+
+### Body sections
+
+1. **One-liner + the model.** *Build a structural model with pyeye before reading or
+   changing Python — orient cheap, drill on demand.* Progressive disclosure as the
+   spine: **orient** (`resolve` → `inspect` / `outline`) → **drill** (`expand`) →
+   **trace across hops** (`trace`). **Canonical handles** (`a.b.c.Name`, definition-site,
+   stable across edits, dedup across import aliases) are the currency — everything
+   downstream takes a handle.
+
+2. **Skill type — mixed rigid/flexible.**
+   - Rigid gates: (1) first move on unfamiliar Python is pyeye, not a blind `Read()`;
+     (2) never re-explore what's already in context.
+   - Flexible: depth scaling, which calls to make, and stating your mental model when it
+     aids the user (softened from the old mandatory summary).
+
+3. **Do NOT trigger when** — the exclusion list from the frontmatter, restated for the
+   agent with the "already in context → skip to using it" shortcut.
+
+4. **The primitives (the toolkit).** Table of `resolve` / `resolve_at` / `inspect` /
+   `outline` / `expand` / `trace` with one-line purpose, accurate return summary, and the
+   cheap→rich ordering. Emphasise: no source content — `Read` with the returned
+   `file:line` pointers when you need the actual code.
+
+5. **Supported edges.** Table of the seven live `expand`/`trace` edges with
+   direction + meaning: `members`, `callees`, `imported_by`, `subclasses`,
+   `superclasses`, `imports`, `enclosing_scope`.
+
+6. **⭐ The honest-limits rule (the #1 fix).** Prominent section:
+   - `callers` / `references` (and `read_by` / `written_by` / `passed_by` / `overrides`
+     / `overridden_by` / `decorated_by` / `decorates`) are **NOT available** — deferred
+     to the Pyright reference backend (#333). pyeye **refuses** rather than returning
+     wrong/empty data.
+   - **Do NOT fake "who calls this" / "what references this"** with `grep` **or** the
+     deprecated legacy tools (`find_references`, `get_call_hierarchy`). They
+     under-report non-deterministically — the exact failure the new API exists to avoid.
+     Say *"reverse-reference data isn't reliably available yet"* and offer what you can
+     answer instead.
+   - **What you CAN answer reliably:** forward `callees`, `imported_by`,
+     `subclasses` / `superclasses`, `members`, `imports`, `enclosing_scope`.
+   - **Absence vs zero:** a missing `edge_counts` key means *not measured*, not zero —
+     don't read absence as "none."
+
+7. **Workflow flowchart + worked examples.**
+   - Updated `dot` flowchart: trigger → (explicit read? → `Read`) → (already in context?
+     → use it) → orient → drill / trace as needed → act.
+   - Examples use generic placeholders **plus one stdlib** scope example. Coverage:
+     - "What is this class?" → `resolve` → `inspect` (kind, location, `edge_counts`).
+     - "What's inside this module?" → `outline`.
+     - "What does this function call?" → `expand(edge="callees")`.
+     - "Who imports this module?" → `expand(edge="imported_by")`.
+     - "What subclasses this base?" → `expand(edge="subclasses")`.
+     - A multi-hop closure → `trace(follow=[...])`.
+     - **"Who calls this function?" → the honest refusal** (state the limitation, do NOT
+       grep or use legacy tools, offer `callees`/forward alternatives).
+     - **Scope demo** → `inspect("pathlib.Path")` returns `scope: "external"`;
+       `expand("pathlib.Path", edge="subclasses")` returns project-internal classes only.
+
+8. **Mental model (softened summary).** When it aids the user, state the symbol's
+   location, dependencies, and likely impact using **canonical handles + `file:line`**
+   (stable references, per `feedback_stable_references`). Not mandatory ceremony; scale
+   to the task.
+
+9. **Failure mode.** pyeye unavailable → note it explicitly, degrade to `Read()`, warn
+   that static analysis is off. Don't block.
+
+10. **Red flags.** First call is `Read()` on unexplored Python; grep to find a
+    definition **or** a relationship; reaching for deprecated `find_*` / `get_*` tools;
+    **faking `callers` via grep/legacy tools**; re-exploring what's already in context.
+
+## `03-mcp-dogfooding.md` (internal) — slimmed shape
+
+Keep:
+
+- "We build pyeye — we MUST use it" framing and the semantic-over-text principle.
+- The redesign "preferred operations" note (resolve/inspect/outline/expand/trace are the
+  surface; legacy tools deprecated, backwards-compat only).
+- Metrics commands (`mcp-report`, `mcp-logs`, etc.) and a high-level "measuring success"
+  note.
+- Repo-specific dogfooding context (we develop *in* this codebase).
+
+Replace:
+
+- The entire "Pattern Replacements" legacy catalogue and the legacy "Required Workflow"
+  phases (`find_symbol`, `goto_definition`, `get_call_hierarchy`, …) with a short
+  pointer: **"For tool mechanics — which primitive to call, the supported edges, and the
+  honest-limits rule — the `python-explore` skill is the single canonical reference.
+  Don't restate tool usage here."**
+
+## Out of scope
+
+- Any change to the pyeye Python implementation or the MCP tools themselves.
+- Fixing the stale `callers`/`references` docstrings inside `inspect.py` (noted above;
+  separate concern).
+- The `decision-log` skill.
+- Retiring the legacy tools (tracked elsewhere; the skill just stops recommending them).
+
+## Acceptance
+
+- Skill rewritten around `resolve` / `resolve_at` / `inspect` / `outline` / `expand` /
+  `trace`; no recommendation of deprecated tools or the unreliable reverse-reference
+  search; explicit "callers/references unavailable (#333) — don't fake them" guidance;
+  canonical-handle-centric; examples localised (generic placeholders + one stdlib scope
+  demo).
+- `03-mcp-dogfooding.md` defers tool mechanics to the skill (no parallel copy that can
+  drift).
+- Skill description/triggers updated; the skill loads and triggers correctly.
+- Every supported-edge and deferred-edge claim in the skill matches
+  `src/pyeye/mcp/operations/edges.py`.

--- a/docs/superpowers/specs/2026-06-15-python-explore-skill-rewrite-design.md
+++ b/docs/superpowers/specs/2026-06-15-python-explore-skill-rewrite-design.md
@@ -202,13 +202,22 @@ Keep:
   note.
 - Repo-specific dogfooding context (we develop *in* this codebase).
 
-Replace:
-
-- The entire "Pattern Replacements" legacy catalogue and the legacy "Required Workflow"
-  phases (`find_symbol`, `goto_definition`, `get_call_hierarchy`, …) with a short
-  pointer: **"For tool mechanics — which primitive to call, the supported edges, and the
-  honest-limits rule — the `python-explore` skill is the single canonical reference.
-  Don't restate tool usage here."**
+Replace / remove — **all** sections that recommend legacy tools or the reverse-reference
+search, not just the obvious catalogue. The rot is spread across at least six sections
+(verified against `main`): "Required Workflow for Python Code Analysis", "Pattern
+Replacements (MANDATORY)", "Real-World Usage Examples", "Troubleshooting Common
+Scenarios", "Measuring Success", and "Performance Tips". The Troubleshooting metric
+(*"Always start with `find_references` — NEVER skip this"*) and the Measuring-Success
+metrics (*"100% of refactoring should use `find_references` first"*, *"All inheritance
+checks should use `find_subclasses`"*) are the **same honesty bug as #374, sitting
+internally** — they steer the agent to the exact unreliable reverse-reference search the
+redesign rejects, so they must go too. Replace the removed mechanics with a short
+pointer: **"For tool mechanics — which primitive to call, the supported edges, and the
+honest-limits rule — the `python-explore` skill is the single canonical reference. Don't
+restate tool usage here."** After the sweep, no legacy tool (`find_references`,
+`find_subclasses`, `get_call_hierarchy`, `find_symbol`, `goto_definition`,
+`get_type_info`, `lookup`) should remain as a *recommendation* — a bare mention inside a
+"these are deprecated, use the skill" note is the only acceptable residue.
 
 ## Anti-drift conformance guard
 
@@ -226,6 +235,13 @@ next edge change can't silently re-rot the skill:
   `_DEFERRED_REFERENCE_BACKEND_EDGES` member as supported/recommended. If the registry
   changes, this test fails until the skill is updated — converting drift from a silent
   rot into a CI failure.
+- The test also adds a **prose negative assertion**: the pure-legacy tools `lookup`,
+  `find_symbol`, `goto_definition`, `get_type_info` must appear **nowhere** in the skill
+  (they have no legitimate place in the rewrite). `find_references` /
+  `get_call_hierarchy` are deliberately excluded from this ban — they legitimately appear
+  inside the honest-limits "do NOT use these to fake callers" warning, so a blanket ban
+  would false-positive. This catches a future "use `find_symbol`" sentence the edge
+  anchor alone would miss; manual review remains the backstop for contextual cases.
 
 This is the one piece of Python in an otherwise docs-only change; it exists specifically
 to prevent a recurrence of the bug this issue fixes.

--- a/skills/python-explore/SKILL.md
+++ b/skills/python-explore/SKILL.md
@@ -1,81 +1,133 @@
 ---
 name: python-explore
-description: Use when understanding, modifying, refactoring, debugging, extending, or implementing Python code. Triggers on "how does", "what does", "why is X doing", "add feature", "implement", "update behaviour". Does NOT trigger for explicit "show me"/"read this file" requests, single-line typo fixes with exact location, or adding new test cases only. Requires pyeye MCP server.
+description: Use when understanding, navigating, debugging, refactoring, or extending Python code with the pyeye MCP server. Triggers on "how does X work", "what does", "why is X doing", "what calls/imports/subclasses this", "add feature", "implement", "refactor", "trace", "debug", "extend". Does NOT trigger for explicit "show me"/"read this file"/"print"/"display" requests, "what's the syntax for" language questions, single-line typo/string fixes with an exact location given, adding a new test case only, or when pyeye output for the symbol is already in context. Requires the pyeye MCP server.
 ---
 
 # Python Explore
 
-Build a mental model with pyeye before touching Python code.
+Build a structural model of Python code with pyeye before reading or changing it —
+**orient cheap, drill on demand.**
+
+## The Model: Progressive Disclosure
+
+pyeye answers questions in three widening steps. Start at the cheapest that answers
+your question; only go wider when you need to.
+
+1. **Orient (cheap):** `resolve` a name to a canonical handle, then `inspect` it for
+   structure, or `outline` a module/class for its skeleton.
+2. **Drill (on demand):** `expand` one edge from a handle to see its immediate
+   neighbours (members, callees, importers, subclasses…).
+3. **Trace (across hops):** `trace` follows edges multiple hops to see structure
+   across a call chain, import closure, or member tree.
+
+**Canonical handles are the currency.** A handle is Python's own dotted notation —
+`a.b.c.Name` — anchored at the *definition site*, stable across edits, and the same
+no matter which import alias you arrived through. Everything downstream takes a handle.
+pyeye returns **pointers and structured facts, never source** — when you need the actual
+code, `Read` the `file:line` it points you at.
 
 ## Skill Type: Mixed Rigid/Flexible
 
 **Rigid gates (non-negotiable):**
 
-- Always produce a written summary before proceeding
-- Always use pyeye before Read() on unfamiliar code
-- Never re-explore what's already in context
+- Your first move on unfamiliar Python is pyeye, not a blind `Read()`.
+- Never re-explore what pyeye already surfaced in this conversation.
 
-**Flexible path (use judgement):**
+**Flexible (use judgement):**
 
-- Depth scaling based on task scope
-- Which specific pyeye calls to make
-- When the mental model is "sufficient"
+- How deep to go (a single `inspect`, or a multi-hop `trace`).
+- Which primitives and edges to call.
+- Whether to write out a mental-model summary — do it when it helps the user, not as
+  ceremony (see [Stating Your Mental Model](#stating-your-mental-model)).
 
 ## Do NOT Trigger When
 
-- User says "show me", "print", "display", "read this file" — respect explicit requests
-- User says "run", "execute" — not exploration
-- User asks "what's the syntax for" — language question, not codebase question
-- Single-line typo/string fix where user gives exact location
-- Adding a new test case (not modifying test infrastructure)
-- Pyeye output for this module is already visible in conversation context
+- User says "show me", "print", "display", "read this file" — respect explicit requests,
+  use `Read()`.
+- User says "run", "execute" — that is not exploration.
+- User asks "what's the syntax for" — a language question, not a codebase question.
+- Single-line typo/string fix where the user gives the exact location.
+- Adding a new test case only (not modifying the code under test).
+- pyeye output for this symbol is already visible in conversation context — skip straight
+  to using it.
 
-If pyeye output is already in context, skip to summary and proceed.
+## The Primitives
 
-## Depth Scaling
+| Primitive | Use it to | Returns |
+|-----------|-----------|---------|
+| `resolve(identifier)` | Turn a name, dotted path, or `file:line` into a canonical handle | `{handle, kind, scope, location}` — or `{ambiguous, candidates}` |
+| `resolve_at(file, line, column)` | Turn a position (stack frame, pasted line) into a handle | same shape as `resolve` |
+| `inspect(handle)` | Answer "what is this?" — kind, signature, docstring, `edge_counts` | a structural Node (no source) |
+| `outline(handle)` | See the structural skeleton of a module or class in one call | a tree of member stubs |
+| `expand(handle, edge)` | Walk ONE edge to the immediate neighbours | a list of stubs |
+| `trace(start, follow, …)` | Walk edges across multiple hops | a subgraph (nodes + edges) |
 
-| Task Scope | Pyeye Calls |
-|------------|-------------|
-| Single class/function change | `lookup()` (primary entry point) — for advanced use: `find_references()` with field filtering |
-| Cross-module change | `lookup()` + `analyze_dependencies()` |
-| "I don't know where to start" | Full: `list_project_structure()` → `list_modules()` → drill down |
+Notes that matter:
 
-Never run `list_project_structure()` for a scoped single-symbol task.
+- `resolve` already includes a `location` pointer, so it answers "where is this defined?"
+  on its own — you do **not** need a follow-up `inspect` just for location. Use `inspect`
+  when you want signature/docstring/`edge_counts`.
+- **Ambiguity:** a bare name can match several symbols. `resolve` then returns
+  `{found: true, ambiguous: true, candidates: [...]}`, each candidate carrying
+  `handle`/`kind`/`scope`/`location`. Pick the right one, or re-resolve with the full
+  dotted handle.
+- **`scope`** is `"project"` or `"external"`. Project symbols get full-graph answers;
+  external symbols (stdlib, site-packages) get project-scoped answers — see the scope
+  example below.
+- **No source content, ever.** `inspect`/`outline`/`expand`/`trace` return pointers and
+  structured facts. `Read` is the content layer.
 
-## Relationship Queries Require Pyeye, Not Grep
+## Supported Edges
 
-**These patterns start with `lookup()`. Use `find_references` for the complete reference list with field filtering, or `get_call_hierarchy` for full call graphs. NEVER Grep:**
+`expand` and `trace` walk these edges. This is the **complete** set pyeye can answer
+reliably today:
 
-- "Find classes that consume/use X"
-- "Which code references this symbol"
-- "Find classes where field contains/equals X"
-- "Who calls this function"
-- "What depends on this"
+<!-- pyeye-supported-edges: members callees imported_by subclasses superclasses imports enclosing_scope -->
 
-**Why:** Grep does text matching and misses semantic relationships (inheritance, imports, indirect references). Pyeye follows the actual reference graph.
+| Edge | Direction | Meaning |
+|------|-----------|---------|
+| `members` | container → children | a class's methods/attributes, or a module's top-level defs |
+| `enclosing_scope` | child → parent | the one lexical scope containing this symbol (method → class, etc.) |
+| `callees` | function → what it calls | forward call targets resolved from the body |
+| `subclasses` | class → its subclasses | project classes that extend this class |
+| `superclasses` | class → its bases | the class's direct base classes |
+| `imports` | module → what it imports | the module's top-level imports |
+| `imported_by` | module → its importers | project modules that import this module |
 
-### Example: "Find classes that consume api_mesh"
+## ⭐ Honest Limits — Reverse References Are NOT Available
 
-`pyeye.lookup(identifier="api_mesh")` → returns symbol info including references in one call
+This is the most important rule in this skill.
 
-If the short name is ambiguous (multiple matches), use the full dotted path from `full_name`:
-`pyeye.lookup(identifier="aac.logical.patterns.common.cdis.components.api_mesh")`
+**"Who calls this?" and "what references this?" cannot be answered reliably yet.** The
+edges `callers`, `references`, `read_by`, `written_by`, `passed_by`, `overrides`,
+`overridden_by`, `decorated_by`, and `decorates` are **deferred** — they need an indexed
+reference backend (Pyright) that isn't wired up yet ([#333](https://github.com/okeefeco/pyeye-mcp/issues/333)).
+When you ask for one, pyeye **refuses** (reports it as unsupported) rather than returning
+a wrong or empty answer. Likewise, `inspect`'s `edge_counts` simply **omits** `callers`
+and `references` — it does not report them as `0`.
 
-For the complete unfiltered reference list (e.g., with field filtering), use the targeted tool:
-`pyeye.find_references(symbol_name="aac.logical.patterns.common.cdis.components.api_mesh")`
+**Do NOT fake reverse-reference data.** Specifically:
 
-You can also use coordinates directly if you already have them:
-`pyeye.find_references(file=<path>, line=<line>, column=<column>)`
+- Do **not** fall back to `grep` to guess who calls or references a symbol.
+- Do **not** use the deprecated legacy tools `find_references` or `get_call_hierarchy`
+  to fill the gap. They are backed by exactly the reverse search the redesign rejected:
+  it under-reports non-deterministically — anchored at a definition it can return a
+  near-empty set for a heavily-used symbol. A confident wrong answer is worse than an
+  honest "not available."
 
-## Exit Criteria
+Instead, **say so plainly**: "pyeye can't give reliable caller/reference data yet
+(deferred to #333)." Then offer what you *can* answer:
 
-Mental model is sufficient when you can answer:
+- **Forward** from a function: `callees` (what it calls).
+- **Around a module:** `imported_by` (who imports it) and `imports` (what it imports).
+- **Inheritance:** `subclasses` / `superclasses`.
+- **Structure:** `members`, `enclosing_scope`.
 
-- What is this thing?
-- What does it depend on?
-- What would break if I change it?
+### Absence vs zero
 
-This is a judgement call, not a checklist. Explain at least one decision with "because" or "so that".
+When you read `edge_counts`, a **missing key means "not measured," not "zero."** A
+present `subclasses: 0` means measured-and-none (genuinely unextended). An *absent*
+`callers` key means pyeye didn't measure it — don't read that as "no callers."
 
 ## Workflow
 
@@ -86,84 +138,142 @@ digraph python_explore {
     "Task involves Python code" [shape=diamond];
     "Explicit read/show request?" [shape=diamond];
     "Already explored in context?" [shape=diamond];
-    "Scope clear?" [shape=diamond];
+    "Reverse-reference question?" [shape=diamond];
 
     "Respect request, use Read()" [shape=box];
-    "Skip to summary" [shape=box];
-    "Run scoped pyeye calls" [shape=box];
-    "Run broad pyeye discovery" [shape=box];
-    "Write brief summary" [shape=box];
+    "Use what's in context" [shape=box];
+    "State the limit honestly, offer forward edges" [shape=box];
+    "Orient: resolve then inspect / outline" [shape=box];
+    "Drill / trace as needed" [shape=box];
     "Proceed with task" [shape=box];
 
     "Task involves Python code" -> "Explicit read/show request?" [label="yes"];
     "Task involves Python code" -> "Proceed with task" [label="no"];
     "Explicit read/show request?" -> "Respect request, use Read()" [label="yes"];
     "Explicit read/show request?" -> "Already explored in context?" [label="no"];
-    "Already explored in context?" -> "Skip to summary" [label="yes"];
-    "Already explored in context?" -> "Scope clear?" [label="no"];
-    "Scope clear?" -> "Run scoped pyeye calls" [label="yes"];
-    "Scope clear?" -> "Run broad pyeye discovery" [label="no"];
-    "Run scoped pyeye calls" -> "Write brief summary";
-    "Run broad pyeye discovery" -> "Write brief summary";
-    "Skip to summary" -> "Write brief summary";
-    "Write brief summary" -> "Proceed with task";
+    "Already explored in context?" -> "Use what's in context" [label="yes"];
+    "Already explored in context?" -> "Reverse-reference question?" [label="no"];
+    "Reverse-reference question?" -> "State the limit honestly, offer forward edges" [label="yes"];
+    "Reverse-reference question?" -> "Orient: resolve then inspect / outline" [label="no"];
+    "Orient: resolve then inspect / outline" -> "Drill / trace as needed";
+    "Drill / trace as needed" -> "Proceed with task";
+    "Use what's in context" -> "Proceed with task";
+    "State the limit honestly, offer forward edges" -> "Proceed with task";
 }
 ```
 
-## Summary Format
+## Worked Examples
 
-**MANDATORY:** Always output before proceeding. All four fields are NON-NEGOTIABLE:
+Handles below use a placeholder project (`myapp.…`) — substitute your own. The
+`pathlib` example is real and works anywhere.
 
-```markdown
-**Mental Model: [symbol/module name]**
-- Location: `path/to/file.py:line`
-- Dependencies: [key imports/bases]
-- Impact: [what uses this / what would break]
-- Done when: All callers identified and impact understood; changes can proceed safely
+**"What is `Settings`?"** — orient in one or two calls:
+
+```text
+resolve("myapp.config.Settings")   -> { handle: "myapp.config.Settings", kind: "class",
+                                        scope: "project", location: {...} }
+inspect("myapp.config.Settings")   -> kind, signature, docstring,
+                                        edge_counts: { members: 7, superclasses: 1, subclasses: 0 }
 ```
 
-**CRITICAL: Every class referenced in the summary MUST include:**
+**Ambiguous name** — let `resolve` disambiguate, don't guess:
 
-- **Full dotted path:** e.g., `aac.logical.patterns.common.cdis.components.api_mesh`
-- **File path with line number:** e.g., `aac/logical/patterns/common/cdis/components.py:13`
+```text
+resolve("Settings")  -> { ambiguous: true, candidates: [
+                            { handle: "myapp.config.Settings", ... },
+                            { handle: "myapp.cli.Settings", ... } ] }
+```
 
-The `full_name` field in pyeye results is the full dotted path — use it as-is in summaries. You can also pass it directly as `identifier` to `lookup` (or as `symbol_name` to `find_references`) for unambiguous resolution without needing coordinates.
+Pick the candidate you meant, or re-resolve with the full dotted handle.
 
-Never reference a class with only a name, only a line number, or only a module path. Both full dotted path and file:line are required for every class to make the summary actionable.
+**"I'm looking at this line / stack frame — what is it?"** — position to handle:
 
-This creates an audit trail the user can correct if wrong.
+```text
+resolve_at("myapp/cache.py", line=42, column=8)  -> { handle: "myapp.cache.Cache.evict", ... }
+```
 
-## Pyeye Tool Reference
+**"What's inside this module?"** — skeleton in one call:
 
-| Purpose | Tool |
-|---------|------|
-| Look up any identifier (name, dotted path, file path, or coordinates) | `pyeye.lookup(identifier="X")` — **primary entry point** |
-| Fuzzy symbol search | `pyeye.find_symbol(name="X")` — targeted: when you need fuzzy matching |
-| Full reference lists with field filtering | `pyeye.find_references(symbol_name="X")` or `pyeye.find_references(file="...", line=X, column=Y)` — targeted |
-| Complete call graphs | `pyeye.get_call_hierarchy(function_name="X")` — targeted |
-| Inheritance hierarchies | `pyeye.find_subclasses(base_class="X")` — targeted: use `show_hierarchy=True` for trees |
-| Circular dependency detection | `pyeye.analyze_dependencies(module_path="...")` — targeted |
-| Project layout | `pyeye.list_project_structure(max_depth=3)` — discovery |
-| All modules | `pyeye.list_modules()` — discovery |
-| All packages | `pyeye.list_packages()` — discovery |
+```text
+outline("myapp.cache")  -> tree of (Cache, DependencyTracker, ...) with their methods
+```
+
+**"What does this function call?"** — forward, reliable:
+
+```text
+expand("myapp.cache.Cache.evict", edge="callees")  -> stubs for each call target
+```
+
+**"Who imports this module?"** — reverse, but reliably static:
+
+```text
+expand("myapp.cache", edge="imported_by")  -> module stubs that import myapp.cache
+```
+
+**"What subclasses this base?"** — inheritance down:
+
+```text
+expand("myapp.plugins.Base", edge="subclasses")  -> project classes extending Base
+```
+
+**Multi-hop closure** — structure across hops:
+
+```text
+trace(start="myapp.cache.Cache.evict", follow=["callees"], max_depth=3)
+  -> subgraph of the 3-hop forward call structure
+```
+
+**Project vs external scope** — `pathlib.Path` is external, so subclasses come back
+project-scoped:
+
+```text
+inspect("pathlib.Path")                      -> scope: "external", members/signature derived on demand
+expand("pathlib.Path", edge="subclasses")    -> only classes in THIS project that extend Path
+```
+
+**"Who calls `Cache.evict`?"** — the honest refusal:
+
+> Reliable caller data isn't available yet — `callers` is deferred to the Pyright
+> backend (#333), and faking it with grep or the legacy reference tools would
+> under-report. What I *can* show: what `Cache.evict` itself calls (`callees`), and which
+> modules import `myapp.cache` (`imported_by`). Want either of those?
+
+## Stating Your Mental Model
+
+When it helps the user — a non-trivial change, an ambiguous request, a risky edit —
+state what you found before proceeding. Use **canonical handles + `file:line`** so the
+user can correct you:
+
+```markdown
+**Mental model: `myapp.cache.Cache`** (`myapp/cache.py:31`)
+- Depends on: `myapp.config.Settings`, `collections.OrderedDict`
+- I can see: 7 members, 1 superclass, 0 subclasses (measured)
+- I cannot see: callers/references (deferred, #333) — change impact on callers is unverified
+```
+
+Scale this to the task. A pure "how does X work?" answer may need no separate summary;
+a refactor that touches shared code deserves one — and should be explicit that
+caller impact can't be statically confirmed.
 
 ## Failure Mode
 
 If pyeye is unavailable (server down, tools not responding):
 
-1. Note explicitly: "pyeye unavailable — falling back to Read()"
-2. Proceed with Read()
-3. Warn that static analysis is unavailable
+1. Note it explicitly: "pyeye unavailable — falling back to `Read()`."
+2. Proceed with `Read()`.
+3. Warn that static structural analysis is unavailable.
 
-Do not block — degrade gracefully but make the limitation visible.
+Don't block — degrade gracefully, but make the limitation visible.
 
 ## Red Flags — You're About to Violate This Skill
 
-- First tool call is Read() on a Python file you haven't explored
-- Reaching for Grep to find a class/function definition
-- Reaching for Grep to find relationships (see "Relationship Queries" section above)
-- Calling `find_symbol` or `get_module_info` when `lookup` would do
-- "Let me just quickly read this file" without pyeye context
-- Modifying code without knowing what depends on it
+- Your first tool call is `Read()` on a Python file you haven't oriented in pyeye.
+- Reaching for `grep` to find a definition.
+- Reaching for `grep` to answer a relationship/reference question.
+- Reaching for deprecated `find_*` / `get_*` legacy tools.
+- **Faking "who calls this" with grep or the legacy reference tools** instead of stating
+  the limit honestly.
+- Re-exploring a symbol pyeye already surfaced in this conversation.
 
-**If you catch yourself doing any of these: STOP. Run pyeye first.**
+**If you catch yourself doing any of these: STOP. Orient with pyeye, or say honestly
+what it can't answer.**

--- a/skills/python-explore/SKILL.md
+++ b/skills/python-explore/SKILL.md
@@ -57,7 +57,7 @@ code, `Read` the `file:line` it points you at.
 |-----------|-----------|---------|
 | `resolve(identifier)` | Turn a name, dotted path, or `file:line` into a canonical handle | `{handle, kind, scope, location}` — or `{ambiguous, candidates}` |
 | `resolve_at(file, line, column)` | Turn a position (stack frame, pasted line) into a handle | same shape as `resolve` |
-| `inspect(handle)` | Answer "what is this?" — kind, signature, docstring, `edge_counts` | a structural Node (no source) |
+| `inspect(handle)` | Answer "what is this?" — kind, signature, docstring, `edge_counts` | a structural Node, plus kind-dependent fields (e.g. `superclasses`, `re_exports`); no source |
 | `outline(handle)` | See the structural skeleton of a module or class in one call | a tree of member stubs |
 | `expand(handle, edge)` | Walk ONE edge to the immediate neighbours | a list of stubs |
 | `trace(start, follow, …)` | Walk edges across multiple hops | a subgraph (nodes + edges) |

--- a/tests/test_python_explore_skill_conformance.py
+++ b/tests/test_python_explore_skill_conformance.py
@@ -1,0 +1,75 @@
+"""Anti-drift conformance guard for the shipped ``python-explore`` skill.
+
+This test binds the user-facing skill (``skills/python-explore/SKILL.md``) to the
+edge registry that is the genuine source of truth
+(``pyeye.mcp.operations.edges``).  Issue #374 happened because the skill drifted
+from that registry; "the skill is the single source of truth" is an organisational
+defence only.  This test converts that drift from a silent rot into a CI failure:
+if the implemented edge set changes, the skill's documented anchor must change too,
+or this test fails.
+
+Dependency-free by design: stdlib ``re`` + ``pathlib`` only (no yaml).
+"""
+
+import re
+from pathlib import Path
+
+from pyeye.mcp.operations.edges import (
+    _DEFERRED_REFERENCE_BACKEND_EDGES,
+    _IMPLEMENTED_EDGES,
+)
+
+SKILL = Path(__file__).resolve().parent.parent / "skills" / "python-explore" / "SKILL.md"
+_ANCHOR = re.compile(r"<!--\s*pyeye-supported-edges:\s*(.*?)\s*-->")
+
+
+def _skill_text() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def _documented_edges() -> set[str]:
+    m = _ANCHOR.search(_skill_text())
+    assert m is not None, (
+        "SKILL.md must embed a `<!-- pyeye-supported-edges: ... -->` anchor "
+        "listing the supported expand/trace edges"
+    )
+    return set(m.group(1).split())
+
+
+def test_skill_file_exists() -> None:
+    assert SKILL.is_file(), f"skill not found at {SKILL.as_posix()}"
+
+
+def test_documented_edges_equal_implemented_registry() -> None:
+    # Drift guard: the skill's supported-edge list must track edges.py exactly.
+    assert _documented_edges() == set(_IMPLEMENTED_EDGES)
+
+
+def test_no_deferred_edge_listed_as_supported() -> None:
+    # The #1 bug class: never present a reference-backend edge as available.
+    assert _documented_edges().isdisjoint(_DEFERRED_REFERENCE_BACKEND_EDGES)
+
+
+def test_skill_name_is_stable() -> None:
+    # The plugin resolves the skill by this name; a rename would unship it.
+    assert re.search(r"^name:\s*python-explore\s*$", _skill_text(), re.MULTILINE)
+
+
+def test_skill_declares_a_description() -> None:
+    assert re.search(r"^description:\s*\S", _skill_text(), re.MULTILINE)
+
+
+# Pure-legacy tools with NO legitimate reason to appear anywhere in the rewritten
+# skill. NOTE: find_references / get_call_hierarchy are deliberately NOT in this set —
+# they legitimately appear inside the honest-limits "do NOT use these to fake callers"
+# warning, so they cannot be blanket-banned. These four have no such excuse.
+_PURE_LEGACY_TOOLS = ("lookup", "find_symbol", "goto_definition", "get_type_info")
+
+
+def test_pure_legacy_tools_absent() -> None:
+    # Mechanical backstop for prose drift: catches a future "use find_symbol" sentence
+    # that the edge anchor alone would miss. Manual review remains the backstop for the
+    # contextual cases (find_references in the honest-limits warning).
+    text = _skill_text()
+    present = [t for t in _PURE_LEGACY_TOOLS if t in text]
+    assert not present, f"pure-legacy tools must not appear in the skill: {present}"


### PR DESCRIPTION
## Summary

Rewrites the **shipped, user-facing** `python-explore` skill around pyeye's
progressive-disclosure API and fixes the correctness/honesty bug it was shipping.

- **Skill rewritten** around `resolve` / `resolve_at` / `inspect` / `outline` /
  `expand` / `trace` (the live primitives), replacing the rotted `lookup`/legacy-tool
  guidance. Canonical-handle-centric; `resolve`'s `location` + ambiguous-`candidates`
  paths covered; `resolve_at` demonstrated; examples localised to generic placeholders
  plus one stdlib scope demo (`pathlib.Path`).
- **⭐ Honest-limits rule front and centre:** `callers`/`references` (and the rest of
  the reverse-reference family) are deferred to the Pyright backend (#333) — pyeye
  refuses rather than guessing. The skill explicitly tells users **not** to fake them
  with `grep` or the deprecated `find_references`/`get_call_hierarchy` tools. This is
  the #1 thing the old skill got wrong (it recommended exactly that unreliable search).
- **`03-mcp-dogfooding.md` slimmed** to defer all tool mechanics to the skill (one
  source of truth). All six legacy-recommending sections swept — including the internal
  Troubleshooting/Measuring-Success steps that were the same honesty bug sitting
  internally.
- **Anti-drift conformance test** (`tests/test_python_explore_skill_conformance.py`):
  pins the skill's machine-readable supported-edge anchor to `_IMPLEMENTED_EDGES`,
  forbids deferred edges from being listed as supported, and bans pure-legacy tool
  names from the skill. Converts future drift from silent rot into a CI failure.

Design of record: `docs/superpowers/specs/2026-06-15-python-explore-skill-rewrite-design.md`.
Plan: `docs/superpowers/plans/2026-06-15-python-explore-skill-rewrite.md`.

Note: the stale `inspect.py` `callers`/`references` docstrings surfaced during this work
were filed as #377 and have since been fixed independently (PR #378, now on `main`) —
not part of this PR's diff.

## Test Plan

- [x] `uv run pytest tests/test_python_explore_skill_conformance.py` — 6/6 pass
- [x] `uv run pytest` — 2063 passed, coverage 86.75% (the only failures are two
      load-sensitive perf benchmarks that pass in isolation; unrelated to this docs change)
- [x] `markdownlint` clean on `SKILL.md` and `03-mcp-dogfooding.md`
- [x] Verified mechanically: no pure-legacy tool names in the skill; `find_references`/
      `get_call_hierarchy` appear only inside the honest-limits "don't use these" warning;
      `callers`/`references` only ever framed as unavailable

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)