### PR TITLE
chore(ci): single-source dev-tool versions via repo:local pre-commit hooks (#413)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: |
-          uv venv
-          uv pip install -e ".[dev]"
+        run: uv sync --all-extras  # creates .venv so the repo:local hooks' `uv run <tool>` resolves
       - uses: pre-commit/action@v3.0.1
 
   # Detect if only documentation files changed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,15 +62,19 @@ repos:
         types: [python]
         args: ['--fix', '--exit-non-zero-on-fix']
 
-      # Type checking (src only — mypy type stubs live in the pyproject dev
-      # group so `uv run mypy` picks them up)
+      # Type checking — run on the whole package as a unit (pass_filenames:
+      # false), NOT on the per-file list pre-commit would otherwise pass. mypy
+      # is a whole-program analyser; feeding it batched file subsets makes
+      # mypy 2.x INTERNAL-ERROR on a partial module graph (caught in CI on #413).
+      # This invocation is identical to the CI `type-check` job. Type stubs live
+      # in the pyproject dev group so `uv run mypy` picks them up.
       - id: mypy
         name: mypy
         entry: uv run mypy
         language: system
         types: [python]
-        args: ['--ignore-missing-imports']
-        exclude: ^tests/
+        pass_filenames: false
+        args: ['src/pyeye', '--ignore-missing-imports']
 
   # Documentation
   - repo: https://github.com/pycqa/pydocstyle

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,32 +37,38 @@ repos:
         pass_filenames: false
         files: '(requirements.*\.txt|pyproject\.toml|uv\.lock)$'
 
-  # Code formatting
-  - repo: https://github.com/psf/black
-    rev: 26.3.1
+  # Formatting / linting / type-checking run from the uv-managed venv via
+  # `uv run`, so their versions come from the single pin in pyproject.toml
+  # (dev group) rather than separate hook `rev:`s. This keeps pre-commit,
+  # `uv run <tool>`, and CI on the exact same binary — no drift (#413).
+  # Requires a synced env (`uv sync --all-extras`); CI does this before
+  # running pre-commit.
+  - repo: local
     hooks:
+      # Code formatting
       - id: black
-        language_version: python3.12
+        name: black
+        entry: uv run black
+        language: system
+        types: [python]
         args: ['--line-length=100']
 
-  # Linting (Note: Ruff handles import sorting via the "I" rule)
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.10
-    hooks:
+      # Linting (Note: Ruff handles import sorting via the "I" rule;
+      # ruff-format disabled since we use black for formatting)
       - id: ruff
+        name: ruff
+        entry: uv run ruff check
+        language: system
+        types: [python]
         args: ['--fix', '--exit-non-zero-on-fix']
-      # Note: ruff-format disabled since we use black for formatting
 
-  # Type checking
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
-    hooks:
+      # Type checking (src only — mypy type stubs live in the pyproject dev
+      # group so `uv run mypy` picks them up)
       - id: mypy
-        additional_dependencies:
-          - types-setuptools
-          - types-requests
-          - types-PyYAML
-          - types-aiofiles
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]
         args: ['--ignore-missing-imports']
         exclude: ^tests/
 

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -2,6 +2,13 @@
 
 Contract/invariant-significant, friction-driven decisions. Each entry is a small verifiable fact: Friction · Decision · Anchor (stable ref) · Verify (checkable or honestly-labelled). Newest on top. Maintained via the `decision-log` skill.
 
+## 2026-06-18 — Dev-tool versions (black/ruff/mypy) single-sourced in pyproject; pre-commit runs them via `uv run`
+
+**Friction:** black/ruff/mypy were pinned in two places — the `pyproject.toml` dev group AND `.pre-commit-config.yaml` hook `rev:`s — which drifted (e.g. mypy `v1.17.1` vs `2.1.0`, ruff `v0.12.10` vs `0.15.17`). Dependabot bumps only `pyproject.toml`, never the pre-commit revs, so `uv run mypy` (CI `type-check` job + local dev) and the pre-commit `mypy` hook ran *different* versions, and the drift recurred on every dev-tooling bump. Surfaced while validating the dev-dependencies dependabot PR (#327).
+**Decision:** Convert the black/ruff/mypy pre-commit hooks to a single `repo: local` block that invokes `uv run <tool>`, making the `pyproject.toml` dev pin the one source for pre-commit, CI, and local dev (literally the same binary — drift impossible). mypy's type-stub `additional_dependencies` moved into the pyproject dev group. Rejected: (a) bump the pre-commit `rev:`s to match + add a `pre-commit` dependabot ecosystem — keeps two pins that still transiently diverge between dependabot PRs; (b) one-time manual rev sync — drift just recurs. Tradeoff accepted: hooks now require a synced uv env, so the CI `pre-commit` job runs `uv sync --all-extras` first (and contributors must `uv sync`).
+**Anchor:** #413 ; `.pre-commit-config.yaml` `repo: local` black/ruff/mypy hooks ; `pyproject.toml` `[project.optional-dependencies].dev` pins ; `.github/workflows/ci.yml` `pre-commit` job
+**Verify:** gold [needs synced env: `uv sync --all-extras`] — (1) no second pin can exist: `grep -E "psf/black|ruff-pre-commit|mirrors-mypy" .pre-commit-config.yaml` returns nothing (the hooks are `repo: local`); (2) the tools resolve to the pyproject pins: `uv run ruff --version` == `0.15.17`, `uv run mypy --version` reports `2.1.0`, `uv run black --version` reports `26.5.1` — the same binaries the pre-commit hooks invoke.
+
 ## 2026-06-16 — AST/Script cache cap is configurable via `PYEYE_ARTIFACT_CACHE_MAX_ENTRIES`
 
 **Friction:** The `file_artifact_cache` combined AST+Script LRU cap was hardcoded at 500. On large repos (hundreds of files / 10k+ classes) the working set exceeds it, so a repeated scan (e.g. `expand` `subclasses`) evicts its own entries mid-scan and the next identical call re-parses from disk — the cache silently stops helping. Reproduced: same call twice → same cost, with eviction count climbing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,14 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.1.0",
     "pytest-timeout>=2.2.0",  # Prevent individual test hangs
-    "black==26.5.1",  # Pinned to match .pre-commit-config.yaml
+    # Single source of truth for these tool versions: .pre-commit-config.yaml
+    # runs them via `uv run`, so the pin here drives pre-commit, CI, and local
+    # dev alike (#413).
+    "black==26.5.1",  # Pinned for reproducible formatting
     "ruff==0.15.17",  # Pinned to avoid unexpected linting rule changes
     "mypy==2.1.0",  # Pinned to avoid type checking behavior changes
+    "types-setuptools",  # mypy stubs for setuptools
+    "types-requests",  # mypy stubs for requests
     "types-aiofiles",  # mypy stubs for aiofiles
     "types-PyYAML",  # mypy stubs for PyYAML (lazy-imported in config.py)
     "detect-secrets==1.5.0",  # Pinned to match current version

--- a/uv.lock
+++ b/uv.lock
@@ -2036,6 +2036,8 @@ dev = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "types-aiofiles" },
     { name = "types-pyyaml" },
