### PR TITLE
chore(deps): remove vestigial isort dev dependency (#410)

### DIFF
--- a/.claude/instructions/07-validation.md
+++ b/.claude/instructions/07-validation.md
@@ -101,8 +101,8 @@ assert_performance_threshold(elapsed_ms, threshold, "Operation name")
 Pre-commit runs automatically on commit and includes:
 
 - **Security scanning** (detect-secrets, bandit, pip-audit)
-- **Code formatting** (black, isort)
-- **Linting** (ruff)
+- **Code formatting** (black)
+- **Linting and import sorting** (ruff)
 - **Type checking** (mypy)
 - **Documentation checks** (pydocstyle)
 - **Cross-platform path checking** (custom hook)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dev = [
     "pip-audit>=2.6.0",  # Dependency vulnerability scanning (OSV database)
     "commitizen>=3.13.0",
     "pydocstyle==6.3.0",  # Pinned for consistent docstring checks
-    "isort==7.0.0",  # Pinned for consistent import sorting
     "tomli>=2.0.0; python_version < '3.11'",  # TOML parsing for Python 3.10
     # Note: pre-commit removed from dev deps - install at user level instead:
     # python3 -m pip install --user --break-system-packages pre-commit

--- a/src/pyeye/workflows/code_review_standards.md
+++ b/src/pyeye/workflows/code_review_standards.md
@@ -59,9 +59,8 @@ This workflow enforces:
 
 **Automated Checks** (should be in CI):
 
-- [ ] `ruff check` - Fast linter (replaces flake8)
+- [ ] `ruff check` - Fast linter and import sorting (replaces flake8, isort)
 - [ ] `black` - Code formatting
-- [ ] `isort` - Import sorting
 
 **Manual Review**:
 
@@ -341,7 +340,7 @@ except ValueError as e:
 2. Third-party libraries
 3. Local application imports
 
-**Tool**: Use `isort` to automatically organize imports
+**Tool**: Use `ruff` (the `I` import-sorting rules) to automatically organize imports
 
 **MCP Tool**: `expand(edge="imports")` on a module to review its top-level imports — check for appropriate dependencies and no circular imports.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1010,15 +1010,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
-]
-
-[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1978,7 +1969,6 @@ dev = [
     { name = "black" },
     { name = "commitizen" },
     { name = "detect-secrets" },
-    { name = "isort" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pydocstyle" },
@@ -2003,7 +1993,6 @@ requires-dist = [
     { name = "diskcache", specifier = ">=5.6.0" },
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "filelock", specifier = ">=3.13.0" },
-    { name = "isort", marker = "extra == 'dev'", specifier = "==7.0.0" },
     { name = "jedi", specifier = ">=0.19.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.13.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },


### PR DESCRIPTION
## Summary

`isort` was a dev dependency that nothing uses — import sorting is handled by **ruff** (`[tool.ruff.lint.isort]`, `I` rules). `pyproject.toml` even noted: *"isort configuration removed - using ruff's import sorting instead."*

Evidence it's vestigial:
- No `[tool.isort]` config, no `.isort.cfg`/`setup.cfg`.
- Not in `.pre-commit-config.yaml`, not in any `.github/` CI workflow.
- Not imported in `src/`, `tests/`, or `scripts/`.
- In `uv.lock`, the only package requiring isort was `pyeye-mcp` itself (no transitive need).

## Changes

- Remove `"isort==7.0.0"` from the `[project.optional-dependencies] dev` group.
- Regenerate `uv.lock` (isort dropped; 155 → 154 packages; `uv lock --check` passes).
- Fix stale docs that still listed isort as an active tool:
  - `.claude/instructions/07-validation.md` — pre-commit "Code formatting" no longer lists isort; ruff noted for import sorting.
  - `src/pyeye/workflows/code_review_standards.md` — point import-sorting guidance at ruff.

## Context

Surfaced while validating dependabot PR #298 (bump isort 7.0.0 → 8.0.1), which had also left `uv.lock` stale. Since the tool is unused, removing it is cleaner than bumping it — **this supersedes #298**, which should be closed once this merges.

## Test plan

- [x] `uv lock --check` passes; `uv.lock` no longer contains an isort entry; isort uninstalled from the venv (unimportable).
- [x] `uv run ruff check src tests` passes — import sorting unaffected (ruff owns it).
- [x] Full suite: 2020 passed, 8 skipped, coverage 86.70%. (One `test_clear_stale` failure under full-suite load is a pre-existing timing flake — passes in isolation, unrelated to a dependency removal.)
- [x] pre-commit clean on all changed files.

Fixes #410