### PR TITLE
docs(honesty): surface static-surface ceiling on members/outline/subclasses (#417)

### DIFF
--- a/skills/python-explore/SKILL.md
+++ b/skills/python-explore/SKILL.md
@@ -94,6 +94,17 @@ reliably today:
 | `imports` | module → what it imports | the module's top-level imports |
 | `imported_by` | module → its importers | project modules that import this module |
 
+**Static-surface ceiling.** These structural edges are complete over what is
+*written in source*, not over what exists at runtime. `members` / `outline` /
+`subclasses` do not see runtime-injected relationships — metaclass injection,
+`setattr`, `__getattr__`, `type(...)`, `__init_subclass__` registration, or
+`importlib` with computed targets. So `outline` of a Django `Model` omits its
+metaclass-injected `_meta` / `objects` / `DoesNotExist`, and a "full subclass
+closure" covers literal `class B(A):` subclassing only. An absent member or
+subclass means "not in source," **not** "not at runtime" — don't report a static
+result as runtime-exhaustive. (Same boundary `imported_by` already names for
+dynamic imports.)
+
 ## ⭐ Honest Limits — Reverse References Are NOT Available
 
 This is the most important rule in this skill.

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -203,6 +203,14 @@ def resolve_members(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult:
     - **non-container** (function / method / variable / attribute / property /
       …) → ``[]`` (measured: genuinely no members).
 
+    Static-surface ceiling: members are enumerated from source.  Runtime-injected
+    members (metaclass / ``setattr`` / ``__getattr__`` / ``type()`` /
+    ``__init_subclass__``) are NOT captured — e.g. a Django ``Model`` returns none
+    of its metaclass-injected ``_meta`` / ``objects`` / ``DoesNotExist``.  This is
+    the same static-only boundary ``resolve_imported_by`` carries for dynamic
+    imports; ``[]`` therefore means "no statically-defined members," not "no
+    members at runtime."
+
     Synchronous: Jedi ``get_names`` + AST walk + ``Handle`` construction are all
     sync, so the resolver is sync (a sync resolver called from async ``expand``
     is fine).
@@ -681,6 +689,13 @@ async def resolve_subclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResu
     it intentionally returns the full project subclass closure (direct +
     indirect), a deliberate divergence from ``members``/``callees`` direct-only
     semantics — appropriate because the caller asked to walk the edge explicitly.
+
+    Static-surface ceiling: the closure is "full" only over literal
+    ``class B(A):`` subclassing.  Dynamically-created subclasses
+    (``type('B', (A,), {})``, factory-built classes, ``__init_subclass__``
+    registration) are NOT captured — the same static-only boundary
+    ``resolve_imported_by`` carries for dynamic imports.  ``[]`` therefore means
+    "no statically-declared subclasses," not "no subclasses at runtime."
 
     Each adjacent's ``Name`` is built from the subclass's OWN FILE (via
     :func:`_subclass_name_from_file`) — never by re-resolving the dotted handle —

--- a/src/pyeye/mcp/operations/outline.py
+++ b/src/pyeye/mcp/operations/outline.py
@@ -97,7 +97,15 @@ async def outline(
 
     Walks the ``members`` edge from *handle* via BFS-bounded recursion, building
     each node with ``stubs.build_stub`` and stopping at depth, budget, or
-    external-scope limits.  The §4.2 absence contracts are enforced on every node:
+    external-scope limits.
+
+    Static-surface ceiling: because the walk is over ``members``, the tree is
+    complete over statically-defined members but NOT over runtime-injected ones
+    (metaclass / ``setattr`` / ``__getattr__`` / ``type()`` /
+    ``__init_subclass__``) — e.g. a Django ``Model`` omits its metaclass-injected
+    ``_meta`` / ``objects`` / ``DoesNotExist``.
+
+    The §4.2 absence contracts are enforced on every node:
 
     - ``children`` present ⇔ the node was expanded (walked).
     - ``truncated: true`` + ``truncation_reason`` present ⇔ a cap prevented expansion.

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -416,7 +416,11 @@ async def expand(
     Supported edges (the complete static/outbound set):
       - ``members``  — class/module → direct members (attributes, methods, nested
         classes).  ``stubs: []`` means the class/module was found but has no
-        members; that is NOT the same as unsupported.
+        members; that is NOT the same as unsupported.  Static-surface ceiling:
+        members are read from source; runtime-injected members (metaclass /
+        ``setattr`` / ``__getattr__`` / ``type()`` / ``__init_subclass__``) are
+        NOT captured — e.g. a Django ``Model`` shows none of its metaclass-injected
+        ``_meta`` / ``objects`` / ``DoesNotExist``.
       - ``callees``  — function/method → forward static call targets.  Includes
         project symbols and stdlib/external symbols reachable via Jedi's goto.
         Dynamic calls (un-inferable parameters, ``getattr``, lambdas, etc.) are
@@ -438,6 +442,10 @@ async def expand(
         handle also returns the supported branch with ``stubs: []`` — only a
         class CAN be subclassed,
         so ``[]`` is true by definition, not an absence-vs-zero lie.
+        Static-surface ceiling: the "full closure" is full only over literal
+        ``class B(A):`` subclassing; dynamically-created subclasses
+        (``type('B', (A,), {})``, factory-built classes, ``__init_subclass__``
+        registration) are NOT captured.
       - ``superclasses``  — class → its base classes (class Stubs), resolved by
         Jedi from the class definition (no reverse search).  A non-class handle
         returns ``stubs: []`` (``[]`` true by definition, as with ``subclasses``).
@@ -598,6 +606,13 @@ async def outline(
     Use ``resolve()`` or ``inspect()`` first to obtain a canonical handle, then
     ``outline()`` to see the complete structural skeleton in one call — the
     single-call answer to "show me the structure of this scope."
+
+    **Static-surface ceiling.** The tree walks the ``members`` edge, so it is
+    complete over what is *statically defined in source* but not over runtime.
+    Runtime-injected members (metaclass / ``setattr`` / ``__getattr__`` /
+    ``type()`` / ``__init_subclass__``) are NOT captured — e.g. ``outline`` of a
+    Django ``Model`` omits its metaclass-injected ``_meta`` / ``objects`` /
+    ``DoesNotExist``.  An absent member is "not in source," not "not at runtime."
 
     **Absence contracts — an agent MUST read these before consuming the tree.**
 

--- a/tests/test_static_surface_ceiling_docs.py
+++ b/tests/test_static_surface_ceiling_docs.py
@@ -1,0 +1,103 @@
+"""Conformance guard for the static-surface ceiling caveat (#417).
+
+pyeye's static structural edges (``members`` / ``outline`` / ``subclasses``) are
+deterministic and complete over the *static surface* — what is literally written
+in source — but Python's runtime-dynamic features (metaclass injection,
+``setattr``, ``__getattr__``, ``type(...)``, ``__init_subclass__``) put real
+relationships outside that surface.  ``imported_by`` already documents its
+analogous ceiling; #417 is the consistency gap that the other static edges did
+not.
+
+This test converts that honesty contract from prose-that-can-rot into a CI
+failure: every surface that presents a static structural edge MUST carry the
+ceiling marker.  Mirrors the anti-drift posture of
+``test_python_explore_skill_conformance`` (#374).
+
+Dependency-free: stdlib ``ast`` + ``re`` + ``pathlib`` only.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+from pyeye.mcp.operations.edges import resolve_members, resolve_subclasses
+from pyeye.mcp.operations.outline import outline as outline_operation
+
+# The single canonical phrase every static-edge surface must carry.  Anchoring on
+# one exact substring is what makes the contract mechanically checkable (and what
+# stops a future edit from silently dropping it from one surface).
+MARKER = "Static-surface ceiling"
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SERVER = _REPO_ROOT / "src" / "pyeye" / "mcp" / "server.py"
+_SKILL = _REPO_ROOT / "skills" / "python-explore" / "SKILL.md"
+
+
+def _tool_docstring(func_name: str) -> str:
+    """Return the docstring of a top-level ``async def`` in server.py via AST.
+
+    Reading the docstring out of the source (rather than importing the decorated
+    object) is robust to the ``@mcp.tool()`` decorator stack, which may wrap the
+    function in a registration object that does not forward ``__doc__``.
+    """
+    tree = ast.parse(_SERVER.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == func_name:
+            doc = ast.get_docstring(node)
+            assert doc is not None, f"{func_name} in server.py has no docstring"
+            return doc
+    raise AssertionError(f"no top-level def named {func_name!r} in {_SERVER.as_posix()}")
+
+
+# ---------------------------------------------------------------------------
+# MCP tool docstrings — the JSON-consumer-facing surface.
+# ---------------------------------------------------------------------------
+
+
+def test_expand_docstring_carries_ceiling_for_members_and_subclasses() -> None:
+    doc = _tool_docstring("expand")
+    # The marker must appear for BOTH static structural edges, not just once.
+    assert doc.count(MARKER) >= 2, (
+        "expand() must carry the static-surface ceiling caveat for both the "
+        "members and subclasses edges"
+    )
+
+
+def test_outline_tool_docstring_carries_ceiling() -> None:
+    assert MARKER in _tool_docstring("outline")
+
+
+# ---------------------------------------------------------------------------
+# Operation-level docstrings — the internal contract (#417 cites these sites).
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_members_docstring_carries_ceiling() -> None:
+    assert resolve_members.__doc__ is not None and MARKER in resolve_members.__doc__
+
+
+def test_resolve_subclasses_docstring_carries_ceiling() -> None:
+    assert resolve_subclasses.__doc__ is not None and MARKER in resolve_subclasses.__doc__
+
+
+def test_outline_operation_docstring_carries_ceiling() -> None:
+    assert outline_operation.__doc__ is not None and MARKER in outline_operation.__doc__
+
+
+# ---------------------------------------------------------------------------
+# Shipped skill — single source of truth for tool mechanics (CLAUDE.md / #374).
+# ---------------------------------------------------------------------------
+
+
+def test_skill_documents_static_surface_ceiling() -> None:
+    text = _SKILL.read_text(encoding="utf-8")
+    assert MARKER in text, (
+        "the python-explore skill must document the static-surface ceiling so the "
+        "honesty contract stays consistent with the tool docstrings"
+    )
+
+
+def test_marker_phrasing_is_stable() -> None:
+    # Guards the exact wording the other tests anchor on; a drift here is a signal
+    # to update every surface deliberately, not silently.
+    assert re.fullmatch(r"Static-surface ceiling", MARKER)


### PR DESCRIPTION
## Summary

pyeye's static structural edges (`members` / `outline` / `subclasses`) presented exhaustive-over-**source** results as if exhaustive-over-**runtime**. `imported_by` already documents its analogous runtime-dynamic ceiling; the other static edges did not — so the honesty contract pyeye applies to uncertain data was not applied uniformly to its own static edges.

This is **part 1 (uniform documentation)** of #417 — pure contract/presentation consistency. No logic change, no backend change. (Part 2 — a machine-readable `static_only` / `ceiling: "static-surface"` response-shape marker — remains an open design question and is deliberately out of scope here.)

## Changes

Added the same **"Static-surface ceiling"** caveat `imported_by` carries to every surface that presents a static structural edge:

| Surface | File |
|---|---|
| `expand` tool docstring (`members` + `subclasses` bullets) | `src/pyeye/mcp/server.py` |
| `outline` tool docstring | `src/pyeye/mcp/server.py` |
| `resolve_members` docstring | `src/pyeye/mcp/operations/edges.py` |
| `resolve_subclasses` docstring | `src/pyeye/mcp/operations/edges.py` |
| `outline` operation docstring | `src/pyeye/mcp/operations/outline.py` |
| supported-edges note | `skills/python-explore/SKILL.md` (single source of truth for tool mechanics) |

Each caveat names the runtime-injection mechanisms (metaclass / `setattr` / `__getattr__` / `type()` / `__init_subclass__`) and uses the concrete Django `Model` example from the issue (`_meta` / `objects` / `DoesNotExist`).

## Anti-rot guard

New `tests/test_static_surface_ceiling_docs.py` — a conformance test mirroring the `#374` pattern: asserts the `"Static-surface ceiling"` marker is present on each tool docstring (parsed via AST), each operation `__doc__`, and the skill. If a future edit drops the caveat from any surface, CI fails. Written test-first (6 red → 7 green).

## Test plan
- [x] New conformance test passes (7 passed)
- [x] Full suite green: 2028 passed, 8 skipped, **coverage 86.74%** (≥85 gate)
- [x] All pre-commit hooks pass on changed files (black, ruff, whole-package mypy, pydocstyle, conformance linter, markdownlint)

Addresses #417