### PR TITLE
perf(cache): surface artifact-cache metrics + make cap configurable; add decision-log nudge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,10 @@
 default_language_version:
   python: python3.12
 
+# Install pre-commit, commit-msg, AND post-commit hooks on `pre-commit install`
+# (post-commit drives the non-blocking decision-log nudge below).
+default_install_hook_types: [pre-commit, commit-msg, post-commit]
+
 repos:
   # Security checks
   - repo: https://github.com/Yelp/detect-secrets
@@ -142,3 +146,19 @@ repos:
     hooks:
       - id: markdownlint
         args: ['--fix']
+
+  # Decision-log nudge — runs AFTER each commit, never blocks. Prints a one-line
+  # suggestion when the just-committed diff touches a contract surface (new
+  # PYEYE_* config knob, public/dunder signature change, or an output-shape dict
+  # key in a report/schema/export function). Suggestion only — the decision to
+  # log stays human. verbose:true so the nudge is shown despite the 0 exit code.
+  - repo: local
+    hooks:
+      - id: decision-log-nudge
+        name: Decision-log nudge (contract-surface suggestion)
+        entry: python scripts/decision_log_nudge.py
+        language: system
+        stages: [post-commit]
+        pass_filenames: false
+        always_run: true
+        verbose: true

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -2,6 +2,20 @@
 
 Contract/invariant-significant, friction-driven decisions. Each entry is a small verifiable fact: Friction · Decision · Anchor (stable ref) · Verify (checkable or honestly-labelled). Newest on top. Maintained via the `decision-log` skill.
 
+## 2026-06-16 — AST/Script cache cap is configurable via `PYEYE_ARTIFACT_CACHE_MAX_ENTRIES`
+
+**Friction:** The `file_artifact_cache` combined AST+Script LRU cap was hardcoded at 500. On large repos (hundreds of files / 10k+ classes) the working set exceeds it, so a repeated scan (e.g. `expand` `subclasses`) evicts its own entries mid-scan and the next identical call re-parses from disk — the cache silently stops helping. Reproduced: same call twice → same cost, with eviction count climbing.
+**Decision:** Add `PYEYE_ARTIFACT_CACHE_MAX_ENTRIES` (default 500, min 1, max 1_000_000). `FileArtifactCache(ast_max_entries=None)` falls back to `settings.artifact_cache_max_entries`; an explicit constructor arg always wins (test isolation / targeted tuning). Rejected: hardcoded constant; auto-sizing to project file count (deferred — wants the eviction signal observed in the field first).
+**Anchor:** `Settings.artifact_cache_max_entries` ; `FileArtifactCache.__init__` ; commit `0d7933d` ; #397
+**Verify:** gold — `PYEYE_ARTIFACT_CACHE_MAX_ENTRIES=7 python -c "from pyeye import file_artifact_cache as f; assert f.FileArtifactCache()._ast_max_entries==7"`; covered by `tests/test_artifact_cache_configurable.py` (default-vs-explicit precedence) and `tests/unit/core/test_settings.py` (default/env/clamp).
+
+## 2026-06-16 — AST/Script cache stats surfaced in the performance report
+
+**Friction:** The `file_artifact_cache` (AST/Script) cache — the one that actually accelerates navigation — was wired to no report. `get_performance_metrics` surfaced only the result/scoped cache, so a healthy run and a cap-thrashing run reported *identically* (both `1 hit, 1 miss`); the eviction signal that distinguishes them was invisible. Root cause: four disconnected `CacheMetrics` objects, only one of them reported.
+**Decision:** Surface `file_artifact_cache.stats()` as a distinct top-level `artifact_cache` section in `MetricsCollector.get_performance_report()` and as `pyeye_artifact_cache_{hits,misses,evictions}` Prometheus series. Kept *separate* from the existing `cache` block (not merged) so the metric fragmentation stays visible rather than hidden.
+**Anchor:** `MetricsCollector.get_performance_report` ; `MetricsCollector.export_prometheus` ; commit `e9e47d5` ; #397
+**Verify:** gold — `tests/test_artifact_cache_metrics_surface.py` asserts the report exposes `artifact_cache` reflecting real hits/misses/evictions, and that an over-cap run (evictions>0) is now distinguishable from an under-cap run (evictions==0) — the exact blind spot this closes.
+
 ## 2026-06-13 — decision-log ships in the pyeye plugin, not ~/.claude/skills
 
 **Friction:** A loose `~/.claude/skills/` file is unmanaged — not versioned, lost on a machine move, not shareable — and it split the work across two homes (user dir + repo).

