### PR TITLE
fix(resolve): report methods as kind="method" consistently (#406)

### DIFF
--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -55,7 +55,10 @@ from pyeye._module_sentinel import ModuleSentinel
 from pyeye.canonicalization import collect_re_exports, find_module_file
 from pyeye.handle import Handle
 from pyeye.mcp.operations.edges import resolve_members, resolve_superclasses
-from pyeye.mcp.operations.resolve import _normalise_kind  # reuse kind table
+
+# Kind normalisation + method detection live in resolve (the lower-level module)
+# so resolve, inspect, and stubs share one source of truth (#406).
+from pyeye.mcp.operations.resolve import _normalise_kind_from_name
 from pyeye.mcp.operations.typeref import build_typeref
 from pyeye.scope import classify_scope
 
@@ -127,33 +130,6 @@ def _make_location(
     if column_end is not None:
         loc["column_end"] = column_end
     return loc
-
-
-def _is_method(jedi_name: Any) -> bool:
-    """Return True if *jedi_name* is a method (a function enclosed by a class).
-
-    Reads the resolved Jedi ``Name``'s parent scope directly via
-    ``Name.parent()`` instead of re-deriving the enclosing scope from the dotted
-    handle.  Dotted-name string arithmetic plus a filesystem module lookup
-    cannot see class nesting — for ``module.Outer.Inner.method`` it treats
-    ``Outer`` as a module, fails to find it, and misclassifies the nested-class
-    method as a plain function (issue #337).  Using ``parent()`` also avoids a
-    redundant per-call Jedi ``Script`` load.
-
-    Args:
-        jedi_name: The resolved Jedi ``Name`` object for the symbol.
-
-    Returns:
-        ``True`` when the symbol is a function whose immediate enclosing scope
-        is a class (at any nesting depth).
-    """
-    if getattr(jedi_name, "type", None) != "function":
-        return False
-    try:
-        parent = jedi_name.parent()
-    except Exception:
-        return False
-    return parent is not None and getattr(parent, "type", None) == "class"
 
 
 def _extract_function_flags_from_ast(file_path: Path, line: int) -> tuple[bool, bool, bool]:
@@ -923,10 +899,8 @@ async def inspect(handle: str, analyzer: JediAnalyzer) -> dict[str, Any]:
 
     scope = classify_scope(file_str, analyzer) if file_str else "external"
 
-    jedi_type: str = getattr(jedi_name, "type", None) or "statement"
-    # Determine if this function is actually a method
-    raw_kind = _normalise_kind(jedi_type)
-    kind = "method" if raw_kind == "function" and _is_method(jedi_name) else raw_kind
+    # Normalise kind, promoting class-enclosed functions to "method" (#406).
+    kind = _normalise_kind_from_name(jedi_name)
 
     location = location_from_name(file_str, jedi_name)
 

--- a/src/pyeye/mcp/operations/resolve.py
+++ b/src/pyeye/mcp/operations/resolve.py
@@ -30,12 +30,17 @@ Kind normalisation
 Jedi's ``Name.type`` is mapped to the API kind vocabulary:
 
     class      → "class"
-    function   → "function"
+    function   → "function"  (→ "method" when enclosed by a class)
     module     → "module"
     statement  → "variable"
     param      → "variable"
     property   → "property"
     keyword    → "variable"  (rare; included for completeness)
+
+A class-enclosed function is promoted to ``"method"`` via
+``_normalise_kind_from_name`` — the single normalisation helper shared by
+``resolve``, ``inspect``, and the stub builder so all three primitives agree on
+``kind`` for the same symbol (issue #406).
 
 Deterministic ambiguous ordering
 ---------------------------------
@@ -190,6 +195,59 @@ def _normalise_kind(jedi_type: str | None) -> str:
     return _JEDI_TYPE_TO_KIND.get(jedi_type, jedi_type)
 
 
+def _is_method(jedi_name: Any) -> bool:
+    """Return True if *jedi_name* is a method (a function enclosed by a class).
+
+    Reads the resolved Jedi ``Name``'s parent scope directly via
+    ``Name.parent()`` instead of re-deriving the enclosing scope from the dotted
+    handle.  Dotted-name string arithmetic plus a filesystem module lookup
+    cannot see class nesting — for ``module.Outer.Inner.method`` it treats
+    ``Outer`` as a module, fails to find it, and misclassifies the nested-class
+    method as a plain function (issue #337).  Using ``parent()`` also avoids a
+    redundant per-call Jedi ``Script`` load.
+
+    Lives here (rather than in ``inspect``) so the resolve path can apply the
+    same promotion without a circular import — ``inspect`` and ``stubs`` import
+    it from this module (issue #406).
+
+    Args:
+        jedi_name: The resolved Jedi ``Name`` object for the symbol.
+
+    Returns:
+        ``True`` when the symbol is a function whose immediate enclosing scope
+        is a class (at any nesting depth).
+    """
+    if getattr(jedi_name, "type", None) != "function":
+        return False
+    try:
+        parent = jedi_name.parent()
+    except Exception:
+        return False
+    return parent is not None and getattr(parent, "type", None) == "class"
+
+
+def _normalise_kind_from_name(jedi_name: Any) -> str:
+    """Normalise a Jedi ``Name`` to the API kind, promoting methods.
+
+    The single source of truth for kind normalisation across ``resolve``,
+    ``inspect``, and the stub builder.  Maps ``Name.type`` via
+    :func:`_normalise_kind`, then promotes a class-enclosed function from
+    ``"function"`` to ``"method"`` via :func:`_is_method`.
+
+    Before #406 only ``inspect`` and ``stubs`` applied this promotion, so the
+    resolve path reported a method as ``"function"`` while the others reported
+    ``"method"`` — three primitives, two answers, one symbol.
+
+    Args:
+        jedi_name: The resolved Jedi ``Name`` object for the symbol.
+
+    Returns:
+        The API kind string, with ``"method"`` substituted for a method.
+    """
+    raw_kind = _normalise_kind(getattr(jedi_name, "type", None))
+    return "method" if raw_kind == "function" and _is_method(jedi_name) else raw_kind
+
+
 # ---------------------------------------------------------------------------
 # Scope ordering helper
 # ---------------------------------------------------------------------------
@@ -294,7 +352,7 @@ async def _resolve_at_position(
     # Determine file for scope classification
     def_file = name.module_path.as_posix() if name.module_path else file_path.as_posix()
     scope = classify_scope(def_file, analyzer)
-    kind = _normalise_kind(name.type)
+    kind = _normalise_kind_from_name(name)
 
     return _SuccessResult(
         found=True,
@@ -464,7 +522,6 @@ async def _build_success_from_match(match: dict[str, Any], analyzer: JediAnalyze
     """Build a _SuccessResult from a single find_symbol match dict."""
     full_name = match.get("full_name", "")
     file_str = match.get("file", "")
-    kind = _normalise_kind(match.get("type"))
 
     # Canonicalise
     handle = await resolve_canonical(full_name, analyzer)
@@ -481,11 +538,15 @@ async def _build_success_from_match(match: dict[str, Any], analyzer: JediAnalyze
 
     # Attempt to get a real Jedi Name for the span (column_end + line_end).
     # Falls back to the degenerate _make_location shape when lookup fails.
+    # The Jedi Name also drives method promotion (function → method, #406);
+    # the match dict's flat ``type`` cannot see class nesting.
     jedi_name = _get_jedi_name_from_match(file_posix, match_line, match_col, analyzer)
     if jedi_name is not None:
         location = cast(_Location, location_from_name(file_posix, jedi_name))
+        kind = _normalise_kind_from_name(jedi_name)
     else:
         location = _make_location(file_posix, match_line, match_col)
+        kind = _normalise_kind(match.get("type"))
 
     return _SuccessResult(
         found=True,
@@ -502,7 +563,6 @@ async def _build_candidate_from_match(
     """Build a _Candidate dict from a single find_symbol match dict."""
     full_name = match.get("full_name", "")
     file_str = match.get("file", "")
-    kind = _normalise_kind(match.get("type"))
 
     if not full_name:
         return None
@@ -522,11 +582,15 @@ async def _build_candidate_from_match(
     file_posix = Path(file_str).as_posix() if file_str else ""
 
     # Attempt to get a real Jedi Name for the span (column_end + line_end).
-    # Falls back to the degenerate point shape when lookup fails.
+    # Falls back to the degenerate point shape when lookup fails.  The Jedi Name
+    # also drives method promotion (function → method, #406) so candidates carry
+    # the same kind a later resolve/inspect of the chosen handle would report.
     jedi_name = _get_jedi_name_from_match(file_posix, match_line, match_col, analyzer)
     if jedi_name is not None:
         loc = cast(_Location, location_from_name(file_posix, jedi_name))
+        kind = _normalise_kind_from_name(jedi_name)
     else:
+        kind = _normalise_kind(match.get("type"))
         loc = _Location(
             file=file_posix,
             line_start=match_line,
@@ -552,8 +616,15 @@ def _kind_for_canonical(canonical_handle: str, analyzer: JediAnalyzer) -> str:
     """Look up kind by re-deriving from the canonical handle's definition site.
 
     Used as a fallback when ``find_symbol`` leaf search doesn't return the
-    matching symbol.  Splits the handle into ``<module>.<leaf>``, resolves the
-    module file, then searches ``jedi.Script.get_names`` for the symbol.
+    matching symbol.  Walks the dotted handle up to its enclosing module file,
+    then searches ``jedi.Script.get_names`` (all scopes) for the symbol and
+    normalises its kind — promoting class-enclosed functions to ``"method"``.
+
+    The handle may name a nested symbol (``Class.method``, ``Outer.Inner``) whose
+    module is several components up, so we strip trailing components until
+    ``find_module_file`` succeeds rather than splitting only at the last dot —
+    the old single split treated the class as a module, missed the symbol, and
+    fell through to ``"variable"`` (issue #406).
 
     Returns ``"module"`` for a bare module name (no dot), ``"variable"`` when
     the kind genuinely cannot be determined (safest Python kind — every binding
@@ -561,18 +632,24 @@ def _kind_for_canonical(canonical_handle: str, analyzer: JediAnalyzer) -> str:
     """
     from pyeye.canonicalization import find_module_file
 
-    parts = canonical_handle.rsplit(".", 1)
-    if len(parts) != 2:
+    if "." not in canonical_handle:
         return "module"  # bare module name
-    module_path, _ = parts
-    module_file = find_module_file(module_path, analyzer)
+
+    module_file = None
+    prefix = canonical_handle
+    while "." in prefix:
+        prefix = prefix.rsplit(".", 1)[0]
+        module_file = find_module_file(prefix, analyzer)
+        if module_file is not None:
+            break
     if module_file is None:
         return "variable"  # safer default than "class"
+
     script = file_artifact_cache.get_script(module_file, analyzer.project)
     try:
         for name_obj in script.get_names(all_scopes=True, definitions=True, references=False):
             if name_obj.full_name == canonical_handle:
-                return _normalise_kind(name_obj.type) or "variable"
+                return _normalise_kind_from_name(name_obj) or "variable"
     except Exception as exc:
         logger.debug("_kind_for_canonical(%r): get_names failed: %s", canonical_handle, exc)
     return "variable"
@@ -618,7 +695,7 @@ async def _resolve_external_dotted_name(name: str, analyzer: JediAnalyzer) -> _S
 
         def_file = jedi_name.module_path.as_posix() if jedi_name.module_path else ""
         scope = classify_scope(def_file, analyzer) if def_file else "external"
-        kind = _normalise_kind(jedi_name.type)
+        kind = _normalise_kind_from_name(jedi_name)
 
         if def_file:
             location = cast(_Location, location_from_name(def_file, jedi_name))
@@ -660,33 +737,40 @@ async def _resolve_dotted_name(name: str, analyzer: JediAnalyzer) -> ResolveResu
 
     # Try to find the match whose full_name matches our canonical handle
     file_str = ""
-    kind: str | None = None
+    matched_type: str | None = None
+    match_found = False
     match_line: int | None = None
     match_column: int | None = None
     for match in matches:
         if match.get("full_name") == str(handle):
             file_str = match.get("file", "")
-            kind = _normalise_kind(match.get("type"))
+            matched_type = match.get("type")
             match_line = match.get("line")
             match_column = match.get("column")
+            match_found = True
             break
     else:
         # Fallback: use the file derived from the handle path
         file_str = _handle_to_file(handle, analyzer) or ""
 
-    if kind is None:
-        # Leaf search missed — recover kind from the canonical handle's definition site
-        kind = _kind_for_canonical(str(handle), analyzer)
-
     scope = classify_scope(file_str, analyzer) if file_str else "external"
     file_posix = Path(file_str).as_posix() if file_str else ""
 
     # Attempt span location via Jedi Name; fall back to degenerate point location.
+    # The Jedi Name is also the only source that can promote function → method
+    # (the flat match ``type`` cannot see class nesting, #406); prefer it for
+    # kind, then fall back to the match type, then to canonical re-derivation.
     jedi_name = _get_jedi_name_from_match(file_posix, match_line, match_column, analyzer)
     if jedi_name is not None:
         location = cast(_Location, location_from_name(file_posix, jedi_name))
+        kind = _normalise_kind_from_name(jedi_name)
     else:
         location = _make_location(file_posix, match_line, match_column)
+        if match_found:
+            kind = _normalise_kind(matched_type)
+        else:
+            # Leaf search missed — recover kind from the canonical definition site
+            kind = _kind_for_canonical(str(handle), analyzer)
 
     return _SuccessResult(
         found=True,

--- a/src/pyeye/mcp/operations/stubs.py
+++ b/src/pyeye/mcp/operations/stubs.py
@@ -46,8 +46,7 @@ Reuse policy (#330)
 -------------------
 All helpers come from existing modules — no second implementation:
 
-- Kind normalisation: ``pyeye.mcp.operations.resolve._normalise_kind``
-- Method detection:   ``pyeye.mcp.operations.inspect._is_method``
+- Kind + method:      ``pyeye.mcp.operations.resolve._normalise_kind_from_name``
 - Signature:          ``pyeye.mcp.operations.inspect._build_signature``
 - Scope:              ``pyeye.scope.classify_scope``
 - Span:               ``pyeye._jedi_location.get_end_line``
@@ -67,8 +66,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from pyeye._jedi_location import get_end_line
-from pyeye.mcp.operations.inspect import _build_signature, _is_method
-from pyeye.mcp.operations.resolve import _normalise_kind
+from pyeye.mcp.operations.inspect import _build_signature
+from pyeye.mcp.operations.resolve import _normalise_kind_from_name
 from pyeye.scope import classify_scope
 
 if TYPE_CHECKING:
@@ -96,10 +95,9 @@ def build_stub(jedi_name: Any, handle: str, analyzer: JediAnalyzer) -> dict[str,
         A Stub dict conforming to spec §4.1.
     """
     # ------------------------------------------------------------------
-    # 1. Kind — normalise then promote function → method when applicable
+    # 1. Kind — normalise, promoting function → method when applicable (#406)
     # ------------------------------------------------------------------
-    raw_kind = _normalise_kind(getattr(jedi_name, "type", None))
-    kind = "method" if raw_kind == "function" and _is_method(jedi_name) else raw_kind
+    kind = _normalise_kind_from_name(jedi_name)
 
     # ------------------------------------------------------------------
     # 2. Scope — pure path comparison via classify_scope

--- a/tests/unit/mcp/operations/test_resolve.py
+++ b/tests/unit/mcp/operations/test_resolve.py
@@ -880,6 +880,82 @@ class TestResolveAt:
 
 
 # ---------------------------------------------------------------------------
+# Method-kind consistency (issue #406)
+# ---------------------------------------------------------------------------
+
+
+class TestMethodKindConsistency:
+    """Regression tests for #406: every resolve path must report a method as
+    ``kind="method"``, consistent with ``inspect``/``outline``.
+
+    The fixture method is ``Widget.greet`` at ``widgets.py:37`` (``def greet``;
+    column 8 is the ``g`` of ``greet``).  Before the fix, the resolve path mapped
+    Jedi's ``type="function"`` straight to ``"function"`` while ``inspect`` and the
+    stub builder promoted it to ``"method"`` via ``_is_method`` — three primitives,
+    two answers, one symbol.
+    """
+
+    METHOD_HANDLE = "mypackage._core.widgets.Widget.greet"
+
+    @pytest.mark.asyncio
+    async def test_resolve_at_method_kind_is_method(self, analyzer: JediAnalyzer) -> None:
+        """resolve_at on a method reports kind='method', not 'function'."""
+        from pyeye.mcp.operations.resolve import resolve_at
+
+        widgets_path = str(_FIXTURE / "mypackage" / "_core" / "widgets.py")
+        # Line 37: "    def greet(self) -> str:" — column 8 is 'g' of greet.
+        result = await resolve_at(widgets_path, 37, 8, analyzer)
+
+        assert result["found"] is True, f"Expected found=True, got: {result}"
+        assert result["handle"] == self.METHOD_HANDLE
+        assert (
+            result["kind"] == "method"
+        ), f"resolve_at should report a method as 'method', got: {result['kind']!r}"
+
+    @pytest.mark.asyncio
+    async def test_resolve_dotted_method_kind_is_method(self, analyzer: JediAnalyzer) -> None:
+        """resolve on a dotted method handle reports kind='method'."""
+        from pyeye.mcp.operations.resolve import resolve
+
+        result = await resolve(self.METHOD_HANDLE, analyzer)
+
+        assert result["found"] is True, f"Expected found=True, got: {result}"
+        assert result["handle"] == self.METHOD_HANDLE
+        assert (
+            result["kind"] == "method"
+        ), f"resolve (dotted) should report a method as 'method', got: {result['kind']!r}"
+
+    @pytest.mark.asyncio
+    async def test_kind_for_canonical_method_is_method(self, analyzer: JediAnalyzer) -> None:
+        """The _kind_for_canonical fallback re-derives a method as 'method'."""
+        from pyeye.mcp.operations.resolve import _kind_for_canonical
+
+        kind = _kind_for_canonical(self.METHOD_HANDLE, analyzer)
+        assert (
+            kind == "method"
+        ), f"_kind_for_canonical should recover 'method' for a method, got: {kind!r}"
+
+    @pytest.mark.asyncio
+    async def test_resolve_at_and_inspect_agree_on_method_kind(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        """resolve_at and inspect must report the SAME kind for one method symbol."""
+        from pyeye.mcp.operations.inspect import inspect
+        from pyeye.mcp.operations.resolve import resolve_at
+
+        widgets_path = str(_FIXTURE / "mypackage" / "_core" / "widgets.py")
+        resolved = await resolve_at(widgets_path, 37, 8, analyzer)
+        assert resolved["found"] is True
+
+        inspected = await inspect(resolved["handle"], analyzer)
+
+        assert resolved["kind"] == inspected["kind"], (
+            "resolve_at and inspect disagree on kind for the same symbol: "
+            f"resolve_at={resolved['kind']!r} inspect={inspected['kind']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Identifier form parser — edge cases
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`resolve`/`resolve_at` reported a method's `kind` as `"function"` while `inspect`/`outline` reported `"method"` — three primitives, two answers for one symbol. An agent branching on `kind` (e.g. "is this a method?") misclassified depending on entry point.

Root cause: `inspect` and the stub builder normalised Jedi's `type="function"` to `"method"` via `_is_method`, but the resolve path mapped `"function" → "function"` directly without that promotion.

## Changes

- Factor kind-normalisation + method-promotion into a single shared helper, `_normalise_kind_from_name(jedi_name)`, in `resolve.py`. `_is_method` moves there too (the lower-level module) so the resolve path can apply the promotion without a circular import; `inspect` and `stubs` now import the shared helper instead of duplicating the `function → method` check.
- Apply it at **every** resolve kind-producing site: `_resolve_at_position`, `_build_success_from_match`, `_build_candidate_from_match`, `_resolve_dotted_name`, `_resolve_external_dotted_name`, and `_kind_for_canonical`.
- Fix `_kind_for_canonical`: it split the handle only at the last dot, treating a class as a module (`Class.method` → look up module `…Class`, miss, fall through to `"variable"`). It now walks the dotted handle up to its enclosing module file, so methods/nested symbols resolve correctly.

## Test plan

- [x] New regression class `tests/unit/mcp/operations/test_resolve.py::TestMethodKindConsistency` — asserts `resolve_at`, `resolve` (dotted), and `_kind_for_canonical` all report `"method"` for `Widget.greet`, and that `resolve_at` and `inspect` agree on `kind` for the same symbol.
- [x] Watched all 4 tests fail (`function`/`variable`) before the fix, pass after.
- [x] Full suite: 2016 passed, coverage 86.74% (≥85% gate). The one failure under full-suite load was a known-flaky perf benchmark (`test_cache_hit_performance`) that passes in isolation and is unrelated to kind normalisation.
- [x] `pre-commit` (black, ruff, mypy, pydocstyle, PyEye conformance, detect-secrets, bandit) all pass.

Fixes #406