+    { name = "types-requests" },
+    { name = "types-setuptools" },
 ]
 
 [package.metadata]
@@ -2065,6 +2067,8 @@ requires-dist = [
     { name = "tree-sitter-python", specifier = ">=0.20.0" },
     { name = "types-aiofiles", marker = "extra == 'dev'" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
+    { name = "types-requests", marker = "extra == 'dev'" },
+    { name = "types-setuptools", marker = "extra == 'dev'" },
     { name = "watchdog", specifier = ">=3.0.0" },
 ]
 provides-extras = ["dev"]
@@ -3134,6 +3138,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
+]
+
+[[package]]
+name = "types-setuptools"
+version = "82.0.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/bc/73c2c27e047e42f114ac50fb3bdef986c56cbdb68096f8690eeafb839a93/types_setuptools-82.0.0.20260518.tar.gz", hash = "sha256:3b743cfe63d0981ea4c15b90710fc1ed41e3464a537d51e705be514e891c1d07", size = 44999, upload-time = "2026-05-18T06:02:55.642Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/8f/d5e2d493f09a7a98c95619edda1cb37cee377626c0a869d53274c26f2858/types_setuptools-82.0.0.20260518-py3-none-any.whl", hash = "sha256:31c04a62b57a653a5021caf191be0f10f70df890f813b51f02bab3969d300f20", size = 68444, upload-time = "2026-05-18T06:02:54.582Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`black` / `ruff` / `mypy` were pinned in **two** places — the `pyproject.toml` dev group **and** `.pre-commit-config.yaml` hook `rev:`s — which had drifted (mypy `v1.17.1` vs `2.1.0`, ruff `v0.12.10` vs `0.15.17`). Dependabot only bumps `pyproject.toml`, never the pre-commit revs, so `uv run mypy` (CI `type-check` job + local dev) and the pre-commit `mypy` hook ran **different versions** — and the drift recurred on every dev-tooling bump.

## Changes

- **`.pre-commit-config.yaml`** — the black/ruff/mypy hooks become a single `repo: local` block invoking `uv run black` / `uv run ruff check` / `uv run mypy`. The `pyproject.toml` dev pin is now the **single source of truth** — pre-commit, CI, and local dev run the *same binary*, so drift is structurally impossible. Args/excludes preserved (`--line-length=100`; `--fix --exit-non-zero-on-fix`; `--ignore-missing-imports`, tests excluded).
- **`pyproject.toml`** — added `types-setuptools` + `types-requests` (the stubs the old mypy hook carried in `additional_dependencies`, now needed by `uv run mypy`); fixed the stale `# Pinned to match .pre-commit-config.yaml` comment.
- **`.github/workflows/ci.yml`** — the `pre-commit` job now runs `uv sync --all-extras` (the `repo: local` hooks' `uv run` needs a synced env).
- **`uv.lock`** — the two new stubs.
- **`docs/decisions/DECISIONS.md`** — logged the decision + rejected alternatives.

## Tradeoff

Pre-commit hooks now require a synced uv env (CI does `uv sync` first; contributors already `uv sync`). In exchange, the dual-pin drift is eliminated at the root rather than papered over.

## Test plan

- [x] `pre-commit run --all-files` — all hooks green, including the 3 converted `repo: local` hooks.
- [x] `uv run black/ruff/mypy --version` resolve to the pyproject pins (26.5.1 / 0.15.17 / 2.1.0).
- [x] No black/ruff/mypy `rev:` remains in `.pre-commit-config.yaml` (drift can't recur).
- [x] Full suite: 2021 passed, 8 skipped, coverage 86.74%.

Fixes #413