--- a/scripts/decision_log_nudge.py
+++ b/scripts/decision_log_nudge.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Post-commit nudge: flag commits that touch a contract surface.
+
+Prototype for the decision-log handoff gap (see docs/decisions/DECISIONS.md):
+the decision-log trigger is meant to fire at the commit checkpoint, but relies
+on the agent remembering to surface it. This makes the signal *deterministic* —
+git runs it on every commit, it inspects the just-committed diff, and prints a
+ONE-LINE nudge **only** when it detects a contract surface. Trivial commits stay
+silent (so it doesn't train you to ignore it).
+
+It NEVER blocks and never writes anything — it only prints a suggestion. The
+judgement of whether to actually log a decision stays with the human/agent.
+
+What it detects (high-precision, low-noise):
+  * public signature changes  — added/removed/changed `def`/`async def`/`class`
+    whose name is public or a dunder (e.g. `__init__`), in src .py files
+    (tests/docs excluded; private `_helper` names ignored).
+  * new/changed config knobs   — added lines introducing a `PYEYE_*` env var.
+  * output-shape contracts      — a dict key added to the return value of a
+    function whose name implies an output contract (report/schema/export/
+    stats/serialize/to_dict/to_json/metrics/summary).
+
+Residual limitation (honest): output-shape detection is scoped to recognised
+output-function names via the diff hunk header; a contract dict built in a
+helper with an unrecognised name is still missed. It is a high-precision nudge,
+not a complete gate — the judgement of whether to log stays human.
+
+Usage:
+    decision_log_nudge.py [<commit-ish>]   # defaults to HEAD
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# A diff body line (+/-) declaring a def/class. Group 1 = the name.
+_SIGNATURE = re.compile(r"^[+-]\s*(?:async\s+def|def|class)\s+([A-Za-z_][A-Za-z0-9_]*)")
+# A def/class name anywhere (used to read the enclosing-scope from hunk headers).
+_DEF_IN_CONTEXT = re.compile(r"(?:async\s+def|def|class)\s+([A-Za-z_][A-Za-z0-9_]*)")
+# An added line that introduces a PYEYE_* environment/config key.
+_ENV_KEY = re.compile(r"^\+.*\b(PYEYE_[A-Z0-9_]+)\b")
+# An added line introducing a quoted dict key (group 1 = key).
+_DICT_KEY = re.compile(r"""^\+.*["']([A-Za-z_][\w.]*)["']\s*:""")
+# Function names that imply an output/serialisation contract.
+_OUTPUT_FUNC = re.compile(
+    r"(report|schema|export|stats|serialize|serialise|to_dict|to_json|metrics|summary)",
+    re.IGNORECASE,
+)
+# Paths whose changes should NOT trigger a nudge (per the decision-log skill:
+# new test cases / docs are not contract surfaces).
+_EXCLUDED_PREFIXES = ("tests/", "docs/")
+
+
+def _is_contract_name(name: str) -> bool:
+    """True for public names and dunders; False for private helpers.
+
+    ``resolve`` / ``ProjectCache`` -> True. ``__init__`` (constructor contract)
+    -> True. ``_helper`` / ``__mangled`` -> False.
+    """
+    if name.startswith("__") and name.endswith("__"):
+        return True
+    return not name.startswith("_")
+
+
+def _commit_diff(ref: str) -> str:
+    """Return the diff for *ref* with the commit message suppressed."""
+    return subprocess.run(
+        ["git", "show", "--format=", ref],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def scan(diff: str) -> dict[str, set[str]]:
+    """Return detected contract surfaces grouped by kind.
+
+    Tracks the current file via ``+++ b/<path>`` headers so excluded paths
+    (tests/docs) contribute nothing.
+    """
+    signatures: set[str] = set()
+    env_keys: set[str] = set()
+    output_keys: set[str] = set()
+    current_excluded = False
+    enclosing: str | None = None  # nearest def/class name (from hunk headers)
+
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[len("+++ b/") :]
+            current_excluded = path.startswith(_EXCLUDED_PREFIXES) or not path.endswith(".py")
+            enclosing = None
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("@@"):
+            # The hunk header's trailing context carries the enclosing def/class.
+            ctx = line.split("@@")[-1]
+            m = _DEF_IN_CONTEXT.search(ctx)
+            enclosing = m.group(1) if m else None
+            continue
+        if current_excluded:
+            continue
+        sig = _SIGNATURE.match(line)
+        if sig and _is_contract_name(sig.group(1)):
+            signatures.add(sig.group(1))
+        env = _ENV_KEY.match(line)
+        if env:
+            env_keys.add(env.group(1))
+        key = _DICT_KEY.match(line)
+        if key and enclosing and _OUTPUT_FUNC.search(enclosing):
+            output_keys.add(key.group(1))
+
+    found: dict[str, set[str]] = {}
+    if signatures:
+        found["public signature"] = signatures
+    if env_keys:
+        found["config/env key"] = env_keys
+    if output_keys:
+        found["output-shape key"] = output_keys
+    return found
+
+
+def main(argv: list[str]) -> int:
+    """Scan the committed diff and print a one-line decision-log nudge.
+
+    Always returns 0 so the post-commit hook never blocks a commit, and
+    stays silent unless the diff touches a recognised contract surface.
+    """
+    ref = argv[1] if len(argv) > 1 else "HEAD"
+    try:
+        diff = _commit_diff(ref)
+    except subprocess.CalledProcessError:
+        return 0  # never block a commit over our own failure
+
+    found = scan(diff)
+    if not found:
+        return 0  # silent on trivial commits
+
+    parts = [f"{kind} ({', '.join(sorted(names))})" for kind, names in found.items()]
+    print(
+        f"decision-log: this commit touches a contract surface — {'; '.join(parts)}. "
+        f"Consider proposing an entry (skill: decision-log). This is a suggestion, not a gate."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/decision_log_nudge.py
+++ b/scripts/decision_log_nudge.py
@@ -48,9 +48,10 @@ _OUTPUT_FUNC = re.compile(
     r"(report|schema|export|stats|serialize|serialise|to_dict|to_json|metrics|summary)",
     re.IGNORECASE,
 )
-# Paths whose changes should NOT trigger a nudge (per the decision-log skill:
-# new test cases / docs are not contract surfaces).
-_EXCLUDED_PREFIXES = ("tests/", "docs/")
+# Only the shipped package is a contract surface. An allowlist (rather than a
+# tests/docs blocklist) keeps dev tooling — scripts/ (incl. this script), ci,
+# config — from nagging, which is what trains people to ignore the nudge.
+_INCLUDED_PREFIX = "src/"
 
 
 def _is_contract_name(name: str) -> bool:
@@ -89,7 +90,7 @@ def scan(diff: str) -> dict[str, set[str]]:
     for line in diff.splitlines():
         if line.startswith("+++ b/"):
             path = line[len("+++ b/") :]
-            current_excluded = path.startswith(_EXCLUDED_PREFIXES) or not path.endswith(".py")
+            current_excluded = not path.startswith(_INCLUDED_PREFIX) or not path.endswith(".py")
             enclosing = None
             continue
         if line.startswith("+++") or line.startswith("---"):

--- a/src/pyeye/file_artifact_cache.py
+++ b/src/pyeye/file_artifact_cache.py
@@ -115,9 +115,19 @@ class FileArtifactCache:
 
     def __init__(
         self,
-        ast_max_entries: int = 500,
+        ast_max_entries: int | None = None,
     ) -> None:
-        """Initialise the cache with the given combined entry cap."""
+        """Initialise the cache with the given combined entry cap.
+
+        When *ast_max_entries* is ``None`` the cap is taken from
+        ``settings.artifact_cache_max_entries`` (env ``PYEYE_ARTIFACT_CACHE_MAX_ENTRIES``),
+        so large codebases can grow the cache without code changes (#397). An
+        explicit argument always wins — used by tests and targeted tuning.
+        """
+        if ast_max_entries is None:
+            from .settings import settings
+
+            ast_max_entries = settings.artifact_cache_max_entries
         self._ast_max_entries = ast_max_entries
 
         # AST store: _FileKey -> ast.Module (LRU, shared count cap with Script)

--- a/src/pyeye/metrics.py
+++ b/src/pyeye/metrics.py
@@ -251,10 +251,17 @@ class MetricsCollector:
             else:
                 other_metrics[name] = stats
 
+        # The AST/Script cache (file_artifact_cache) keeps its own counters and
+        # is otherwise wired to no report — surface it as a distinct section so a
+        # cap-thrashing run is visible (it is the cache that actually accelerates
+        # navigation). Lazy import avoids any import-time coupling.
+        from . import file_artifact_cache
+
         return {
             "uptime_seconds": uptime_seconds,
             "memory": self.get_memory_stats(),
             "cache": self.cache_metrics.get_stats(),
+            "artifact_cache": file_artifact_cache.stats(),
             "operations": {
                 "symbol_search": symbol_metrics,
                 "file_operations": file_metrics,
@@ -334,6 +341,20 @@ class MetricsCollector:
         lines.append("# HELP pyeye_cache_misses Cache misses")
         lines.append("# TYPE pyeye_cache_misses counter")
         lines.append(f"pyeye_cache_misses {self.cache_metrics.misses}")
+
+        # AST/Script (artifact) cache metrics — separate from the result cache.
+        from . import file_artifact_cache
+
+        artifact = file_artifact_cache.stats()
+        lines.append("# HELP pyeye_artifact_cache_hits AST/Script cache hits")
+        lines.append("# TYPE pyeye_artifact_cache_hits counter")
+        lines.append(f"pyeye_artifact_cache_hits {artifact['hits']}")
+        lines.append("# HELP pyeye_artifact_cache_misses AST/Script cache misses")
+        lines.append("# TYPE pyeye_artifact_cache_misses counter")
+        lines.append(f"pyeye_artifact_cache_misses {artifact['misses']}")
+        lines.append("# HELP pyeye_artifact_cache_evictions AST/Script cache evictions")
+        lines.append("# TYPE pyeye_artifact_cache_evictions counter")
+        lines.append(f"pyeye_artifact_cache_evictions {artifact['evictions']}")
 
         # Memory metrics
         memory = self.get_memory_stats()

--- a/src/pyeye/settings.py
+++ b/src/pyeye/settings.py
@@ -28,6 +28,17 @@ class PerformanceSettings:
             max_val=86400,  # Max 24 hours
         )
 
+        # AST/Script (file_artifact_cache) combined LRU entry cap. Raise this on
+        # large codebases: when the working set exceeds the cap, repeated scans
+        # (e.g. subclasses) evict their own entries and stop benefiting from the
+        # cache. See issue #397.
+        self.artifact_cache_max_entries: int = self._get_int_env(
+            "PYEYE_ARTIFACT_CACHE_MAX_ENTRIES",
+            500,
+            min_val=1,
+            max_val=1_000_000,
+        )
+
         # File watcher settings
         self.watcher_debounce: float = self._get_float_env(
             "PYEYE_WATCHER_DEBOUNCE", 0.5, min_val=0.0, max_val=10.0
@@ -167,6 +178,7 @@ class PerformanceSettings:
 
   Caching:
     cache_ttl: {self.cache_ttl}s
+    artifact_cache_max_entries: {self.artifact_cache_max_entries}
 
   File Watching:
     watcher_debounce: {self.watcher_debounce}s

--- a/tests/test_artifact_cache_configurable.py
+++ b/tests/test_artifact_cache_configurable.py
@@ -1,0 +1,27 @@
+"""The artifact cache cap is configurable (settings-driven default).
+
+Follows from the #397 investigation: the AST/Script cache cap (formerly a
+hardcoded 500 shared between AST and Script stores) is the cheapest lever for
+large repos, so it must be tunable without code changes.
+"""
+
+from __future__ import annotations
+
+from pyeye import (
+    file_artifact_cache,
+    settings as settings_mod,
+)
+
+
+def test_default_cap_follows_settings(monkeypatch):
+    """FileArtifactCache() with no argument uses the configured cap."""
+    monkeypatch.setattr(settings_mod.settings, "artifact_cache_max_entries", 1234)
+    cache = file_artifact_cache.FileArtifactCache()
+    assert cache._ast_max_entries == 1234
+
+
+def test_explicit_cap_overrides_settings(monkeypatch):
+    """An explicit constructor argument still wins (test isolation, tuning)."""
+    monkeypatch.setattr(settings_mod.settings, "artifact_cache_max_entries", 1234)
+    cache = file_artifact_cache.FileArtifactCache(ast_max_entries=7)
+    assert cache._ast_max_entries == 7

--- a/tests/test_artifact_cache_metrics_surface.py
+++ b/tests/test_artifact_cache_metrics_surface.py
@@ -1,0 +1,97 @@
+"""The AST/Script (file_artifact_cache) stats must be visible in the
+performance report.
+
+Regression guard for the metrics-fragmentation gap found while investigating
+#397: ``get_performance_metrics`` surfaced only the result/scoped cache, so a
+healthy run and a cap-thrashing run reported identically. The artifact cache —
+the one that actually accelerates navigation — was wired to no report.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyeye import file_artifact_cache
+from pyeye.metrics import MetricsCollector
+
+
+@pytest.fixture()
+def fresh_artifact_cache():
+    """Swap in a clean default cache and restore the original afterwards."""
+    original = file_artifact_cache._default_cache
+    file_artifact_cache._default_cache = file_artifact_cache.FileArtifactCache(ast_max_entries=500)
+    try:
+        yield file_artifact_cache
+    finally:
+        file_artifact_cache._default_cache = original
+
+
+def test_performance_report_surfaces_artifact_cache_stats(tmp_path, fresh_artifact_cache):
+    """A miss-then-hit on the artifact cache shows up in the performance report."""
+    src = tmp_path / "m.py"
+    src.write_text("class A:\n    pass\n", encoding="utf-8")
+
+    fresh_artifact_cache.get_ast(src)  # miss (cold)
+    fresh_artifact_cache.get_ast(src)  # hit (unchanged mtime)
+
+    report = MetricsCollector().get_performance_report()
+
+    assert "artifact_cache" in report, "performance report omits the AST/Script cache"
+    assert report["artifact_cache"] == fresh_artifact_cache.stats()
+    assert report["artifact_cache"]["hits"] == 1
+    assert report["artifact_cache"]["misses"] == 1
+    assert report["artifact_cache"]["evictions"] == 0
+
+
+def test_prometheus_export_surfaces_artifact_cache(tmp_path, fresh_artifact_cache):
+    """Artifact-cache counters are exported as Prometheus series too."""
+    src = tmp_path / "p.py"
+    src.write_text("class B:\n    pass\n", encoding="utf-8")
+    fresh_artifact_cache.get_ast(src)  # miss
+    fresh_artifact_cache.get_ast(src)  # hit
+
+    text = MetricsCollector().export_prometheus()
+
+    assert "pyeye_artifact_cache_hits 1" in text
+    assert "pyeye_artifact_cache_misses 1" in text
+    assert "pyeye_artifact_cache_evictions 0" in text
+
+
+def test_report_makes_cap_thrash_visible(tmp_path):
+    """Over-cap eviction thrash is now visible in the report; under-cap is not.
+
+    Before this fix the surfaced metric was identical for both regimes — the
+    core blind spot from the #397 investigation. This pins the new behaviour:
+    parsing more distinct files than the cap allows produces evictions in the
+    report, while a cap that fits the working set does not.
+    """
+    files = []
+    for i in range(10):
+        f = tmp_path / f"f{i}.py"
+        f.write_text(f"class C{i}:\n    pass\n", encoding="utf-8")
+        files.append(f)
+
+    original = file_artifact_cache._default_cache
+    try:
+        # Under cap: working set (10) fits -> no evictions.
+        file_artifact_cache._default_cache = file_artifact_cache.FileArtifactCache(
+            ast_max_entries=50
+        )
+        for f in files:
+            file_artifact_cache.get_ast(f)
+        healthy = MetricsCollector().get_performance_report()["artifact_cache"]
+
+        # Over cap: working set (10) exceeds cap (3) -> eviction thrash.
+        file_artifact_cache._default_cache = file_artifact_cache.FileArtifactCache(
+            ast_max_entries=3
+        )
+        for f in files:
+            file_artifact_cache.get_ast(f)
+        thrashing = MetricsCollector().get_performance_report()["artifact_cache"]
+    finally:
+        file_artifact_cache._default_cache = original
+
+    assert healthy["evictions"] == 0
+    assert thrashing["evictions"] > 0
+    # The distinguishing signal the old surfaced metric could not show.
+    assert thrashing["evictions"] != healthy["evictions"]

--- a/tests/test_decision_log_nudge.py
+++ b/tests/test_decision_log_nudge.py
@@ -79,6 +79,16 @@ def test_tests_and_docs_paths_ignored():
     assert nudge.scan(_diff("docs/guide.md", body)) == {}
 
 
+def test_non_shipped_paths_ignored():
+    """Only the shipped surface (src/) is a contract surface — dev tooling isn't.
+
+    Guards against the nudge firing on its own kind of change (scripts/, ci, etc.).
+    """
+    body = "@@ -1,0 +1,1 @@\n+def scan(diff):\n"
+    assert nudge.scan(_diff("scripts/decision_log_nudge.py", body)) == {}
+    assert nudge.scan(_diff("noxfile.py", body)) == {}
+
+
 def test_trivial_body_change_silent():
     body = "@@ -1,1 +1,1 @@ def existing(self):\n-    return 1\n+    return 2\n"
     assert nudge.scan(_diff("src/pyeye/x.py", body)) == {}

--- a/tests/test_decision_log_nudge.py
+++ b/tests/test_decision_log_nudge.py
@@ -1,0 +1,84 @@
+"""Tests for the decision-log post-commit nudge's contract-surface detector.
+
+Drives the tightened net: dunder/constructor signatures and output-shape
+dict-key additions must be caught; private helpers, tests/docs, and trivial
+body edits must stay silent (a nudge you learn to ignore is worse than none).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "decision_log_nudge.py"
+_spec = importlib.util.spec_from_file_location("decision_log_nudge", _SCRIPT)
+assert _spec and _spec.loader
+nudge = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(nudge)
+
+
+def _diff(path: str, body: str) -> str:
+    """Wrap hunk *body* in a minimal git-show diff for *path*."""
+    return f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n{body}"
+
+
+def test_public_signature_change_detected():
+    body = "@@ -1,1 +1,1 @@\n-def resolve(handle):\n+def resolve(handle, scope):\n"
+    found = nudge.scan(_diff("src/pyeye/x.py", body))
+    assert "resolve" in found["public signature"]
+
+
+def test_constructor_dunder_signature_detected():
+    """Changing __init__ is a public constructor contract — must be caught."""
+    body = (
+        "@@ -1,1 +1,1 @@\n-    def __init__(self, cap=500):\n+    def __init__(self, cap=None):\n"
+    )
+    found = nudge.scan(_diff("src/pyeye/cache.py", body))
+    assert "__init__" in found["public signature"]
+
+
+def test_private_helper_signature_ignored():
+    body = "@@ -1,1 +1,1 @@\n-def _helper(a):\n+def _helper(a, b):\n"
+    found = nudge.scan(_diff("src/pyeye/x.py", body))
+    assert "public signature" not in found
+
+
+def test_env_key_detected():
+    body = '@@ -1,0 +1,1 @@\n+    self.x = self._get_int_env("PYEYE_NEW_KNOB", 5)\n'
+    found = nudge.scan(_diff("src/pyeye/settings.py", body))
+    assert "PYEYE_NEW_KNOB" in found["config/env key"]
+
+
+def test_output_shape_dict_key_in_report_detected():
+    """Adding a key to a *report* function's return dict is an output contract."""
+    body = (
+        "@@ -1,3 +1,4 @@ def get_performance_report(self) -> dict:\n"
+        "         return {\n"
+        '             "cache": self.cache_metrics.get_stats(),\n'
+        '+            "artifact_cache": file_artifact_cache.stats(),\n'
+        "         }\n"
+    )
+    found = nudge.scan(_diff("src/pyeye/metrics.py", body))
+    assert "artifact_cache" in found["output-shape key"]
+
+
+def test_dict_key_in_non_output_function_ignored():
+    body = (
+        "@@ -1,2 +1,3 @@ def _build_internal(self):\n"
+        "         d = {\n"
+        '+            "scratch": 1,\n'
+        "         }\n"
+    )
+    found = nudge.scan(_diff("src/pyeye/x.py", body))
+    assert "output-shape key" not in found
+
+
+def test_tests_and_docs_paths_ignored():
+    body = "@@ -1,1 +1,1 @@\n-def public_thing():\n+def public_thing(x):\n"
+    assert nudge.scan(_diff("tests/test_x.py", body)) == {}
+    assert nudge.scan(_diff("docs/guide.md", body)) == {}
+
+
+def test_trivial_body_change_silent():
+    body = "@@ -1,1 +1,1 @@ def existing(self):\n-    return 1\n+    return 2\n"
+    assert nudge.scan(_diff("src/pyeye/x.py", body)) == {}

--- a/tests/unit/core/test_settings.py
+++ b/tests/unit/core/test_settings.py
@@ -21,6 +21,19 @@ class TestPerformanceSettings:
         assert settings.analysis_timeout == 30.0
         assert settings.enable_memory_profiling is False
         assert settings.enable_performance_metrics is False
+        assert settings.artifact_cache_max_entries == 500
+
+    def test_artifact_cache_max_entries_env_override(self):
+        """PYEYE_ARTIFACT_CACHE_MAX_ENTRIES tunes the AST/Script cache cap."""
+        with patch.dict(os.environ, {"PYEYE_ARTIFACT_CACHE_MAX_ENTRIES": "2000"}):
+            settings = PerformanceSettings()
+            assert settings.artifact_cache_max_entries == 2000
+
+    def test_artifact_cache_max_entries_min_validation(self):
+        """A sub-minimum cap is clamped to the minimum (must hold >=1 entry)."""
+        with patch.dict(os.environ, {"PYEYE_ARTIFACT_CACHE_MAX_ENTRIES": "0"}):
+            settings = PerformanceSettings()
+            assert settings.artifact_cache_max_entries == 1
 
     def test_env_var_override(self):
         """Test environment variables override defaults."""


### PR DESCRIPTION
## Summary

Came out of investigating #397 (subclasses/imported_by re-scan cost). Before building the graph cache, this PR ships the **measurement instrument** and the **cheapest lever**, plus a process tool that emerged from the work:

1. **Surface the AST/Script (artifact) cache stats** in the performance report. This cache — the one that actually accelerates navigation — was wired to no report, so a healthy run and a cap-thrashing run reported *identically*. Now `get_performance_report()` has an `artifact_cache` section and `export_prometheus()` emits `pyeye_artifact_cache_{hits,misses,evictions}`.
2. **Make the cache cap configurable** via `PYEYE_ARTIFACT_CACHE_MAX_ENTRIES` (default 500, min 1, max 1_000_000). On large repos the working set exceeds the hardcoded 500, so repeated scans evict their own entries and stop benefiting from the cache; raising the cap is the cheapest first win. Confirmed end-to-end: env `=15` → 102 evictions / no repeat speedup; `=5000` → 0 evictions / ~12× repeat speedup.
3. **Decision-log entries** for both, in `docs/decisions/DECISIONS.md`.
4. **Non-blocking post-commit `decision-log-nudge` hook** (#399) — a deterministic, suggestion-only signal that flags commits touching a contract surface, scoped to `src/`. Closes the handoff gap where the commit-checkpoint trigger relied on the agent remembering to surface it.

## Why this, before the #397 graph cache

The same `expand subclasses` run twice cost the same (no cross-call memoization) — but *why* it doesn't help is environment-dependent (cap-thrash vs. goto-bound). The surfaced `evictions` counter is exactly the instrument needed to tell which regime a given repo is in, and the configurable cap is the zero-risk lever to try first. The graph cache (Option B / Layer-A) is the next PR.

## What is NOT in this PR

- The inverted class/import graph cache (the core of #397) — deliberately deferred to a follow-up; this PR is the measurement + cheap-lever groundwork.

## Test plan

- [x] `tests/test_artifact_cache_metrics_surface.py` — report + Prometheus expose artifact-cache stats; over-cap (evictions>0) is now distinguishable from under-cap (evictions==0).
- [x] `tests/test_artifact_cache_configurable.py` + `tests/unit/core/test_settings.py` — settings default / env override / clamp; explicit-arg precedence.
- [x] `tests/test_decision_log_nudge.py` — 9 tests covering signature/dunder/env/output-shape detection and the tests/docs/non-shipped exclusions.
- [x] Full suite green (86.79% coverage) apart from the known flaky `test_scope_performance.py::...::test_cache_hit_performance` (#383/#384), which passes in isolation.

## Notes

- The post-commit hook activates on the next `pre-commit install`; it was intentionally NOT installed in-session because worktrees share `.git/hooks` with the main checkout.
- Honest residual limits of the nudge are documented in #399 and the script docstring.

Addresses #397
Fixes #399