### PR TITLE
fix(tests): use platform-aware perf thresholds and exclude warmup from baselines (#383)

### DIFF
--- a/tests/performance/benchmarks/test_performance_regression.py
+++ b/tests/performance/benchmarks/test_performance_regression.py
@@ -64,23 +64,29 @@ class TestPerformanceBaselines:
         async def search():
             return await analyzer.find_symbol("TestClass")
 
-        # Warm up
-        await search()
+        # Warm up the analyzer's caches WITHOUT recording the call. The first call is
+        # cold (jedi import + initial parse) and on slow CI runners takes 400-500ms;
+        # counting it would dominate p95 over only ~10 samples and deterministically
+        # fail macOS CI (#383). Warm up via the analyzer directly so the collector
+        # only records steady-state, warm runs.
+        await analyzer.find_symbol("TestClass")
 
-        # Measure multiple runs
+        # Measure multiple warm runs
         for _ in range(10):
             await search()
 
         stats = collector.get_stats("symbol_search")
 
-        # Performance requirements
-        # Note: Threshold increased from 100ms to 200ms after adding AST fallback
-        # for inheritance detection (fix #234). The AST parsing adds overhead but
-        # correctness is more important than speed.
-        # CI shows high variability: 116ms local, 143-175ms in CI.
-        # TODO: Investigate optimization opportunities for AST fallback path
-        assert stats["p95_ms"] < 200, f"Symbol search p95 ({stats['p95_ms']}ms) exceeds 200ms"
-        assert stats["p50_ms"] < 50, f"Symbol search p50 ({stats['p50_ms']}ms) exceeds 50ms"
+        # Performance requirements (platform-aware thresholds — see tests/utils/performance.py).
+        # The AST fallback for inheritance detection (fix #234) adds overhead, and CI runners
+        # (especially macOS) are slow and variable, so naive flat caps deterministically fail
+        # on macOS CI (#383). CommonThresholds carries the macos_ci tier for exactly this.
+        assert_performance_threshold(
+            stats["p95_ms"], CommonThresholds.SYMBOL_SEARCH_P95, "Symbol search p95"
+        )
+        assert_performance_threshold(
+            stats["p50_ms"], CommonThresholds.SYMBOL_SEARCH_P50, "Symbol search p50"
+        )
 
     @pytest.mark.asyncio
     async def test_goto_definition_performance(self, temp_project):
@@ -94,18 +100,26 @@ class TestPerformanceBaselines:
         async def goto():
             return await analyzer.goto_definition(str(test_file), 4, 10)
 
-        # Warm up
-        await goto()
+        # Warm up the analyzer's caches WITHOUT recording the call (see the note in
+        # test_symbol_search_performance): the cold first call would otherwise
+        # dominate p95 over only ~10 samples and fail on slow CI runners (#383).
+        await analyzer.goto_definition(str(test_file), 4, 10)
 
-        # Measure multiple runs
+        # Measure multiple warm runs
         for _ in range(10):
             await goto()
 
         stats = collector.get_stats("goto_definition")
 
-        # Performance requirements
-        assert stats["p95_ms"] < 75, f"Goto definition p95 ({stats['p95_ms']}ms) exceeds 75ms"
-        assert stats["p50_ms"] < 30, f"Goto definition p50 ({stats['p50_ms']}ms) exceeds 30ms"
+        # Performance requirements (platform-aware thresholds — see tests/utils/performance.py).
+        # macOS CI runners are ~2-3x slower, so flat caps fail deterministically (#383);
+        # CommonThresholds carries the macos_ci tier for exactly this.
+        assert_performance_threshold(
+            stats["p95_ms"], CommonThresholds.GOTO_DEFINITION_P95, "Goto definition p95"
+        )
+        assert_performance_threshold(
+            stats["p50_ms"], CommonThresholds.GOTO_DEFINITION_P50, "Goto definition p50"
+        )
 
     def test_cache_lookup_performance(self):
         """Test that cache lookups are fast."""

--- a/tests/utils/performance.py
+++ b/tests/utils/performance.py
@@ -105,9 +105,12 @@ class CommonThresholds:
         windows_ci=15.0,  # 15ms for Windows CI (very lenient)
     )
 
-    # Symbol search performance
+    # Symbol search performance.
+    # p95 over only ~10 warm samples is effectively the slowest single call, so a single
+    # GC/disk hiccup can spike it (~98ms observed locally against the old 100ms base).
+    # These tiers carry headroom for that jitter; macOS/Windows runners get a 3x margin.
     SYMBOL_SEARCH_P95 = PerformanceThresholds(
-        base=100.0, linux_ci=150.0, macos_ci=300.0, windows_ci=300.0
+        base=150.0, linux_ci=225.0, macos_ci=450.0, windows_ci=450.0
     )
 
     SYMBOL_SEARCH_P50 = PerformanceThresholds(


### PR DESCRIPTION
## Summary

`TestPerformanceBaselines::test_symbol_search_performance` (and its sibling `test_goto_definition_performance`) **deterministically failed on the `macos-latest` runner** (~462–486ms vs a flat 200ms cap), blocking every PR's macOS check.

### Root cause (deeper than just the threshold)

Both tests warm up before measuring, but the warmup call went *through* the `@collector.measure` decorator and was counted (`count == 11`, not 10). With only ~10 samples, `p95` is effectively the **slowest single call** — so the test was asserting on **cold-start latency** (jedi import + first parse), which is 7ms→409ms locally and 462–486ms on slow macOS runners.

This also means the naive flat caps violated the project's own rule (`07-validation.md`, `11-pr-requirements.md`): *never write naive timing assertions; always use the `PerformanceThresholds` framework* — which the same file already imports and uses elsewhere.

### Fix

1. **Exclude the warmup from measurement** — warm up via the analyzer directly so the collector only records steady-state warm runs. This removes the cold-call domination of p95 at its source.
2. **Migrate both tests** from `assert p95 < N` to the platform-aware `assert_performance_threshold` / `CommonThresholds` framework, mirroring the pattern already used in `test_metrics_overhead` / the concurrent-ops test.
3. **Raise `SYMBOL_SEARCH_P95` tiers** (base 100→150, macOS/Windows CI →450) for headroom over residual single-call jitter (~98ms observed locally against the old 100ms base).

## Test plan

- [x] Both baseline tests pass 8/8 consecutive runs locally (stable)
- [x] Full perf regression file passes (10/10)
- [x] Full suite: 2058 passed, coverage 86.75% (> 85% gate)
- [ ] CI green on ubuntu / macOS / windows

Fixes #383