### PR TITLE
perf(inspect): drop subclasses from edge_counts — expand-only edge (#392)

### DIFF
--- a/skills/python-explore/SKILL.md
+++ b/skills/python-explore/SKILL.md
@@ -126,7 +126,7 @@ Instead, **say so plainly**: "pyeye can't give reliable caller/reference data ye
 ### Absence vs zero
 
 When you read `edge_counts`, a **missing key means "not measured," not "zero."** A
-present `subclasses: 0` means measured-and-none (genuinely unextended). An *absent*
+present `superclasses: 0` means measured-and-none (the class has no bases). An *absent*
 `callers` key means pyeye didn't measure it — don't read that as "no callers."
 
 ## Workflow
@@ -173,7 +173,7 @@ Handles below use a placeholder project (`myapp.…`) — substitute your own. T
 resolve("myapp.config.Settings")   -> { handle: "myapp.config.Settings", kind: "class",
                                         scope: "project", location: {...} }
 inspect("myapp.config.Settings")   -> kind, signature, docstring,
-                                        edge_counts: { members: 7, superclasses: 1, subclasses: 0 }
+                                        edge_counts: { members: 7, superclasses: 1 }
 ```
 
 **Ambiguous name** — let `resolve` disambiguate, don't guess:
@@ -247,7 +247,7 @@ user can correct you:
 ```markdown
 **Mental model: `myapp.cache.Cache`** (`myapp/cache.py:31`)
 - Depends on: `myapp.config.Settings`, `collections.OrderedDict`
-- I can see: 7 members, 1 superclass, 0 subclasses (measured)
+- I can see: 7 members, 1 superclass (measured); subclasses on demand via `expand`
 - I cannot see: callers/references (deferred, #333) — change impact on callers is unverified
 ```
 

--- a/src/pyeye/analyzers/jedi_analyzer.py
+++ b/src/pyeye/analyzers/jedi_analyzer.py
@@ -3066,7 +3066,7 @@ class JediAnalyzer:
 
         return False
 
-    # DEPRECATED: replaced by inspect(handle).edge_counts.subclasses (count) and future expand(handle, edge="subclasses") (list). Will be removed in the legacy-tool cleanup phase.
+    # DEPRECATED: replaced by expand(handle, edge="subclasses") for the list (and len() for the count); subclasses is expand-only, not in inspect's edge_counts (#392). Will be removed in the legacy-tool cleanup phase.
     async def find_subclasses(
         self,
         base_class: str,
@@ -3076,9 +3076,9 @@ class JediAnalyzer:
     ) -> dict[str, Any]:
         """Find all classes that inherit from a given base class.
 
-        **Deprecated:** Replaced by ``inspect(handle).edge_counts.subclasses``
-        (count) and future ``expand(handle, edge="subclasses")`` (list) in the
-        redesigned API. See
+        **Deprecated:** Replaced by ``expand(handle, edge="subclasses")`` for the
+        list (use ``len(...)`` for the count) in the redesigned API.  ``subclasses``
+        is an expand-only edge — ``inspect`` does not measure it (#392). See
         docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md
         for the migration plan. This method will be removed once the legacy
         MCP tools are deprecated (Phase B of the migration).

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -675,12 +675,12 @@ async def resolve_subclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResu
     Reuses :meth:`JediAnalyzer.find_subclasses` — an AST class-graph walk +
     forward ``goto``/``resolve_canonical`` (NO ``get_references`` /
     ``find_references``, the same load-bearing trust constraint as ``callees`` /
-    ``imported_by``).  The call shape (``scope="main"``, ``include_indirect=True``,
-    ``show_hierarchy=False``) is IDENTICAL to ``inspect._count_subclasses`` so
-    ``len(adjacents) == inspect(handle).edge_counts.subclasses``.  As a
-    single-hop edge it intentionally returns the full project subclass closure
-    (direct + indirect), a deliberate divergence from ``members``/``callees``
-    direct-only semantics justified by that count/list consistency.
+    ``imported_by``).  ``subclasses`` is an **expand-only** edge: ``inspect``
+    does NOT measure it (dropped in #392 — counting it requires this same
+    project-wide scan, so it has no cheap-preview value).  As a single-hop edge
+    it intentionally returns the full project subclass closure (direct +
+    indirect), a deliberate divergence from ``members``/``callees`` direct-only
+    semantics — appropriate because the caller asked to walk the edge explicitly.
 
     Each adjacent's ``Name`` is built from the subclass's OWN FILE (via
     :func:`_subclass_name_from_file`) — never by re-resolving the dotted handle —
@@ -718,17 +718,16 @@ async def resolve_subclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResu
     if not handle:
         return EdgeResult(adjacents=[])
 
-    # Identical call shape to inspect._count_subclasses so len(stubs) == the
-    # measured edge_counts.subclasses (the progressive-disclosure contract).
+    # Project-internal subclass closure (direct + indirect), project-scoped.
     result = await analyzer.find_subclasses(
         handle,
         scope="main",
         include_indirect=True,
         show_hierarchy=False,
     )
-    # An FQN input never triggers the ambiguous variant (as _count_subclasses
-    # asserts).  Carry the same defensive assert so a future regression surfaces
-    # loudly instead of silently yielding an empty list.
+    # An FQN input never triggers the ambiguous variant.  Carry a defensive
+    # assert so a future regression surfaces loudly instead of silently yielding
+    # an empty list.
     assert not result.get(
         "ambiguous", False
     ), f"FQN input to find_subclasses returned ambiguous variant: {handle!r}"

--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -13,11 +13,13 @@ Public API
 
 Design notes
 ------------
-- ``edge_counts`` is ALWAYS present.  It measures 3 edge types: ``members``
-  (class/module), ``superclasses`` (class), and ``subclasses`` (class,
-  project-scoped).  ``callers`` and ``references`` are intentionally OMITTED —
-  they are deferred to the Pyright reference backend (#333) per the
-  absence-vs-zero invariant.  Unmeasured edge types are ABSENT (not 0).
+- ``edge_counts`` is ALWAYS present.  It measures only edges derivable from the
+  symbol's own definition: ``members`` (class/module) and ``superclasses``
+  (class).  ``subclasses`` is intentionally OMITTED — counting it requires a
+  project-wide inheritance scan with no cheap-preview value, so it is an
+  expand-only edge (``expand(handle, "subclasses")``) (#392).  ``callers`` and
+  ``references`` are likewise OMITTED — deferred to the Pyright reference backend
+  (#333).  Unmeasured edge types are ABSENT (not 0).
 - ``re_exports`` (non-module kinds): present when measured (``[]`` = measured,
   none found), or ABSENT if collection failed (couldn't measure).  ABSENT for
   module kind (not computed for this kind).  Per the absence-vs-zero invariant,
@@ -770,36 +772,6 @@ async def _count_superclasses(
     return len(resolve_superclasses(jedi_name, analyzer).handles)
 
 
-async def _count_subclasses(handle: str, analyzer: JediAnalyzer) -> int:
-    """Count project-internal subclasses of a class.
-
-    Delegates to ``analyzer.find_subclasses`` with ``scope="main"`` so only
-    project files are searched.  External subclasses (stdlib, third-party)
-    are excluded.
-
-    Args:
-        handle: The class's canonical dotted-name string.
-        analyzer: Active analyzer.
-
-    Returns:
-        Count of project-internal subclasses (direct + indirect).
-    """
-    try:
-        result = await analyzer.find_subclasses(
-            handle,  # Pass the full FQN for unambiguous, FQN-strict resolution
-            scope="main",
-            include_indirect=True,
-            show_hierarchy=False,
-        )
-        # Unambiguous path (FQN input never triggers ambiguous variant)
-        assert not result.get(
-            "ambiguous", False
-        ), f"FQN input to find_subclasses returned ambiguous variant: {handle!r}"
-        return len(result.get("subclasses", []))
-    except Exception:
-        return 0
-
-
 async def _build_edge_counts(
     handle: str,
     kind: str,
@@ -814,10 +786,14 @@ async def _build_edge_counts(
     time out or error are OMITTED from the returned dict (absence-vs-zero
     invariant).  Edges that succeed are included even when the count is 0.
 
-    Measured edge types:
+    Measured edge types (only edges derivable from the symbol's own definition):
     - ``members``: count of direct members (class and module handles)
     - ``superclasses``: count of direct superclasses (class handles)
-    - ``subclasses``: count of project-internal subclasses (class handles)
+
+    **``subclasses`` is intentionally NOT measured** (see #392).  Counting
+    project-internal subclasses requires the same project-wide inheritance scan
+    as listing them, so it has no cheap-preview value and is an expand-only edge
+    (``expand(handle, "subclasses")``).
 
     **``callers`` and ``references`` are intentionally NOT measured** (see #332).
     They were derived from Jedi's ``get_references``, which is budget-capped
@@ -855,7 +831,11 @@ async def _build_edge_counts(
     if kind == "class":
         coros["members"] = _count_class_members(handle, jedi_name, analyzer)
         coros["superclasses"] = _count_superclasses(jedi_name, analyzer, superclasses)
-        coros["subclasses"] = _count_subclasses(handle, analyzer)
+        # subclasses is intentionally NOT measured here — counting subclasses
+        # requires the same project-wide inheritance scan as listing them, so it
+        # has no cheap-preview value (#392).  It is an expand-only edge:
+        # expand(handle, "subclasses").  inspect's edge_counts reports only edges
+        # derivable from the symbol's own definition (members, superclasses).
 
     elif kind == "module":
         coros["members"] = _count_module_members(jedi_name, analyzer)
@@ -893,9 +873,12 @@ async def inspect(handle: str, analyzer: JediAnalyzer) -> dict[str, Any]:
     returns source content — signatures are single-line strings; ``location``
     is a pointer dict only; ``default`` fields are simple literals only.
 
-    Always includes ``edge_counts`` (measures: members, superclasses,
-    subclasses — for relevant kinds).  ``callers`` and ``references`` are
-    intentionally OMITTED (deferred to the Pyright reference backend, #333).
+    Always includes ``edge_counts`` (measures only edges derivable from the
+    symbol's own definition: members, superclasses — for relevant kinds).
+    ``subclasses`` is OMITTED — it is an expand-only edge
+    (``expand(handle, "subclasses")``), since counting it needs a project-wide
+    scan (#392).  ``callers`` and ``references`` are likewise OMITTED (deferred
+    to the Pyright reference backend, #333).
     Edges that exceed their per-measurement budget are OMITTED, not zero.
     ``re_exports`` — for non-module kinds (class, function, method, property,
     variable, attribute): present when measured (``[]`` = measured, no

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -513,10 +513,12 @@ async def expand(
       - ``subclasses``  — class → the project classes that subclass it (class
         Stubs), computed by an AST class-graph walk + forward ``goto`` (no
         reverse symbol search).  Returns the full project subclass closure
-        (direct + indirect), so ``len(stubs) == inspect(handle).edge_counts``
-        ``.subclasses``.  ``stubs: []`` means the class has no project
-        subclasses (measured-none).  A non-class handle also returns the
-        supported branch with ``stubs: []`` — only a class CAN be subclassed,
+        (direct + indirect).  ``subclasses`` is an expand-only edge: ``inspect``
+        does NOT measure it (dropped in #392 — counting requires this same
+        project-wide scan, so it has no cheap-preview value).  ``stubs: []``
+        means the class has no project subclasses (measured-none).  A non-class
+        handle also returns the supported branch with ``stubs: []`` — only a
+        class CAN be subclassed,
         so ``[]`` is true by definition, not an absence-vs-zero lie.
       - ``superclasses``  — class → its base classes (class Stubs), resolved by
         Jedi from the class definition (no reverse search).  A non-class handle
@@ -1166,7 +1168,7 @@ def list_project_structure(project_path: str = ".", max_depth: int = 3) -> dict[
     return build_tree(project_root)
 
 
-# DEPRECATED: replaced by inspect(handle).edge_counts.subclasses for the count; future expand(handle, edge="subclasses") for the list. Will be removed in the legacy-tool cleanup phase.
+# DEPRECATED: replaced by expand(handle, edge="subclasses") for the list (and len() for the count); subclasses is expand-only, not in inspect's edge_counts (#392). Will be removed in the legacy-tool cleanup phase.
 @mcp.tool()
 @validate_mcp_inputs
 @metrics.measure("find_subclasses")
@@ -1179,9 +1181,9 @@ async def find_subclasses(
 ) -> list[dict[str, Any]]:
     """Python: Find inheritance tree including indirect subclasses. Impossible with grep.
 
-    **Deprecated:** Replaced by ``inspect(handle).edge_counts.subclasses`` for
-    the count and future ``expand(handle, edge="subclasses")`` for the list in
-    the redesigned API. See
+    **Deprecated:** Replaced by ``expand(handle, edge="subclasses")`` for the
+    list (use ``len(...)`` for the count) in the redesigned API.  ``subclasses``
+    is an expand-only edge — ``inspect`` does not measure it (#392). See
     docs/superpowers/specs/2026-05-02-progressive-disclosure-api-design.md
     for the migration plan. This method will be removed once the legacy
     MCP tools are deprecated (Phase B of the migration).

--- a/tests/conformance/response_linter.py
+++ b/tests/conformance/response_linter.py
@@ -205,10 +205,11 @@ _LAYERING_DOC = (
 # a comment explaining the phase or spec reference.
 KNOWN_EDGE_TYPES: frozenset[str] = frozenset(
     {
-        # Phase 4 measured edges (current implementation):
+        # Edges inspect measures in edge_counts (symbol-local, current impl):
         "members",
         "superclasses",
-        "subclasses",
+        # Known edges NOT measured by inspect (expand-only / deferred):
+        "subclasses",  # expand-only — project-wide scan, no cheap preview (#392)
         "callers",
         "references",
         # Future edges per spec Edge Type Vocabulary:
@@ -233,6 +234,13 @@ _PLUGIN_EDGE_RE: re.Pattern[str] = re.compile(r"^\w+@\w+$")
 # Maps kind → frozenset of edge keys that MUST be present (possibly 0) when
 # the implementation measured them.  "other" kinds produce no measurements.
 #
+# Only edges derivable from the symbol's own definition are measured by inspect.
+#
+# ``subclasses`` was REMOVED from ``class`` (see #392): counting it requires the
+# same project-wide inheritance scan as listing them, so it has no cheap-preview
+# value and is now an expand-only edge.  It lives in ``_PHASE4_UNMEASURED_EDGES``
+# (forbidden in inspect's edge_counts).
+#
 # ``callers`` and ``references`` were REMOVED from every kind (see #332): they
 # were derived from Jedi's budget-capped ``get_references`` and under-reported
 # non-deterministically, so they are no longer measured and now live in
@@ -240,16 +248,18 @@ _PLUGIN_EDGE_RE: re.Pattern[str] = re.compile(r"^\w+@\w+$")
 # variable handles therefore have NO required edges — an empty edge_counts is
 # valid for them.  They return once an indexed backend lands (#333).
 _PHASE4_EXPECTED_EDGES: dict[str, frozenset[str]] = {
-    "class": frozenset({"members", "superclasses", "subclasses"}),
+    "class": frozenset({"members", "superclasses"}),
     "module": frozenset({"members"}),
 }
 
 # B.3 — Keys that must NOT appear (unmeasured edges).
 # These are in KNOWN_EDGE_TYPES (future vocab) but are NOT measured.
 # Their presence with any value (including 0) is a false claim about measurements.
+# ``subclasses`` is here because it is expand-only, not inspect-measured (#392).
 # ``callers``/``references`` are here pending the indexed-backend fix (#332/#333).
 _PHASE4_UNMEASURED_EDGES: frozenset[str] = frozenset(
     {
+        "subclasses",
         "callers",
         "references",
         "callees",

--- a/tests/conformance/test_linter_adversarial.py
+++ b/tests/conformance/test_linter_adversarial.py
@@ -38,7 +38,6 @@ _VALID_CLASS: dict = {
     "edge_counts": {
         "members": 0,
         "superclasses": 0,
-        "subclasses": 0,
     },
     "re_exports": [],
 }
@@ -465,10 +464,10 @@ class TestAbsenceVsZeroDetection:
         with pytest.raises(ConformanceViolation, match="superclasses"):
             lint_response(bad, "inspect")
 
-    def test_class_missing_subclasses_edge_rejected(self) -> None:
-        """class kind must have 'subclasses' in edge_counts."""
+    def test_class_subclasses_edge_present_rejected(self) -> None:
+        """'subclasses' is no longer inspect-measured (#392, expand-only); rejected."""
         bad = _clone(_VALID_CLASS)
-        del bad["edge_counts"]["subclasses"]
+        bad["edge_counts"]["subclasses"] = 0
         with pytest.raises(ConformanceViolation, match="subclasses"):
             lint_response(bad, "inspect")
 
@@ -486,10 +485,14 @@ class TestAbsenceVsZeroDetection:
         with pytest.raises(ConformanceViolation, match="references"):
             lint_response(bad, "inspect")
 
-    def test_class_with_only_two_edges_rejected(self) -> None:
-        """class with only 2 of 3 expected edges is rejected."""
+    def test_class_missing_a_required_edge_rejected(self) -> None:
+        """class missing a required edge (superclasses) is rejected.
+
+        The required class edges are members + superclasses (subclasses is
+        expand-only, #392).  Dropping superclasses must still be rejected.
+        """
         bad = _clone(_VALID_CLASS)
-        bad["edge_counts"] = {"members": 0, "superclasses": 0}
+        bad["edge_counts"] = {"members": 0}
         with pytest.raises(ConformanceViolation):
             lint_response(bad, "inspect")
 
@@ -626,7 +629,6 @@ class TestLinterAcceptsValidResponses:
             "edge_counts": {
                 "members": 3,
                 "superclasses": 0,
-                "subclasses": 1,
             },
             "re_exports": ["pkg.X"],
         }

--- a/tests/conformance/test_spec_acceptance.py
+++ b/tests/conformance/test_spec_acceptance.py
@@ -131,22 +131,21 @@ class TestReExportCanonicality:
 
 
 class TestProjectExternalBoundary:
-    """Spec acceptance criterion 7: project/external boundary (inspect side).
+    """Spec acceptance criterion 7: project/external boundary.
 
     Verifies that inspecting an external handle (stdlib class) returns
-    scope="external" with shallow structural data, and that
-    edge_counts.subclasses reflects project-internal subclasses only.
+    scope="external" with shallow structural data, and that the project-internal
+    subclass closure is project-scoped — now an expand-only edge (#392).
 
     External symbol used: pathlib.PurePath (stdlib, universally available).
 
     The fixture file ``tests/fixtures/resolve_project/mypackage/
     external_subclass_demo.py`` defines ``_ProjectPathExtension(PurePath)``
     so that exactly one project-internal subclass exists.  The test asserts
-    edge_counts["subclasses"] == 1, not the much larger number of subclasses
-    that Python's stdlib itself contains (PurePosixPath, PureWindowsPath, etc.).
-
-    Note: expand() is deferred past Phase 7.  This test covers only the
-    inspect()-side of criterion 7.
+    ``expand('pathlib.PurePath', 'subclasses')`` returns exactly 1 stub, not the
+    much larger number of subclasses that Python's stdlib itself contains
+    (PurePosixPath, PureWindowsPath, etc.), and that inspect does NOT carry the
+    subclasses edge (#392).
     """
 
     @pytest.mark.asyncio
@@ -191,35 +190,47 @@ class TestProjectExternalBoundary:
             )
 
     @pytest.mark.asyncio
-    async def test_external_subclasses_count_is_project_scoped(self) -> None:
-        """Spec criterion 7: edge_counts.subclasses is project-scoped.
+    async def test_external_subclasses_is_project_scoped_via_expand(self) -> None:
+        """Spec criterion 7: project-scoped subclasses (now an expand-only edge).
 
-        The fixture defines exactly one project-internal class extending
-        pathlib.PurePath (_ProjectPathExtension in external_subclass_demo.py).
-        The subclasses count must be 1 — reflecting only project-internal
-        subclasses, NOT the stdlib's own PurePosixPath / PureWindowsPath /
-        etc. which would inflate the count if scope filtering were absent.
+        subclasses is no longer measured by inspect (#392) — counting it needs
+        the same project-wide scan as listing them, so it is an expand-only edge.
+        This test therefore verifies BOTH halves of the new contract:
+
+        1. ``inspect('pathlib.PurePath').edge_counts`` does NOT contain
+           'subclasses' (it is not inspect-measured).
+        2. ``expand('pathlib.PurePath', 'subclasses')`` is project-scoped: the
+           fixture defines exactly one project-internal class extending
+           pathlib.PurePath (_ProjectPathExtension in external_subclass_demo.py),
+           so expand returns exactly 1 stub — NOT the stdlib's own
+           PurePosixPath / PureWindowsPath etc., which would inflate the result
+           if scope filtering were absent.
         """
+        from pyeye.mcp.operations.expand import expand
         from pyeye.mcp.operations.inspect import inspect
 
         # Use resolve_project fixture which contains the _ProjectPathExtension class.
         # The fixture file is:
         #   tests/fixtures/resolve_project/mypackage/external_subclass_demo.py
         analyzer = _make_analyzer(_RESOLVE_PROJECT)
-        node = await inspect("pathlib.PurePath", analyzer)
 
+        # (1) inspect must NOT carry subclasses (expand-only, #392)
+        node = await inspect("pathlib.PurePath", analyzer)
         edge_counts = node.get("edge_counts", {})
-        assert "subclasses" in edge_counts, (
-            f"inspect('pathlib.PurePath').edge_counts must contain 'subclasses'; "
-            f"got edge_counts={edge_counts!r}"
+        assert "subclasses" not in edge_counts, (
+            f"inspect('pathlib.PurePath').edge_counts must NOT contain 'subclasses' "
+            f"(expand-only edge, #392); got edge_counts={edge_counts!r}"
         )
 
-        actual = edge_counts["subclasses"]
-        assert actual == 1, (
-            f"edge_counts['subclasses'] must be 1 (project-scoped: only "
-            f"_ProjectPathExtension from external_subclass_demo.py); "
-            f"got {actual!r}.  If this is >1, scope filtering may be absent. "
-            f"If 0, the fixture file may not be in the project scope."
+        # (2) expand carries the project-scoped subclasses
+        result = await expand("pathlib.PurePath", "subclasses", analyzer)
+        stubs = result.get("stubs", [])
+        assert len(stubs) == 1, (
+            f"expand('pathlib.PurePath', 'subclasses') must return 1 stub "
+            f"(project-scoped: only _ProjectPathExtension from "
+            f"external_subclass_demo.py); got {len(stubs)} stubs={stubs!r}. "
+            f"If >1, scope filtering may be absent. If 0, the fixture file may "
+            f"not be in the project scope."
         )
 
 

--- a/tests/integration/api_redesign/test_inspect_integration.py
+++ b/tests/integration/api_redesign/test_inspect_integration.py
@@ -90,17 +90,19 @@ class TestInspectUniversalFields:
         assert isinstance(
             result["edge_counts"], dict
         ), f"edge_counts must be a dict; got {type(result['edge_counts'])!r}"
-        # edge_counts is populated with measured edges for class handles.
-        # The measured class edges are members/superclasses/subclasses; callers
-        # and references were removed (#332).
-        for edge in ("members", "superclasses", "subclasses"):
+        # edge_counts is populated with the symbol-local measured edges for class
+        # handles: members + superclasses.
+        for edge in ("members", "superclasses"):
             assert edge in result["edge_counts"], (
                 f"inspect must populate edge_counts[{edge!r}] for class Widget; "
                 f"got edge_counts={result['edge_counts']!r}"
             )
-        for edge in ("callers", "references"):
+        # subclasses is expand-only (#392); callers/references were removed (#332).
+        # All must be ABSENT from inspect's edge_counts.
+        for edge in ("subclasses", "callers", "references"):
             assert edge not in result["edge_counts"], (
-                f"edge_counts[{edge!r}] was removed (#332) and must be absent; "
+                f"edge_counts[{edge!r}] must be absent from inspect "
+                f"(subclasses #392; callers/references #332); "
                 f"got edge_counts={result['edge_counts']!r}"
             )
 

--- a/tests/integration/jedi_integration/test_jedi_analyzer.py
+++ b/tests/integration/jedi_integration/test_jedi_analyzer.py
@@ -1267,38 +1267,41 @@ class TestFindSubclassesIndirectIdentity:
         assert names == {"SportsCar"}, f"Unrelated Car must own only SportsCar; got {names}"
 
 
-class TestInspectEdgeCountsSubclassesIssue335:
-    """Issue #335 criterion 3: inspect().edge_counts.subclasses matches truth.
+class TestExpandSubclassesIssue335:
+    """Issue #335 criterion 3: expand(handle, "subclasses") matches truth.
 
-    edge_counts.subclasses delegates to find_subclasses with the canonical FQN,
-    so the Bug A / Bug B fixes must flow through to the inspect surface.
+    subclasses is an expand-only edge (inspect no longer measures it — #392), and
+    the expand resolver delegates to find_subclasses with the canonical FQN, so
+    the Bug A / Bug B fixes must flow through to the expand surface.
     """
 
     @pytest.mark.asyncio
-    async def test_shape_edge_count_includes_reexport_subclasses(self) -> None:
-        """inspect(Shape).edge_counts.subclasses counts both re-export subclasses."""
-        from pyeye.mcp.server import inspect
+    async def test_shape_expand_includes_reexport_subclasses(self) -> None:
+        """expand(Shape, "subclasses") counts both re-export subclasses."""
+        from pyeye.mcp.server import expand
 
-        result = await inspect(
+        result = await expand(
             handle="pkg.shapes._impl.Shape",
+            edge="subclasses",
             project_path=str(_ISSUE_335_FIXTURE),
         )
         assert (
-            result["edge_counts"].get("subclasses") == 2
-        ), f"Expected subclasses count 2 for Shape; got {result['edge_counts']!r}"
+            len(result["stubs"]) == 2
+        ), f"Expected 2 subclass stubs for Shape; got {result['stubs']!r}"
 
     @pytest.mark.asyncio
-    async def test_vehicle_edge_count_excludes_unrelated_grandchild(self) -> None:
-        """inspect(Vehicle).edge_counts.subclasses == 2 (Car, RaceCar), not 3."""
-        from pyeye.mcp.server import inspect
+    async def test_vehicle_expand_excludes_unrelated_grandchild(self) -> None:
+        """expand(Vehicle, "subclasses") == 2 stubs (Car, RaceCar), not 3."""
+        from pyeye.mcp.server import expand
 
-        result = await inspect(
+        result = await expand(
             handle="pkg.vehicles_a.Vehicle",
+            edge="subclasses",
             project_path=str(_ISSUE_335_FIXTURE),
         )
         assert (
-            result["edge_counts"].get("subclasses") == 2
-        ), f"Expected subclasses count 2 for Vehicle; got {result['edge_counts']!r}"
+            len(result["stubs"]) == 2
+        ), f"Expected 2 subclass stubs for Vehicle; got {result['stubs']!r}"
 
 
 class TestFindSubclassesJediIndependence:

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -749,8 +749,8 @@ class TestResolveSubclassesClass:
         self, subclasses_analyzer: JediAnalyzer
     ) -> None:
         # Dog(Mammal) is a grandchild of Animal — include_indirect=True must
-        # surface it (the single-hop edge intentionally returns the full closure
-        # so len(stubs) == inspect.edge_counts.subclasses).
+        # surface it (the single-hop subclasses edge intentionally returns the
+        # full project closure; subclasses is expand-only, #392).
         handles = {
             str(h) for h in (await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)).handles
         }

--- a/tests/unit/mcp/operations/test_expand.py
+++ b/tests/unit/mcp/operations/test_expand.py
@@ -45,7 +45,6 @@ import pytest
 
 from pyeye.analyzers.jedi_analyzer import JediAnalyzer
 from pyeye.mcp.operations.expand import expand
-from pyeye.mcp.operations.inspect import inspect
 
 _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
 
@@ -611,37 +610,28 @@ class TestExpandSubclassesNonClassMeasuredEmpty:
         assert "stubs" not in imported_by_wrong_kind
 
 
-class TestExpandSubclassesCountListConsistency:
-    """Progressive-disclosure contract: len(stubs) == inspect.edge_counts.subclasses.
+class TestExpandSubclassesEnumeration:
+    """``expand(handle, "subclasses")`` enumerates the project subclass closure.
 
-    The resolver and ``inspect._count_subclasses`` share the EXACT call shape
-    (``scope="main"``, ``include_indirect=True``, ``show_hierarchy=False``), so
-    the number of subclass stubs ``expand`` produces MUST equal the count
-    ``inspect`` reports for the same class.  This is the contract that justifies
-    the shared call shape; if it diverges, the resolver's enumeration or dedup
-    has drifted from ``find_subclasses``' result list (reconcile, don't relax).
+    subclasses is an expand-only edge (inspect no longer measures it — #392), so
+    these tests pin expand's enumeration directly against the fixture topology
+    rather than cross-checking an inspect count.
     """
 
     @pytest.mark.asyncio
-    async def test_expand_len_equals_inspect_count(self, subclasses_analyzer: JediAnalyzer) -> None:
+    async def test_expand_returns_full_project_closure(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
         expand_result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
-        inspect_result = await inspect(_ANIMAL_HANDLE, subclasses_analyzer)
-
         stub_count = len(expand_result["stubs"])
-        edge_count = inspect_result["edge_counts"]["subclasses"]
-        assert stub_count == edge_count, (
-            f"len(expand subclasses stubs)={stub_count} must equal "
-            f"inspect edge_counts['subclasses']={edge_count} (shared call shape)"
-        )
         # The fixture's known closure is exactly 3 (Mammal, Dog, Lizard); pin it
-        # so a fixture-topology change can't silently make this a 0==0 tautology.
+        # so a fixture-topology change surfaces loudly.
         assert stub_count == 3, f"fixture Animal closure should be 3 subclasses; got {stub_count}"
 
     @pytest.mark.asyncio
-    async def test_no_subclasses_consistency_holds_at_zero(
+    async def test_class_with_no_subclasses_returns_empty(
         self, subclasses_analyzer: JediAnalyzer
     ) -> None:
-        # The contract also holds for the measured-empty class case: 0 == 0.
+        # Measured-empty class case: a class with no project subclasses → 0 stubs.
         expand_result = await expand(_LONER_HANDLE, "subclasses", subclasses_analyzer)
-        inspect_result = await inspect(_LONER_HANDLE, subclasses_analyzer)
-        assert len(expand_result["stubs"]) == inspect_result["edge_counts"]["subclasses"] == 0
+        assert len(expand_result["stubs"]) == 0

--- a/tests/unit/mcp/operations/test_inspect.py
+++ b/tests/unit/mcp/operations/test_inspect.py
@@ -63,14 +63,14 @@ No source-content fields:
   - ``default`` is a simple literal string when present — NOT a complex expression
   - ``location`` is a pointer dict — NOT a source snippet
 
-Contract tested — Phase 4 (Task 4.1)
+Contract tested — edge_counts
 --------------------------------------
-Phase 4 wires exactly 5 edge types into ``edge_counts``:
+``edge_counts`` measures only edges derivable from the symbol's own definition:
   - ``members``: for class and module handles (count of direct members)
   - ``superclasses``: for class handles
-  - ``subclasses``: for class handles (project-scoped)
-  - ``callers``: for function/method handles
-  - ``references``: for any handle (aggregate read/written/passed; excludes calls)
+Edges requiring a project-wide traversal are NOT measured here (expand-only):
+  - ``subclasses``: expand-only — project-wide scan, no cheap preview (#392)
+  - ``callers`` / ``references``: deferred to the Pyright backend (#332/#333)
 
 The absence-vs-zero invariant (load-bearing):
   - Unmeasured edges are ABSENT from edge_counts (not present with value 0)
@@ -123,21 +123,24 @@ _COLOR_HANDLE = "mypackage._core.widgets.Widget.color"
 _MODULE_HANDLE = "mypackage._core.widgets"
 _DEFAULT_NAME_HANDLE = "mypackage._core.widgets.DEFAULT_NAME"
 
-# Phase 4 fixture handles — subclasses of Widget added at end of widgets.py
+# Fixture handle — Premium is a subclass of Widget (declared in widgets.py)
 _PREMIUM_HANDLE = "mypackage._core.widgets.Premium"
-_DELUXE_HANDLE = "mypackage._core.widgets.Deluxe"
 
 # External symbol — pathlib.Path is stdlib, always available
 _PATH_CLASS_HANDLE = "pathlib.Path"
 
-# All 5 edge types measured by Phase 4 (must be present for relevant kinds)
-# callers/references removed (#332): derived from Jedi's budget-capped
-# get_references, which under-reports non-deterministically. Omitted until an
-# indexed backend lands (#333). Only structural edges remain measured.
-_PHASE4_MEASURED_EDGES = frozenset({"members", "superclasses", "subclasses"})
+# Edge types inspect measures in edge_counts (must be present for relevant kinds).
+# Only edges derivable from the symbol's own definition are measured.
+# - subclasses removed (#392): counting needs a project-wide scan with no cheap
+#   preview, so it is an expand-only edge.
+# - callers/references removed (#332): derived from Jedi's budget-capped
+#   get_references, which under-reports non-deterministically. Omitted until an
+#   indexed backend lands (#333).
+_PHASE4_MEASURED_EDGES = frozenset({"members", "superclasses"})
 
-# All unmeasured edge types in Phase 4 (must be ABSENT from edge_counts)
+# Edge types inspect does NOT measure (must be ABSENT from edge_counts)
 _PHASE4_UNMEASURED_EDGES = [
+    "subclasses",
     "read_by",
     "written_by",
     "passed_by",
@@ -804,23 +807,19 @@ class TestInspectUniversalContract:
 
 
 class TestInspectEdgeCounts:
-    """Phase 4 contract: edge_counts populated with exactly 5 measured edge types.
-
-    These tests are in the RED state until Task 4.2 implements edge_counts.
-    The Phase 3 implementation returns ``edge_counts: {}`` always, so every
-    assertion that checks for a non-empty edge_counts (or for a 0-valued key)
-    will fail with AssertionError.
+    """edge_counts contract: only symbol-local edges are measured.
 
     The absence-vs-zero invariant (load-bearing):
     - Measured edges with zero value MUST be PRESENT with value 0 (not omitted)
     - Unmeasured edge types MUST be ABSENT (not present with value 0)
 
-    Phase 4 measures exactly these 5 edges:
+    edge_counts measures exactly these edges (derivable from the symbol itself):
     - ``members``: class and module handles
     - ``superclasses``: class handles
-    - ``subclasses``: class handles (project-scoped)
-    - ``callers``: function/method handles
-    - ``references``: any handle (aggregate read/written/passed; excludes calls)
+
+    NOT measured (require project-wide traversal — expand-only / deferred):
+    - ``subclasses``: expand-only — project-wide scan, no cheap preview (#392)
+    - ``callers`` / ``references``: deferred to the Pyright backend (#332/#333)
     """
 
     # ------------------------------------------------------------------ (a)
@@ -914,52 +913,23 @@ class TestInspectEdgeCounts:
 
     # ------------------------------------------------------------------ (c)
     @pytest.mark.asyncio
-    async def test_class_with_no_subclasses_returns_zero(self, analyzer: JediAnalyzer) -> None:
-        """(c/g) CRITICAL: measured-and-zero is PRESENT with value 0, not omitted.
+    async def test_subclasses_absent_from_edge_counts(self, analyzer: JediAnalyzer) -> None:
+        """(c) subclasses is NEVER in inspect's edge_counts — it is expand-only (#392).
 
-        Config has no subclasses in the project.
-        edge_counts['subclasses'] MUST be 0 (present!), NOT absent.
-        Phase 3 returns edge_counts: {} — 'subclasses' is absent → FAIL.
-        This tests BOTH directions of the invariant:
-        - key is present ('subclasses' in edge_counts)
-        - value is 0 (not a non-zero count)
+        Counting subclasses requires the same project-wide inheritance scan as
+        listing them, so it has no cheap-preview value and was dropped from
+        inspect.  This must hold regardless of whether the class actually has
+        subclasses: Config has none, Widget has Premium+Deluxe — neither emits a
+        'subclasses' key.  Callers who want them use expand(handle, "subclasses").
         """
         from pyeye.mcp.operations.inspect import inspect
 
-        result = await inspect(_CONFIG_HANDLE, analyzer)
-
-        # CRITICAL: 'subclasses' MUST be in edge_counts even when count is 0
-        assert "subclasses" in result["edge_counts"], (
-            f"Config has no subclasses — but 'subclasses' key MUST be present with value 0; "
-            f"got edge_counts={result['edge_counts']!r}. "
-            "Absence means 'not measured'; 0 means 'measured, none found'. "
-            "Phase 4 measures subclasses for all class handles."
-        )
-        assert result["edge_counts"]["subclasses"] == 0, (
-            f"Config has no project subclasses; expected subclasses=0; "
-            f"got subclasses={result['edge_counts']['subclasses']}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_class_with_subclasses_counts_them(self, analyzer: JediAnalyzer) -> None:
-        """(c) A class with project subclasses returns their count in edge_counts.
-
-        Widget has Premium and Deluxe as explicit subclasses in the project.
-        edge_counts['subclasses'] must be >= 2.
-        Phase 3 returns edge_counts: {} so 'subclasses' is absent → FAIL.
-        """
-        from pyeye.mcp.operations.inspect import inspect
-
-        result = await inspect(_WIDGET_HANDLE, analyzer)
-
-        assert "subclasses" in result["edge_counts"], (
-            f"Widget has subclasses (Premium, Deluxe) — 'subclasses' key must be present; "
-            f"got edge_counts={result['edge_counts']!r}"
-        )
-        assert result["edge_counts"]["subclasses"] >= 2, (
-            f"Widget has >= 2 project subclasses (Premium, Deluxe); "
-            f"got subclasses={result['edge_counts']['subclasses']}"
-        )
+        for handle in (_CONFIG_HANDLE, _WIDGET_HANDLE):
+            result = await inspect(handle, analyzer)
+            assert "subclasses" not in result["edge_counts"], (
+                f"'subclasses' must be ABSENT from inspect edge_counts (expand-only, #392); "
+                f"got edge_counts={result['edge_counts']!r} for handle={handle!r}"
+            )
 
     # ------------------------------------------------------------------ (d/e)
     # callers/references are NO LONGER measured (#332): they were derived from
@@ -1020,14 +990,11 @@ class TestInspectEdgeCounts:
     async def test_unmeasured_edges_are_absent(self, analyzer: JediAnalyzer) -> None:
         """(f) CRITICAL: unmeasured edge types MUST NOT appear in edge_counts.
 
-        Phase 4 measures exactly 5 edges. All other edge types are ABSENT.
-        An absent key means 'we didn't measure this' — not 'the value is 0'.
-        This test runs against a class handle (Widget) where Phase 4 WILL populate
-        members/superclasses/subclasses. It verifies the other 11 types stay absent.
-
-        Phase 3 returns {} — this test PASSES in Phase 3 (no spurious keys).
-        But after Phase 4 implementation, the 5 measured keys will be present.
-        The unmeasured keys must STILL be absent.
+        edge_counts measures only members + superclasses. All other edge types
+        are ABSENT.  An absent key means 'we didn't measure this' — not 'the
+        value is 0'.  This test runs against a class handle (Widget) where
+        members/superclasses are populated; it verifies the unmeasured types
+        (including subclasses — expand-only, #392) stay absent.
 
         NOTE: This test is designed to pass in Phase 3 (nothing to check for yet)
         and continue passing in Phase 4 (measured keys in, unmeasured keys still out).
@@ -1063,43 +1030,15 @@ class TestInspectEdgeCounts:
             )
 
     # ------------------------------------------------------------------ (g) — covered by
-    # test_class_with_no_subclasses_returns_zero (subclasses=0 present)
     # test_function_with_no_callers_returns_zero (callers=0 present)
-
-    # ------------------------------------------------------------------ (h)
-    @pytest.mark.asyncio
-    async def test_external_node_subclasses_are_project_scoped(
-        self, analyzer: JediAnalyzer
-    ) -> None:
-        """(h) edge_counts on an external node reflects project-internal subclasses only.
-
-        pathlib.Path is a stdlib class. The fixture project has no class that
-        extends pathlib.Path, so edge_counts['subclasses'] must be 0.
-        This verifies that the count is project-scoped (not all Python subclasses globally).
-
-        Phase 3 returns edge_counts: {} so 'subclasses' is absent → FAIL.
-        """
-        from pyeye.mcp.operations.inspect import inspect
-
-        result = await inspect(_PATH_CLASS_HANDLE, analyzer)
-
-        assert "subclasses" in result["edge_counts"], (
-            f"External class handle must have edge_counts['subclasses'] key (project-scoped); "
-            f"got edge_counts={result['edge_counts']!r}. "
-            "Phase 4 measures project subclasses even for external symbols."
-        )
-        # No fixture class extends pathlib.Path → project-scoped count must be 0
-        assert result["edge_counts"]["subclasses"] == 0, (
-            f"No project class extends pathlib.Path; expected subclasses=0 (project-scoped); "
-            f"got subclasses={result['edge_counts']['subclasses']}"
-        )
 
     @pytest.mark.asyncio
     async def test_all_measured_edges_present_for_class(self, analyzer: JediAnalyzer) -> None:
         """All measured edge types are present in edge_counts for a class handle.
 
-        Widget is a class — the measured class edges are members, superclasses,
-        and subclasses (callers/references removed, #332).  All must be present.
+        Widget is a class — the measured class edges are members and
+        superclasses (subclasses is expand-only #392; callers/references removed
+        #332).  All must be present.
         """
         from pyeye.mcp.operations.inspect import inspect
 
@@ -1107,7 +1046,7 @@ class TestInspectEdgeCounts:
 
         for edge in _PHASE4_MEASURED_EDGES:
             assert edge in result["edge_counts"], (
-                f"Phase 4 must populate edge_counts[{edge!r}] for class handles; "
+                f"edge_counts must populate edge_counts[{edge!r}] for class handles; "
                 f"got edge_counts={result['edge_counts']!r}"
             )
 
@@ -1116,25 +1055,25 @@ class TestInspectEdgeCounts:
         """edge_counts contains ONLY the measured edges (no extras).
 
         For a class, edge_counts must contain exactly the measured class keys
-        (members, superclasses, subclasses) and nothing else — in particular
-        no callers/references (removed, #332).
+        (members, superclasses) and nothing else — in particular no subclasses
+        (expand-only, #392) and no callers/references (removed, #332).
         """
         from pyeye.mcp.operations.inspect import inspect
 
         result = await inspect(_WIDGET_HANDLE, analyzer)
         edge_counts = result["edge_counts"]
 
-        # All 5 measured keys must be present for a class
+        # All measured keys must be present for a class
         for edge in _PHASE4_MEASURED_EDGES:
             assert edge in edge_counts, (
-                f"Phase 4 must populate {edge!r} for class Widget; "
+                f"edge_counts must populate {edge!r} for class Widget; "
                 f"got edge_counts={edge_counts!r}"
             )
 
-        # No extra keys beyond the 5 measured ones
+        # No extra keys beyond the measured ones (subclasses must NOT leak in)
         extra_keys = set(edge_counts.keys()) - _PHASE4_MEASURED_EDGES
         assert not extra_keys, (
-            f"edge_counts contains unexpected keys beyond Phase 4's 5 measured edges: "
+            f"edge_counts contains unexpected keys beyond the measured edges: "
             f"{sorted(extra_keys)!r}. Only {sorted(_PHASE4_MEASURED_EDGES)!r} are allowed."
         )
 
@@ -1155,54 +1094,53 @@ class TestInspectEdgeTimeout:
     """
 
     @pytest.mark.asyncio
-    async def test_timeout_on_subclasses_omits_edge(self, analyzer: JediAnalyzer) -> None:
-        """A timeout on subclasses measurement omits 'subclasses' from edge_counts.
+    async def test_timeout_on_superclasses_omits_edge(self, analyzer: JediAnalyzer) -> None:
+        """A timeout on superclasses measurement omits 'superclasses' from edge_counts.
 
-        When ``_count_subclasses`` exceeds the per-edge budget,
-        ``edge_counts['subclasses']`` must be ABSENT (not 0).
-        The other edges (members, superclasses, callers, references) should still
-        be measured independently and present in edge_counts.
+        When ``_count_superclasses`` exceeds the per-edge budget,
+        ``edge_counts['superclasses']`` must be ABSENT (not 0).
+        The other measured edge (``members``) should still be measured
+        independently and present in edge_counts.
         """
         import asyncio
         from unittest.mock import patch
 
         from pyeye.mcp.operations.inspect import inspect
 
-        # Patch _count_subclasses to raise asyncio.TimeoutError on every call.
+        # Patch _count_superclasses to raise asyncio.TimeoutError on every call.
         # _measure_with_budget catches TimeoutError from wait_for, but we also
         # need to handle the case where the coroutine itself raises it.
-        async def subclasses_timeout(*_args: object, **_kwargs: object) -> int:
+        async def superclasses_timeout(*_args: object, **_kwargs: object) -> int:
             raise asyncio.TimeoutError()
 
         with patch.object(
             inspect_ops,
-            "_count_subclasses",
-            side_effect=subclasses_timeout,
+            "_count_superclasses",
+            side_effect=superclasses_timeout,
         ):
             result = await inspect(_WIDGET_HANDLE, analyzer)
 
         edge_counts = result["edge_counts"]
 
-        # subclasses must be ABSENT (timed out → not measured)
-        assert "subclasses" not in edge_counts, (
-            f"Timed-out edge 'subclasses' must be ABSENT from edge_counts; "
+        # superclasses must be ABSENT (timed out → not measured)
+        assert "superclasses" not in edge_counts, (
+            f"Timed-out edge 'superclasses' must be ABSENT from edge_counts; "
             f"got edge_counts={edge_counts!r}. "
             "Absence means 'not measured'; 0 means 'measured, none found'."
         )
 
-        # Other class edges must still be present (per-measurement isolation)
-        for edge in ("members", "superclasses"):
-            assert edge in edge_counts, (
-                f"Edge {edge!r} must still be present when subclasses timed out; "
-                f"got edge_counts={edge_counts!r}"
-            )
+        # The other measured class edge must still be present (per-measurement isolation)
+        assert "members" in edge_counts, (
+            f"Edge 'members' must still be present when superclasses timed out; "
+            f"got edge_counts={edge_counts!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_timeout_on_one_edge_does_not_block_others(self, analyzer: JediAnalyzer) -> None:
         """A timeout on one edge does not prevent other edges from being measured.
 
-        This verifies per-measurement isolation: ``subclasses`` timeout must not
-        cause ``members`` or ``superclasses`` to be absent.
+        This verifies per-measurement isolation: a ``superclasses`` timeout must
+        not cause ``members`` to be absent.
 
         Uses a mock with a very short budget (1 ms) so that the slow mock
         times out via ``asyncio.wait_for`` while others proceed normally.
@@ -1212,12 +1150,12 @@ class TestInspectEdgeTimeout:
 
         from pyeye.mcp.operations.inspect import _build_edge_counts
 
-        # Replace _count_subclasses with a coroutine that sleeps longer than the budget
-        async def slow_subclasses(*_args: object, **_kwargs: object) -> int:
+        # Replace _count_superclasses with a coroutine that sleeps longer than the budget
+        async def slow_superclasses(*_args: object, **_kwargs: object) -> int:
             await asyncio.sleep(10)  # longer than any reasonable budget
             return 99  # pragma: no cover
 
-        with patch.object(inspect_ops, "_count_subclasses", side_effect=slow_subclasses):
+        with patch.object(inspect_ops, "_count_superclasses", side_effect=slow_superclasses):
             # Use a 0.01 second budget so the sleep definitely times out
             result = await _build_edge_counts(
                 _WIDGET_HANDLE,
@@ -1230,10 +1168,10 @@ class TestInspectEdgeTimeout:
                 budget_seconds=0.01,
             )
 
-        # subclasses must be absent (timed out)
+        # superclasses must be absent (timed out)
         assert (
-            "subclasses" not in result
-        ), f"subclasses must be absent after timeout; got {result!r}"
+            "superclasses" not in result
+        ), f"superclasses must be absent after timeout; got {result!r}"
 
     @pytest.mark.asyncio
     async def test_all_edges_absent_when_all_timeout(self, analyzer: JediAnalyzer) -> None:
@@ -1253,7 +1191,6 @@ class TestInspectEdgeTimeout:
         with (
             patch.object(inspect_ops, "_count_class_members", side_effect=always_timeout),
             patch.object(inspect_ops, "_count_superclasses", side_effect=always_timeout),
-            patch.object(inspect_ops, "_count_subclasses", side_effect=always_timeout),
         ):
             result = await inspect(_WIDGET_HANDLE, analyzer)
 


### PR DESCRIPTION
## Summary

`inspect`'s `edge_counts` eagerly computed `subclasses` for every class via a **project-wide inheritance scan** (`find_subclasses`, `scope="main"`, `include_indirect=True`). Counting subclasses requires the same scan as listing them, so it has **no cheap-preview value** — it made the "orient cheap" step pay full drill cost (observed `inspect` calls averaging **146s, max 255s** while dogfooding).

`edge_counts` now measures only edges **derivable from the symbol's own definition** — `members`, `superclasses`. `subclasses` is preserved as the existing **expand-only** edge: `expand(handle, "subclasses")`. The dead `_count_subclasses` helper is deleted.

This follows the "orient cheap, drill on demand" principle: per the absence-vs-zero invariant, an absent `subclasses` key correctly reads as "not measured — use expand," so clients degrade gracefully.

## Scope (larger than the issue estimated)

The issue scoped this to `test_inspect.py` + `response_linter.py`, but **8 consumer files** asserted `inspect`'s subclasses; all found via grep and updated:

- **response_linter**: `subclasses` removed from class expected-edges, added to the unmeasured/forbidden set (inspect emitting it is now a violation).
- **Conformance** (`test_spec_acceptance`, `test_linter_adversarial`): assert `subclasses` ABSENT from inspect; the "class must have subclasses" / "two-edges-rejected" tests **inverted** to match the new contract; project-scoping (criterion 7) re-verified via `expand`.
- **Integration** (`test_jedi_analyzer` #335 regressions, `test_inspect_integration`): repointed to `expand` so the #335 fixes stay covered on the new surface.
- **`test_expand` / `test_edges` / `edges.py`**: count/list-consistency-with-inspect tests repurposed to pin `expand`'s enumeration directly; stale `inspect._count_subclasses` comments corrected.
- **Timeout-budget tests** repointed off the deleted `_count_subclasses` to `_count_superclasses`.

Net −63 lines.

## Test plan

- [x] Full suite: **2063 passed, 8 skipped**, coverage **86.77%** (> 85% gate)
- [x] pre-commit on all changed files: black, ruff, mypy, pydocstyle, bandit, detect-secrets, PyEye conformance linter — all pass
- [x] `subclasses` capability preserved and verified via `expand(handle, "subclasses")`

## Related

- #393 (move `re_exports` to an expand edge) — the sibling cheap-by-default reduction
- #394 (cost governance / budget enforcement) — the backstop track
- #333 (deferred reverse references)

Fixes #392