### PR TITLE
feat(edges): make subclasses edge direct-only; transitive via trace (#422)

### DIFF
--- a/docs/api-redesign.md
+++ b/docs/api-redesign.md
@@ -499,7 +499,7 @@ replacements. Use this table to migrate existing agent code:
 | `get_type_info(file, line, col)` | `inspect(handle)` | Richer Node, no source content |
 | `get_module_info(module)` | `inspect(module_handle)` | Same Node contract; `edge_counts.members` |
 | `find_imports(module)` | `expand(handle, edge="imported_by")` | Stub-based, canonical handles |
-| `find_subclasses(class)` | `expand(handle, edge="subclasses")` | Full project subclass closure (use `len(...)` for the count — `subclasses` is expand-only, not in `edge_counts`, per #392) |
+| `find_subclasses(class)` | `expand(handle, edge="subclasses")` (direct) / `trace(follow=["subclasses"], max_depth=k)` (closure) | Direct subclasses only since #422 (one hop); full transitive closure via `trace`. `subclasses` is expand-only, not in `edge_counts` (#392; cheap count gated on #333/#397) |
 | `list_packages` / `list_modules` | `outline` | One structural lister |
 | `list_project_structure` | `outline` | ″ |
 | `lookup(identifier)` | `resolve` → `inspect` | Progressive disclosure |

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -2,6 +2,13 @@
 
 Contract/invariant-significant, friction-driven decisions. Each entry is a small verifiable fact: Friction · Decision · Anchor (stable ref) · Verify (checkable or honestly-labelled). Newest on top. Maintained via the `decision-log` skill.
 
+## 2026-06-20 — subclasses edge becomes single-hop (direct-only), conforming to the expand contract
+
+**Friction:** expand(subclasses) returned the full transitive closure — the lone edge violating expand's "walk ONE edge to the IMMEDIATE neighbours" invariant (every other edge — members/callees/imports/imported_by/superclasses — is single-hop). It mistakenly broke progressive disclosure: on a widely-subclassed base (Django AltersData) the closure was 193 KB, overflowing the MCP token cap and inverting the cheap-by-default contract.
+**Decision:** Make subclasses DIRECT-only (`include_indirect=False`), restoring the single-hop invariant and making it symmetric with superclasses. The transitive closure is served EXCLUSIVELY by `trace(follow=["subclasses"], …)`, which already owns the cap + `truncated` contract — this also fixes trace's per-hop BFS, which a closure-per-hop resolver had collapsed onto depth 1. expand(subclasses) carries a static `transitive_hint` pointer. Rejected: a `transitive=`/`depth=` flag on expand (would special-case one edge or reinvent trace, with two cap impls that drift). The counts-first direct count in `inspect.edge_counts` was NOT shipped — even a DIRECT subclass count is a reverse query (whole-project scan, same family as callers/references), deferred to #333/#397; the earlier "cheap, rides parent_to_children" premise was wrong (FQN input always builds the resolved_index).
+**Anchor:** `resolve_subclasses` + `SUBCLASSES_TRANSITIVE_HINT` (`pyeye.mcp.operations.edges` / `.expand`); #422.
+**Verify:** gold — over `tests/fixtures/subclasses_edge`: `expand("pkg.base.Animal","subclasses")` returns exactly {`pkg.middle.Mammal`, `script_animal.Lizard`}, excluding grandchild `pkg.middle.Dog`; `trace("pkg.base.Animal",["subclasses"],max_depth=1)` excludes Dog while `max_depth=2` includes it. (`test_edges.py` / `test_expand.py` / `test_trace.py`)
+
 ## 2026-06-18 — Dev/docs deps are PEP 735 dependency-groups; bare `uv sync` is the canonical install
 
 **Friction:** The repo was nominally a `uv` project (tracked `uv.lock`, "this is a uv project — NOT uv pip install" in the instructions) but every install site used `uv pip install --system` / `uv venv`, which **bypasses the lockfile** — CI re-resolved deps each run and `uv.lock` was never enforced. `dev` was also a published `[project.optional-dependencies]` extra, exposing dev tooling as `pip install pyeye-mcp[dev]`. (#414, follow-up to #413.)

--- a/skills/python-explore/SKILL.md
+++ b/skills/python-explore/SKILL.md
@@ -89,7 +89,7 @@ reliably today:
 | `members` | container → children | a class's methods/attributes, or a module's top-level defs |
 | `enclosing_scope` | child → parent | the one lexical scope containing this symbol (method → class, etc.) |
 | `callees` | function → what it calls | forward call targets resolved from the body |
-| `subclasses` | class → its subclasses | project classes that extend this class |
+| `subclasses` | class → its direct subclasses | project classes that **directly** extend this class (one hop; full closure via `trace`) |
 | `superclasses` | class → its bases | the class's direct base classes |
 | `imports` | module → what it imports | the module's top-level imports |
 | `imported_by` | module → its importers | project modules that import this module |
@@ -99,11 +99,12 @@ reliably today:
 `subclasses` do not see runtime-injected relationships — metaclass injection,
 `setattr`, `__getattr__`, `type(...)`, `__init_subclass__` registration, or
 `importlib` with computed targets. So `outline` of a Django `Model` omits its
-metaclass-injected `_meta` / `objects` / `DoesNotExist`, and a "full subclass
-closure" covers literal `class B(A):` subclassing only. An absent member or
-subclass means "not in source," **not** "not at runtime" — don't report a static
-result as runtime-exhaustive. (Same boundary `imported_by` already names for
-dynamic imports.)
+metaclass-injected `_meta` / `objects` / `DoesNotExist`, and the `subclasses`
+edge (direct children) plus a `trace` subclass closure cover literal
+`class B(A):` subclassing only. An absent member or subclass means "not in
+source," **not** "not at runtime" — don't report a static result as
+runtime-exhaustive. (Same boundary `imported_by` already names for dynamic
+imports.)
 
 ## ⭐ Honest Limits — Reverse References Are NOT Available
 
@@ -221,10 +222,15 @@ expand("myapp.cache.Cache.evict", edge="callees")  -> stubs for each call target
 expand("myapp.cache", edge="imported_by")  -> module stubs that import myapp.cache
 ```
 
-**"What subclasses this base?"** — inheritance down:
+**"What subclasses this base?"** — inheritance down. `expand` returns the
+**direct** children (one hop); for the full transitive closure use `trace` with
+explicit bounds (the class result carries a static `transitive_hint` pointing
+there):
 
 ```text
-expand("myapp.plugins.Base", edge="subclasses")  -> project classes extending Base
+expand("myapp.plugins.Base", edge="subclasses")  -> project classes DIRECTLY extending Base
+trace("myapp.plugins.Base", follow=["subclasses"], max_depth=3)
+  -> bounded subtree of the full subclass closure (capped + `truncated`)
 ```
 
 **Multi-hop closure** — structure across hops:

--- a/src/pyeye/mcp/operations/edges.py
+++ b/src/pyeye/mcp/operations/edges.py
@@ -684,18 +684,27 @@ async def resolve_subclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResu
     forward ``goto``/``resolve_canonical`` (NO ``get_references`` /
     ``find_references``, the same load-bearing trust constraint as ``callees`` /
     ``imported_by``).  ``subclasses`` is an **expand-only** edge: ``inspect``
-    does NOT measure it (dropped in #392 — counting it requires this same
-    project-wide scan, so it has no cheap-preview value).  As a single-hop edge
-    it intentionally returns the full project subclass closure (direct +
-    indirect), a deliberate divergence from ``members``/``callees`` direct-only
-    semantics — appropriate because the caller asked to walk the edge explicitly.
+    does NOT measure it (dropped in #392; a cheap direct count is gated on the
+    Pyright reference backend / class-graph cache — #333/#397 — because even the
+    DIRECT count needs the same project-wide scan, exactly like ``callers`` /
+    ``references``).
 
-    Static-surface ceiling: the closure is "full" only over literal
+    Single-hop semantics (#422): ``expand`` walks ONE edge to the IMMEDIATE
+    neighbours, so this resolver returns the **DIRECT** subclasses only (depth 1,
+    ``include_indirect=False``) — symmetric with ``superclasses`` (direct bases).
+    The full transitive closure is served exclusively by
+    ``trace(follow=["subclasses"], max_depth=k, max_nodes=N)``, which already owns
+    the cap + ``truncated`` contract; ``expand`` carries a static pointer to that
+    route.  (Before #422 this returned the full direct+indirect closure, which
+    overflowed the MCP token cap on widely-subclassed bases and collapsed trace's
+    per-hop BFS onto depth 1.)
+
+    Static-surface ceiling: the result is "complete" only over literal
     ``class B(A):`` subclassing.  Dynamically-created subclasses
     (``type('B', (A,), {})``, factory-built classes, ``__init_subclass__``
     registration) are NOT captured — the same static-only boundary
     ``resolve_imported_by`` carries for dynamic imports.  ``[]`` therefore means
-    "no statically-declared subclasses," not "no subclasses at runtime."
+    "no statically-declared direct subclasses," not "no subclasses at runtime."
 
     Each adjacent's ``Name`` is built from the subclass's OWN FILE (via
     :func:`_subclass_name_from_file`) — never by re-resolving the dotted handle —
@@ -733,11 +742,17 @@ async def resolve_subclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResu
     if not handle:
         return EdgeResult(adjacents=[])
 
-    # Project-internal subclass closure (direct + indirect), project-scoped.
+    # Project-internal DIRECT subclasses only (#422), project-scoped.  ``expand``
+    # walks ONE edge to the IMMEDIATE neighbours, so ``subclasses`` returns the
+    # depth-1 children — symmetric with ``superclasses`` (direct bases).  The full
+    # transitive closure is served by ``trace(follow=["subclasses"], max_depth=k)``,
+    # which already owns the cap + ``truncated`` contract; routing it there also
+    # makes trace's per-hop BFS correct (a closure-per-hop resolver collapsed the
+    # whole closure onto depth 1).
     result = await analyzer.find_subclasses(
         handle,
         scope="main",
-        include_indirect=True,
+        include_indirect=False,
         show_hierarchy=False,
     )
     # An FQN input never triggers the ambiguous variant.  Carry a defensive
@@ -791,8 +806,9 @@ def resolve_superclasses(jedi_name: Any, analyzer: JediAnalyzer) -> EdgeResult:
 
     The inbound-but-reliably-static ``superclasses`` edge for a **class**
     handle.  Returns only DIRECT bases (no MRO closure), mirroring the count
-    in ``inspect.edge_counts.superclasses``.  This is a deliberate asymmetry
-    with ``subclasses``, which returns the full project closure.
+    in ``inspect.edge_counts.superclasses``.  Symmetric with ``subclasses``,
+    which also returns DIRECT children only since #422 (expand = one hop in
+    both inheritance directions; the closure is served by ``trace``).
 
     Mechanics:
 

--- a/src/pyeye/mcp/operations/expand.py
+++ b/src/pyeye/mcp/operations/expand.py
@@ -73,6 +73,17 @@ if TYPE_CHECKING:
     from pyeye.analyzers.jedi_analyzer import JediAnalyzer
 
 
+#: Static discoverability pointer attached to a CLASS ``subclasses`` result
+#: (#422).  ``expand(subclasses)`` returns DIRECT children only (one hop); this
+#: constant tells the agent where the full transitive closure lives.  It is
+#: deliberately a CONSTANT — it MUST NOT encode a computed descendant count, as
+#: counting deeper subclasses is the expensive reverse scan gated on #333/#397.
+SUBCLASSES_TRANSITIVE_HINT = (
+    "expand returns DIRECT subclasses only; for the full transitive closure use "
+    "trace(follow=['subclasses'], max_depth=k, max_nodes=N)"
+)
+
+
 # ---------------------------------------------------------------------------
 # Unsupported-reason detail messages
 # ---------------------------------------------------------------------------
@@ -214,5 +225,10 @@ async def expand(handle: str, edge: str, analyzer: JediAnalyzer) -> dict[str, An
     # key absent.  This automatically yields the callees-only field.
     if edge_result.unresolved_call_sites is not None:
         result["unresolved_call_sites"] = edge_result.unresolved_call_sites
+    # subclasses is direct-only (#422); a CLASS result carries a static pointer to
+    # the trace route for the full closure.  Class-gated: a non-class subclasses
+    # result is a measured-empty [], where the "use trace" hint would be noise.
+    if edge == "subclasses" and _normalise_kind(getattr(jedi_name, "type", None)) == "class":
+        result["transitive_hint"] = SUBCLASSES_TRANSITIVE_HINT
 
     return result

--- a/src/pyeye/mcp/server.py
+++ b/src/pyeye/mcp/server.py
@@ -432,17 +432,22 @@ async def expand(
         with ``reason: "not_yet_implemented"`` (symbol-level ``imported_by`` is
         not yet implemented).  Ceiling: runtime-dynamic imports
         (``importlib``/``__import__`` with computed targets) are not detected.
-      - ``subclasses``  — class → the project classes that subclass it (class
-        Stubs), computed by an AST class-graph walk + forward ``goto`` (no
-        reverse symbol search).  Returns the full project subclass closure
-        (direct + indirect).  ``subclasses`` is an expand-only edge: ``inspect``
-        does NOT measure it (dropped in #392 — counting requires this same
-        project-wide scan, so it has no cheap-preview value).  ``stubs: []``
-        means the class has no project subclasses (measured-none).  A non-class
-        handle also returns the supported branch with ``stubs: []`` — only a
-        class CAN be subclassed,
-        so ``[]`` is true by definition, not an absence-vs-zero lie.
-        Static-surface ceiling: the "full closure" is full only over literal
+      - ``subclasses``  — class → the project classes that **directly** subclass
+        it (class Stubs), computed by an AST class-graph walk + forward ``goto``
+        (no reverse symbol search).  Returns the DIRECT (depth-1) subclasses only
+        (#422) — one hop, symmetric with ``superclasses``; the full transitive
+        closure is served by ``trace(follow=["subclasses"], max_depth=k,
+        max_nodes=N)``, which carries the cap + ``truncated`` contract.  A class
+        result includes a static ``transitive_hint`` field pointing to that trace
+        route.  ``subclasses`` is an expand-only edge: ``inspect`` does NOT
+        measure it (dropped in #392); a cheap direct count is gated on the Pyright
+        reference backend / class-graph cache (#333/#397), because even the direct
+        count is a reverse query needing the same project-wide scan as
+        ``callers``/``references``.  ``stubs: []`` means the class has no project
+        subclasses (measured-none).  A non-class handle also returns the supported
+        branch with ``stubs: []`` (and no ``transitive_hint``) — only a class CAN
+        be subclassed, so ``[]`` is true by definition, not an absence-vs-zero
+        lie.  Static-surface ceiling: the result is complete only over literal
         ``class B(A):`` subclassing; dynamically-created subclasses
         (``type('B', (A,), {})``, factory-built classes, ``__init_subclass__``
         registration) are NOT captured.

--- a/tests/integration/api_redesign/test_traversal_integration.py
+++ b/tests/integration/api_redesign/test_traversal_integration.py
@@ -704,12 +704,14 @@ class TestExpandSubclassesClassEndToEnd:
         assert len(stubs) > 0, "Animal has known project subclasses — stubs must be non-empty"
 
     @pytest.mark.asyncio
-    async def test_subclasses_class_full_closure_present(self) -> None:
-        """The supported result carries the full direct+indirect closure over the wire.
+    async def test_subclasses_class_direct_children_only(self) -> None:
+        """The supported result carries the DIRECT subclasses only over the wire (#422).
 
-        The fixture's known closure is exactly {Mammal, Dog, Lizard} — including
+        The fixture's direct subclasses are exactly {Mammal, Lizard} — including
         ``script_animal.Lizard`` defined in a non-importable root script, proving
-        the file-based stub construction survives the wire.
+        the file-based stub construction survives the wire.  The grandchild
+        ``pkg.middle.Dog`` is INDIRECT and must NOT appear — since #422 the edge
+        is a single hop and the closure is served by ``trace``.
         """
         from pyeye.mcp.server import expand
 
@@ -722,9 +724,9 @@ class TestExpandSubclassesClassEndToEnd:
         handles = {stub["handle"] for stub in result["stubs"]}
         assert handles == {
             "pkg.middle.Mammal",
-            "pkg.middle.Dog",
             "script_animal.Lizard",
-        }, f"expected the full Animal subclass closure; got {sorted(handles)!r}"
+        }, f"expected the DIRECT Animal subclasses; got {sorted(handles)!r}"
+        assert "pkg.middle.Dog" not in handles, "indirect grandchild Dog must not appear"
 
     @pytest.mark.asyncio
     async def test_subclasses_class_stubs_have_required_fields(self) -> None:

--- a/tests/integration/jedi_integration/test_jedi_analyzer.py
+++ b/tests/integration/jedi_integration/test_jedi_analyzer.py
@@ -1362,8 +1362,13 @@ class TestExpandSubclassesIssue335:
         ), f"Expected 2 subclass stubs for Shape; got {result['stubs']!r}"
 
     @pytest.mark.asyncio
-    async def test_vehicle_expand_excludes_unrelated_grandchild(self) -> None:
-        """expand(Vehicle, "subclasses") == 2 stubs (Car, RaceCar), not 3."""
+    async def test_vehicle_expand_direct_child_only(self) -> None:
+        """expand(Vehicle, "subclasses") == 1 stub (Car only) — direct, #422.
+
+        The genuine grandchild RaceCar is INDIRECT and excluded from the
+        single-hop edge; the unrelated ``vehicles_b.Car``/``SportsCar`` hierarchy
+        (simple-name collision, Bug B) must never appear either.
+        """
         from pyeye.mcp.server import expand
 
         result = await expand(
@@ -1371,9 +1376,36 @@ class TestExpandSubclassesIssue335:
             edge="subclasses",
             project_path=str(_ISSUE_335_FIXTURE),
         )
+        handles = {stub["handle"] for stub in result["stubs"]}
+        assert handles == {
+            "pkg.vehicles_a.Car"
+        }, f"Expected only the direct subclass Car for Vehicle; got {sorted(handles)!r}"
+
+    @pytest.mark.asyncio
+    async def test_vehicle_trace_closure_keeps_grandchild_identity(self) -> None:
+        """trace(Vehicle, [subclasses]) reaches the real grandchild, not the collision (Bug B).
+
+        The transitive closure now lives in ``trace``.  At depth 2 it must reach
+        the genuine grandchild ``RaceCar`` (via the REAL Car) while the simple-name
+        collision ``vehicles_b.Car``/``SportsCar`` stays out — the grandchild walk
+        carries FQN identity rather than re-keying on the simple name ``Car``.
+        """
+        from pyeye.mcp.server import trace
+
+        result = await trace(
+            start="pkg.vehicles_a.Vehicle",
+            follow=["subclasses"],
+            project_path=str(_ISSUE_335_FIXTURE),
+            max_depth=2,
+            max_nodes=100,
+        )
+        nodes = set(result["nodes"])
+        assert "pkg.vehicles_a.Car" in nodes, "direct subclass Car must be reached"
+        assert "pkg.vehicles_a.RaceCar" in nodes, "genuine grandchild RaceCar must be reached"
         assert (
-            len(result["stubs"]) == 2
-        ), f"Expected 2 subclass stubs for Vehicle; got {result['stubs']!r}"
+            "pkg.vehicles_b.SportsCar" not in nodes
+        ), "unrelated SportsCar (simple-name collision) must NOT appear in the closure"
+        assert "pkg.vehicles_b.Car" not in nodes, "unrelated Car must NOT appear in the closure"
 
 
 class TestFindSubclassesJediIndependence:

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -720,14 +720,15 @@ async def _subclasses_for(handle: str, analyzer: JediAnalyzer) -> EdgeResult:
 
 
 class TestResolveSubclassesClass:
-    """``subclasses`` = the project classes that subclass a base, as canonical handles.
+    """``subclasses`` = the project classes that DIRECTLY subclass a base (#422).
 
-    The resolver reuses ``find_subclasses(scope="main", include_indirect=True)``,
-    so the result is the full project subclass closure (direct + indirect). The
-    dedicated fixture pins a known topology:
+    The resolver reuses ``find_subclasses(scope="main", include_indirect=False)``,
+    so the result is the DIRECT (depth-1) subclasses only — one hop, symmetric
+    with ``superclasses``; the full closure is served by ``trace``. The dedicated
+    fixture pins a known topology:
 
-    - ``pkg.middle.Mammal``     — DIRECT subclass (importable module)
-    - ``pkg.middle.Dog``        — INDIRECT (grandchild) via Mammal
+    - ``pkg.middle.Mammal``     — DIRECT subclass (importable module) → included
+    - ``pkg.middle.Dog``        — INDIRECT (grandchild) via Mammal → EXCLUDED
     - ``script_animal.Lizard``  — DIRECT subclass in a NON-importable root script
     """
 
@@ -745,16 +746,18 @@ class TestResolveSubclassesClass:
         assert _MAMMAL_HANDLE in handles, f"direct subclass Mammal missing; got {handles}"
 
     @pytest.mark.asyncio
-    async def test_indirect_grandchild_subclass_present(
+    async def test_indirect_grandchild_subclass_excluded(
         self, subclasses_analyzer: JediAnalyzer
     ) -> None:
-        # Dog(Mammal) is a grandchild of Animal — include_indirect=True must
-        # surface it (the single-hop subclasses edge intentionally returns the
-        # full project closure; subclasses is expand-only, #392).
+        # Dog(Mammal) is a grandchild of Animal — since #422 the edge is a single
+        # hop (include_indirect=False), so the grandchild must NOT appear. The
+        # transitive closure is reached via trace(follow=["subclasses"]).
         handles = {
             str(h) for h in (await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)).handles
         }
-        assert _DOG_HANDLE in handles, f"indirect subclass Dog missing; got {handles}"
+        assert (
+            _DOG_HANDLE not in handles
+        ), f"indirect grandchild Dog must be excluded; got {handles}"
 
     @pytest.mark.asyncio
     async def test_non_importable_file_subclass_present(
@@ -772,11 +775,12 @@ class TestResolveSubclassesClass:
 
     @pytest.mark.asyncio
     async def test_exact_subclass_handle_set(self, subclasses_analyzer: JediAnalyzer) -> None:
-        # The full project subclass closure of Animal is exactly these three.
+        # The DIRECT subclasses of Animal are exactly these two (#422); the
+        # grandchild Dog is excluded (it is reached via trace).
         handles = {
             str(h) for h in (await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)).handles
         }
-        assert handles == {_MAMMAL_HANDLE, _DOG_HANDLE, _LIZARD_HANDLE}, f"got {handles}"
+        assert handles == {_MAMMAL_HANDLE, _LIZARD_HANDLE}, f"got {handles}"
 
     @pytest.mark.asyncio
     async def test_adjacents_are_handle_name_pairs_building_class_stubs(
@@ -807,7 +811,7 @@ class TestResolveSubclassesClass:
         # comparison would pass even with the bug, since set order is fixed
         # within a process). Run under multiple PYTHONHASHSEED values to prove
         # cross-process stability.
-        expected_order = sorted([_MAMMAL_HANDLE, _DOG_HANDLE, _LIZARD_HANDLE])
+        expected_order = sorted([_MAMMAL_HANDLE, _LIZARD_HANDLE])
         first = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
         second = await _subclasses_for(_ANIMAL_HANDLE, subclasses_analyzer)
         assert [str(h) for h in first.handles] == expected_order

--- a/tests/unit/mcp/operations/test_expand.py
+++ b/tests/unit/mcp/operations/test_expand.py
@@ -44,7 +44,7 @@ from pathlib import Path
 import pytest
 
 from pyeye.analyzers.jedi_analyzer import JediAnalyzer
-from pyeye.mcp.operations.expand import expand
+from pyeye.mcp.operations.expand import SUBCLASSES_TRANSITIVE_HINT, expand
 
 _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
 
@@ -63,8 +63,11 @@ _MODULE_NO_IMPORTERS_HANDLE = "mypackage._core.module_forms"
 
 #: subclasses fixtures (#348, Phase 2): a dedicated fixture project with a known
 #: direct + indirect + non-importable-file topology. ``Animal`` is the base whose
-#: full project subclass closure is exactly {Mammal, Dog, Lizard}; ``Loner`` is a
-#: sibling base nobody subclasses (measured-empty class case).
+#: DIRECT subclasses are exactly {Mammal, Lizard} and whose full closure adds the
+#: grandchild {Dog}.  Since #422 the ``subclasses`` edge returns DIRECT children
+#: only (the closure is served by ``trace``), so the edge result over ``Animal``
+#: is {Mammal, Lizard} — ``Dog`` is reachable only via ``trace`` at depth ≥ 2.
+#: ``Loner`` is a sibling base nobody subclasses (measured-empty class case).
 _SUBCLASSES_FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "subclasses_edge"
 _ANIMAL_HANDLE = "pkg.base.Animal"
 _LONER_HANDLE = "pkg.base.Loner"
@@ -488,11 +491,13 @@ class TestExpandSubclassesSupported:
     """``expand`` over ``subclasses`` for a CLASS returns the supported shape.
 
     The resolver (``resolve_subclasses``) is async and returns an ``EdgeResult``
-    of canonical CLASS handles for the full project subclass closure (direct +
-    indirect, including subclasses defined in non-importable root scripts).
-    ``expand`` awaits it and builds a class stub per subclass.  This is a
-    callees-free supported branch — ``unresolved_call_sites`` is ABSENT (the
-    resolver carries it as ``None`` for this edge).
+    of canonical CLASS handles for the DIRECT project subclasses only (#422 —
+    one hop, mirroring ``superclasses``; the full closure is served by
+    ``trace(follow=["subclasses"], …)``).  Direct subclasses defined in
+    non-importable root scripts are still included.  ``expand`` awaits it and
+    builds a class stub per subclass.  This is a callees-free supported branch —
+    ``unresolved_call_sites`` is ABSENT (the resolver carries it as ``None`` for
+    this edge).
     """
 
     @pytest.mark.asyncio
@@ -520,15 +525,18 @@ class TestExpandSubclassesSupported:
             assert stub["kind"] == "class", f"subclass stub should be a class: {stub}"
 
     @pytest.mark.asyncio
-    async def test_class_subclasses_full_closure_present(
+    async def test_class_subclasses_direct_children_only(
         self, subclasses_analyzer: JediAnalyzer
     ) -> None:
-        # include_indirect=True → the full project subclass closure: the direct
-        # subclass (Mammal), the indirect grandchild (Dog), AND the subclass in a
+        # #422: the edge returns DIRECT subclasses only — the direct subclass in
+        # an importable module (Mammal) AND the direct subclass in a
         # non-importable root script (Lizard, preserved by file-based stub build).
+        # The grandchild Dog is INDIRECT and must NOT appear (it is reachable only
+        # via trace(follow=["subclasses"]) at depth ≥ 2).
         result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
         handles = {stub["handle"] for stub in result["stubs"]}
-        assert handles == {_MAMMAL_HANDLE, _DOG_HANDLE, _LIZARD_HANDLE}, f"got {handles}"
+        assert handles == {_MAMMAL_HANDLE, _LIZARD_HANDLE}, f"got {handles}"
+        assert _DOG_HANDLE not in handles, "indirect grandchild Dog must not appear in the edge"
 
     @pytest.mark.asyncio
     async def test_class_subclasses_omits_unresolved_call_sites(
@@ -538,6 +546,21 @@ class TestExpandSubclassesSupported:
         # subclasses edge (the resolver carries it as None).
         result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
         assert "unresolved_call_sites" not in result
+
+    @pytest.mark.asyncio
+    async def test_class_subclasses_carries_static_trace_pointer(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        # #422 discoverability: a class subclasses result points the agent to the
+        # trace route for the full closure (the edge is direct-only).  The pointer
+        # is a STATIC string — it names the trace primitive and its bounds, and
+        # MUST NOT compute "N deeper descendants" (that is the expensive reverse
+        # scan gated on #333/#397).
+        result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
+        assert result["transitive_hint"] == SUBCLASSES_TRANSITIVE_HINT
+        assert "trace" in result["transitive_hint"]
+        assert "subclasses" in result["transitive_hint"]
+        assert "max_depth" in result["transitive_hint"]
 
 
 class TestExpandSubclassesClassNoSubclassesSupported:
@@ -558,6 +581,10 @@ class TestExpandSubclassesClassNoSubclassesSupported:
         assert "reason" not in result
         assert result["edge"] == "subclasses"
         assert "unresolved_call_sites" not in result
+        # The pointer is STATIC, not computed: a class with ZERO subclasses still
+        # carries the identical hint string as a class with many (proves it never
+        # encodes a count).
+        assert result["transitive_hint"] == SUBCLASSES_TRANSITIVE_HINT
 
 
 class TestExpandSubclassesNonClassMeasuredEmpty:
@@ -594,6 +621,11 @@ class TestExpandSubclassesNonClassMeasuredEmpty:
         assert "reason" not in result, f"non-class subclasses must NOT carry a reason: {result}"
         # subclasses never reports unresolved_call_sites (callees-only).
         assert "unresolved_call_sites" not in result
+        # The trace pointer is class-only — a non-class cannot be subclassed, so
+        # the "use trace for the closure" hint would be misleading noise here.
+        assert (
+            "transitive_hint" not in result
+        ), f"non-class subclasses must NOT carry the trace pointer: {result}"
 
     @pytest.mark.asyncio
     async def test_non_class_distinct_from_imported_by_non_module(
@@ -611,22 +643,24 @@ class TestExpandSubclassesNonClassMeasuredEmpty:
 
 
 class TestExpandSubclassesEnumeration:
-    """``expand(handle, "subclasses")`` enumerates the project subclass closure.
+    """``expand(handle, "subclasses")`` enumerates the DIRECT project subclasses.
 
-    subclasses is an expand-only edge (inspect no longer measures it — #392), so
-    these tests pin expand's enumeration directly against the fixture topology
-    rather than cross-checking an inspect count.
+    subclasses is an expand-only edge (inspect no longer measures it — #392) and,
+    since #422, returns DIRECT children only.  These tests pin expand's
+    enumeration directly against the fixture topology rather than cross-checking
+    an inspect count.
     """
 
     @pytest.mark.asyncio
-    async def test_expand_returns_full_project_closure(
+    async def test_expand_returns_direct_subclasses_only(
         self, subclasses_analyzer: JediAnalyzer
     ) -> None:
         expand_result = await expand(_ANIMAL_HANDLE, "subclasses", subclasses_analyzer)
         stub_count = len(expand_result["stubs"])
-        # The fixture's known closure is exactly 3 (Mammal, Dog, Lizard); pin it
-        # so a fixture-topology change surfaces loudly.
-        assert stub_count == 3, f"fixture Animal closure should be 3 subclasses; got {stub_count}"
+        # The fixture's DIRECT subclasses are exactly 2 (Mammal, Lizard); the
+        # grandchild Dog is INDIRECT and excluded (#422).  Pin it so a fixture
+        # -topology change surfaces loudly.
+        assert stub_count == 2, f"fixture Animal direct subclasses should be 2; got {stub_count}"
 
     @pytest.mark.asyncio
     async def test_class_with_no_subclasses_returns_empty(

--- a/tests/unit/mcp/operations/test_subclasses_resolution_guard.py
+++ b/tests/unit/mcp/operations/test_subclasses_resolution_guard.py
@@ -1,10 +1,15 @@
 """Byte-identical guard for the #405 ``find_subclasses`` resolution rewrite.
 
-Pins the FULL subclass closure of ``pkg.core.Root`` across every base-resolution
+Pins the subclass resolution of ``pkg.core.Root`` across every base-resolution
 form — direct / aliased / dotted / re-export / indirect. This must stay GREEN
 through the cold-build rewrite: it's the safety net proving the AST-first
 resolver reproduces Jedi's resolution on the paths the ``subclasses_edge``
 fixture does not cover.
+
+Since #422 the ``subclasses`` edge is DIRECT-only, so the guard is split: the
+edge pins the five DIRECT resolution forms, and ``trace`` (which now owns the
+transitive closure) pins the full set including the INDIRECT grandchild — every
+form stays covered, on the surface where it now lives.
 """
 
 from pathlib import Path
@@ -13,17 +18,20 @@ import pytest
 
 from pyeye.analyzers.jedi_analyzer import JediAnalyzer
 from pyeye.mcp.operations.expand import expand
+from pyeye.mcp.operations.trace import trace
 
 _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "subclasses_resolution"
 _ROOT_HANDLE = "pkg.core.Root"
-_EXPECTED_CLOSURE = {
+#: The five DIRECT (depth-1) subclasses of Root, one per base-resolution form.
+_EXPECTED_DIRECT = {
     "consumers.Direct",  # direct-name base, direct import
     "consumers.Aliased",  # `as R` alias (top-level)
     "consumers.Dotted",  # `core.Root` dotted reference
     "consumers.ViaReexport",  # base via `pkg.Root` re-export
-    "consumers.GrandChild",  # indirect, through the resolved Direct child
     "conditional.ConditionalAlias",  # `as` alias imported under try/except (Jedi-fallback path)
 }
+#: The full closure adds the one INDIRECT form (grandchild through Direct).
+_EXPECTED_CLOSURE = _EXPECTED_DIRECT | {"consumers.GrandChild"}
 
 
 @pytest.fixture
@@ -33,7 +41,19 @@ def analyzer() -> JediAnalyzer:
 
 
 @pytest.mark.asyncio
-async def test_root_closure_covers_all_resolution_forms(analyzer: JediAnalyzer) -> None:
+async def test_root_direct_covers_all_direct_resolution_forms(analyzer: JediAnalyzer) -> None:
+    # The direct-only edge resolves every DIRECT base form; the indirect
+    # grandchild is excluded (it is reached via trace — see below).
     result = await expand(_ROOT_HANDLE, "subclasses", analyzer)
     handles = {stub["handle"] for stub in result["stubs"]}
+    assert handles == _EXPECTED_DIRECT, f"got {handles}"
+
+
+@pytest.mark.asyncio
+async def test_root_closure_covers_all_resolution_forms(analyzer: JediAnalyzer) -> None:
+    # trace owns the transitive closure (#422); a generous depth must reproduce
+    # the full #405 set INCLUDING the indirect grandchild form.
+    result = await trace(_ROOT_HANDLE, ["subclasses"], analyzer, max_depth=5, max_nodes=100)
+    # The start handle is part of the subgraph nodes; the closure is the rest.
+    handles = set(result["nodes"]) - {_ROOT_HANDLE}
     assert handles == _EXPECTED_CLOSURE, f"got {handles}"

--- a/tests/unit/mcp/operations/test_trace.py
+++ b/tests/unit/mcp/operations/test_trace.py
@@ -29,6 +29,16 @@ from pyeye.mcp.operations.trace import _stops_at, trace
 
 _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
 
+#: The subclasses_edge fixture (#348/#422): ``pkg.base.Animal`` has DIRECT
+#: subclasses {Mammal, Lizard} and the grandchild {Dog} one hop deeper.  Because
+#: the ``subclasses`` edge is now a single hop (#422), ``trace`` over it must
+#: walk level-by-level — Dog appears only at depth ≥ 2, never at depth 1.
+_SUBCLASSES_FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "subclasses_edge"
+_ANIMAL_HANDLE = "pkg.base.Animal"
+_MAMMAL_HANDLE = "pkg.middle.Mammal"  # direct subclass of Animal
+_DOG_HANDLE = "pkg.middle.Dog"  # indirect (grandchild) of Animal via Mammal
+_LIZARD_HANDLE = "script_animal.Lizard"  # direct subclass in a non-importable script
+
 _WIDGET_HANDLE = "mypackage._core.widgets.Widget"
 #: A MODULE whose members include the ``Widget`` class, which itself has members
 #: (methods) — a genuine two-level ``members`` tree for depth/truncation tests.
@@ -45,6 +55,12 @@ _STUB_REQUIRED_KEYS = {"handle", "kind", "scope", "line_start", "line_end"}
 def analyzer() -> JediAnalyzer:
     """JediAnalyzer pointed at the resolve_project fixture."""
     return JediAnalyzer(str(_FIXTURE))
+
+
+@pytest.fixture
+def subclasses_analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at the subclasses_edge fixture (#348/#422)."""
+    return JediAnalyzer(str(_SUBCLASSES_FIXTURE))
 
 
 def _assert_is_stub(stub: dict) -> None:
@@ -361,6 +377,47 @@ class TestTraceMultiHopAndMultiEdge:
         for edge in result["edges"]:
             assert edge["from"] in result["nodes"], f"edge from-handle not a node: {edge}"
             assert edge["to"] in result["nodes"], f"edge to-handle not a node: {edge}"
+
+
+class TestTraceSubclassesPerHop:
+    """``trace`` over the now-single-hop ``subclasses`` edge walks level-by-level (#422).
+
+    Before #422 the resolver returned the full closure at every hop, so the whole
+    closure collapsed onto depth 1 and ``max_depth`` was meaningless.  With the
+    resolver returning DIRECT children only, ``trace`` does a proper BFS: the
+    grandchild ``Dog`` is reachable only at depth ≥ 2.
+    """
+
+    @pytest.mark.asyncio
+    async def test_depth_1_yields_direct_children_not_grandchild(
+        self, subclasses_analyzer: JediAnalyzer
+    ) -> None:
+        result = await trace(
+            _ANIMAL_HANDLE, ["subclasses"], subclasses_analyzer, max_depth=1, max_nodes=100
+        )
+        nodes = set(result["nodes"])
+        assert _MAMMAL_HANDLE in nodes, "direct subclass Mammal must be at depth 1"
+        assert _LIZARD_HANDLE in nodes, "direct subclass Lizard must be at depth 1"
+        # The defining assertion: the grandchild is NOT one hop away — it must not
+        # appear at depth 1 (it would have, under the old per-hop-closure bug).
+        assert _DOG_HANDLE not in nodes, "grandchild Dog must NOT appear at depth 1"
+        # A reachable node was cut at the depth frontier → truncated via max_depth.
+        assert result["truncated"] is True
+        assert "max_depth" in result["truncation_reasons"]
+
+    @pytest.mark.asyncio
+    async def test_depth_2_reaches_grandchild(self, subclasses_analyzer: JediAnalyzer) -> None:
+        result = await trace(
+            _ANIMAL_HANDLE, ["subclasses"], subclasses_analyzer, max_depth=2, max_nodes=100
+        )
+        nodes = set(result["nodes"])
+        assert {
+            _MAMMAL_HANDLE,
+            _LIZARD_HANDLE,
+            _DOG_HANDLE,
+        } <= nodes, f"depth 2 must reach the grandchild Dog; got {sorted(nodes)!r}"
+        # The closure is fully explored at depth 2 → natural termination.
+        assert result["truncated"] is False
 
 
 class TestTraceCycleSafe:


### PR DESCRIPTION
## Summary

`expand(handle, edge="subclasses")` was the **lone edge violating expand's single-hop "immediate neighbours" invariant** — it returned the full transitive subclass closure. On a widely-subclassed base (Django's `AltersData` mixin) the closure was **193 KB**, overflowing the MCP token cap and inverting pyeye's cheap-by-default progressive-disclosure contract.

This makes the `subclasses` edge return **DIRECT children only** (`include_indirect=False` in `resolve_subclasses`), restoring the single-hop invariant and making it symmetric with `superclasses`. The full transitive closure is now served **exclusively** by `trace(follow=["subclasses"], max_depth=k, max_nodes=N)`, which already owns the cap + `truncated` contract.

### Changes
- **`resolve_subclasses` → direct-only.** `expand(subclasses)` returns immediate children; the 193 KB overflow is impossible.
- **Transitive closure = `trace`.** This also **fixes a latent trace bug**: `trace` uses the same edge resolver, so the closure-per-hop resolver had collapsed the entire closure onto depth 1 (making `max_depth` meaningless). Direct-only restores proper level-by-level BFS.
- **Static `transitive_hint`** on class `subclasses` results pointing to the `trace` route — a constant string (no computed descendant count, which would itself be the expensive reverse scan).
- Docs: MCP `expand` docstring, `resolve_superclasses` (asymmetry→symmetry note), `docs/api-redesign.md`, the `python-explore` skill, and a `docs/decisions/DECISIONS.md` entry.

### Deferred (not in this PR)
The counts-first **direct count in `inspect.edge_counts`** (deliverable 3 on the issue) is intentionally **not shipped**: even a *direct* subclass count is a reverse query requiring a whole-project scan (same family as `callers`/`references`), so it doesn't belong in cheap-by-default `inspect`. Gated on the Pyright reference backend (#333) / class-graph cache (#397). The earlier "cheap, rides `parent_to_children`" framing was incorrect — an FQN handle always builds the `resolved_index`.

## Test plan
- [x] TDD throughout — every behavioural change had a failing test first (Dog grandchild present → excluded).
- [x] `expand("pkg.base.Animal","subclasses")` returns `{Mammal, Lizard}`, excludes grandchild `Dog`.
- [x] `trace(...,["subclasses"],max_depth=1)` excludes `Dog`; `max_depth=2` includes it.
- [x] Bug-B grandchild-identity coverage (#335) migrated to the `trace` surface (genuine `RaceCar` reached, unrelated `SportsCar` excluded).
- [x] Full suite: **2059 passed, 8 skipped, 86.91% coverage** (gate 85%).
- [x] All pre-commit hooks pass (no bypass flags).

Addresses #422