### PR TITLE
fix(inspect): omit signature instead of emitting "" for methods (#407)

### DIFF
--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -292,13 +292,16 @@ def _build_signature(jedi_name: Any) -> str | None:
 
     Uses Jedi's ``get_signatures()[0].to_string()`` to obtain the signature.
     Returns ``None`` if no signatures are available.  The returned string is
-    guaranteed to be single-line (no embedded newlines).
+    guaranteed to be single-line (no embedded newlines) and non-empty — an
+    empty/whitespace render normalises to ``None`` so callers never have to
+    distinguish ``""`` from "absent" (the stub contract: present-with-real-value
+    or omitted, never ``""``; issue #407).
 
     Args:
         jedi_name: A Jedi ``Name`` object.
 
     Returns:
-        A single-line signature string, or ``None``.
+        A non-empty single-line signature string, or ``None``.
     """
     try:
         sigs = jedi_name.get_signatures()
@@ -307,7 +310,8 @@ def _build_signature(jedi_name: Any) -> str | None:
             # Guard: must be single-line
             if "\n" in sig_str:
                 sig_str = sig_str.split("\n")[0]
-            return str(sig_str)
+            # Normalise an empty/whitespace render to None — never return "".
+            return str(sig_str) if sig_str and sig_str.strip() else None
     except Exception:
         pass
     return None
@@ -1043,8 +1047,12 @@ async def _build_function_fields(
     """
     fields: dict[str, Any] = {}
 
+    # Signature is OMITTED (never "") when Jedi can't render one — consistent with
+    # the class branch and the stub contract (#407).  The structured ``parameters``
+    # below remain available regardless, so consumers don't lose information.
     sig = _build_signature(jedi_name)
-    fields["signature"] = sig or ""
+    if sig is not None:
+        fields["signature"] = sig
 
     fields["parameters"] = await _build_parameters(jedi_name, file_path, analyzer)
     fields["return_type"] = await _extract_return_type(jedi_name, file_path, analyzer)

--- a/tests/unit/mcp/operations/test_inspect.py
+++ b/tests/unit/mcp/operations/test_inspect.py
@@ -410,6 +410,82 @@ class TestInspectMethod:
 
 
 # ---------------------------------------------------------------------------
+# TestInspectSignatureContract — issue #407
+# ---------------------------------------------------------------------------
+
+
+class TestInspectSignatureContract:
+    """Regression tests for #407: ``signature`` is a non-empty string or OMITTED,
+    NEVER ``""``.
+
+    A class omits ``signature`` when Jedi yields none, but ``_build_function_fields``
+    emitted ``fields["signature"] = sig or ""`` — so a method/function whose Jedi
+    signature couldn't be rendered (e.g. Django's ``Model.save``) got ``""``,
+    which reads as "measured: no signature" and violates the stub contract
+    (``stubs.py`` design notes: present-with-real-value or omitted, never ``""``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_method_omits_signature_when_jedi_yields_none(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        """When ``_build_signature`` returns None for a method, the key is omitted
+        (matching the class branch) — never set to ``""``."""
+        from unittest.mock import patch
+
+        from pyeye.mcp.operations.inspect import inspect
+
+        with patch.object(inspect_ops, "_build_signature", return_value=None):
+            result = await inspect(_GREET_HANDLE, analyzer)
+
+        assert result["kind"] == "method"
+        assert (
+            result.get("signature", "<omitted>") != ""
+        ), "signature must never be the empty string"
+        assert "signature" not in result, "signature must be OMITTED when unavailable, not empty"
+
+    @pytest.mark.asyncio
+    async def test_function_omits_signature_when_jedi_yields_none(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        """Same contract for a plain function — both flow through _build_function_fields."""
+        from unittest.mock import patch
+
+        from pyeye.mcp.operations.inspect import inspect
+
+        with patch.object(inspect_ops, "_build_signature", return_value=None):
+            result = await inspect(_MAKE_WIDGET_HANDLE, analyzer)
+
+        assert result["kind"] == "function"
+        assert result.get("signature", "<omitted>") != ""
+        assert "signature" not in result
+
+    def test_build_signature_normalises_empty_to_none(self) -> None:
+        """_build_signature returns None (never "") when Jedi renders an empty string."""
+
+        class _EmptySig:
+            def to_string(self) -> str:
+                return ""
+
+        class _FakeName:
+            def get_signatures(self) -> list[_EmptySig]:
+                return [_EmptySig()]
+
+        assert inspect_ops._build_signature(_FakeName()) is None
+
+    @pytest.mark.asyncio
+    async def test_signature_never_empty_string_across_kinds(self, analyzer: JediAnalyzer) -> None:
+        """Across class/function/method handles, signature is a non-empty string or absent."""
+        from pyeye.mcp.operations.inspect import inspect
+
+        for handle in (_WIDGET_HANDLE, _MAKE_WIDGET_HANDLE, _GREET_HANDLE):
+            result = await inspect(handle, analyzer)
+            if "signature" in result:
+                assert result["signature"] != "", f"{handle} has empty-string signature"
+                assert isinstance(result["signature"], str)
+
+
+# ---------------------------------------------------------------------------
 # TestInspectModule — fixture: mypackage._core.widgets
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`inspect` returned `"signature": ""` (empty string) for a method/function when Jedi's `get_signatures()` couldn't render one (e.g. Django's `Model.save`), while a **class omits** the key in the same situation. An empty string reads as "measured: no signature" and violates the stub contract (`stubs.py` design notes: signature is present-with-a-real-value or **omitted, never `""`**).

Root cause: `_build_function_fields` did `fields["signature"] = sig or ""`, while `_build_class_fields` does `if sig is not None: fields["signature"] = sig`. Methods/functions normally get a real signature; the `""` only surfaced when Jedi failed to render one.

## Changes

- **`_build_signature`** now normalises an empty/whitespace render to `None` — it only ever returns a non-empty single-line string or `None`. Single-source guarantee that propagates to every consumer (inspect + the stub builder).
- **`_build_function_fields`** omits the `signature` key when `None`, exactly matching the class branch and the stub contract. The structured `parameters` array remains available regardless, so no information is lost.

### Why omit rather than reconstruct from `parameters`

The maintainer's comment on #407 flagged reconstruction as the less-clean path and identified pyright `hover` as the preferred future source for real method signatures (if #333 lands). Reconstruction would also introduce a second rendering style divergent from Jedi's `to_string()`. The omit/contract-compliance fix is correct regardless of #333 and doesn't block on it.

## Test plan

- [x] New `tests/unit/mcp/operations/test_inspect.py::TestInspectSignatureContract` (4 tests): method and function omit `signature` when Jedi yields none; `_build_signature` normalises empty→`None`; `signature` is never `""` across class/function/method kinds.
- [x] Watched the 3 fix-dependent tests fail (`'' != ''`, `'' is None`) before the fix, pass after.
- [x] Full suite: 2021 passed, 8 skipped, coverage 86.74% (≥85% gate).
- [x] `pre-commit` (black, ruff, mypy, pydocstyle, conformance, detect-secrets, bandit) all pass.

Fixes #407