### PR TITLE
fix(resolve): anchor re-exported handle on definition site (#429)

### DIFF
--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -503,6 +503,43 @@ def _resolve_base_class_via_jedi(
 # ---------------------------------------------------------------------------
 
 
+def _anchor_on_definition(name: Any, handle: str) -> Any:
+    """Anchor a matched Jedi ``Name`` on its definition site (issue #429).
+
+    A re-export import binding in an ``__init__.py`` reports the *same*
+    ``full_name`` as the class it re-exports — Jedi follows the import one hop —
+    and even reports ``type == "class"``. So the handle→``Name`` walk can match
+    that binding and land on the re-export line instead of the class body,
+    silently reporting ``members: 0`` for a real class. This happens whenever
+    the deepest (definition) module's pass fails to produce a ``full_name``
+    match (the #419-class non-determinism) and the walk falls through to a
+    shallower ``__init__``.
+
+    ``goto`` repairs this deterministically: it is idempotent on a true
+    definition (returns itself) and follows a re-export binding through to the
+    definition. It rides the same ``goto(follow_imports=True)`` path
+    ``resolve_at`` uses, so it does not depend on the flaky ``full_name`` match —
+    making ``inspect``/``expand``/``trace``/``outline`` agree with ``resolve_at``
+    (acceptance criterion #2). The ``full_name``/``module_path`` guard keeps a
+    genuine definition if ``goto`` ever wanders.
+
+    Args:
+        name: The matched Jedi ``Name`` (definition or re-export binding).
+        handle: The canonical dotted-name string being resolved.
+
+    Returns:
+        The definition-site ``Name`` when ``goto`` resolves it, else *name*.
+    """
+    try:
+        targets = name.goto(follow_imports=True)
+    except Exception:
+        return name
+    for target in targets:
+        if target.full_name == handle and target.module_path is not None:
+            return target
+    return name
+
+
 def _find_jedi_name_for_handle(handle: str, analyzer: JediAnalyzer) -> Any | None:
     """Find the Jedi Name object that corresponds to *handle*.
 
@@ -556,7 +593,9 @@ def _find_jedi_name_for_handle(handle: str, analyzer: JediAnalyzer) -> Any | Non
             script = file_artifact_cache.get_script(mod_file, analyzer.project)
             for name in script.get_names(all_scopes=True, definitions=True, references=False):
                 if name.full_name == handle:
-                    return name
+                    # Anchor on the definition: a match here may be a re-export
+                    # import binding in an __init__ (issue #429) — goto-follow it.
+                    return _anchor_on_definition(name, handle)
         except Exception:
             continue
 

--- a/tests/fixtures/reexport_grouped/gp/__init__.py
+++ b/tests/fixtures/reexport_grouped/gp/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for the grouped re-export regression fixture (issue #429)."""

--- a/tests/fixtures/reexport_grouped/gp/sub/__init__.py
+++ b/tests/fixtures/reexport_grouped/gp/sub/__init__.py
@@ -1,0 +1,13 @@
+"""Subpackage that re-exports definitions via a GROUPED, parenthesized import.
+
+This mirrors the Django ``db/models/__init__.py`` pattern from issue #429:
+each re-exported name sits on its own line inside ``from ... import ( ... )``.
+"""
+
+from gp.sub.related import (  # isort:skip
+    ForeignKey,
+    ForeignObject,
+    OneToOneField,
+)
+
+__all__ = ["ForeignKey", "ForeignObject", "OneToOneField"]

--- a/tests/fixtures/reexport_grouped/gp/sub/related.py
+++ b/tests/fixtures/reexport_grouped/gp/sub/related.py
@@ -1,0 +1,35 @@
+"""Definition module — the canonical definition site for the re-exported classes."""
+
+
+class ForeignObject:
+    """Base relation field."""
+
+    base_attr = 1
+
+    def contribute(self) -> int:
+        """Contribute to class."""
+        return self.base_attr
+
+
+class ForeignKey(ForeignObject):
+    """A foreign-key field."""
+
+    fk_attr = 2
+
+    def get_attname(self) -> str:
+        """Return the attribute name."""
+        return "fk"
+
+
+class OneToOneField(ForeignKey):
+    """A one-to-one field — re-exported via a grouped import in ``sub/__init__``."""
+
+    o2o_attr = 3
+
+    def method_a(self) -> int:
+        """Do thing a."""
+        return 1
+
+    def method_b(self) -> int:
+        """Do thing b."""
+        return 2

--- a/tests/unit/mcp/operations/test_reexport_resolution.py
+++ b/tests/unit/mcp/operations/test_reexport_resolution.py
@@ -1,0 +1,189 @@
+"""Regression tests for issue #429 — re-exported class FQN must resolve to its
+definition site, never to the package ``__init__`` re-export line.
+
+Background
+----------
+``_find_jedi_name_for_handle`` maps an FQN handle back to a Jedi ``Name`` by
+walking progressively shorter module paths and accepting the first ``Name``
+whose ``full_name`` equals the handle. The deepest (definition) module is tried
+first, so this is *usually* correct. But for a grouped re-export, the import
+binding in a shallower ``__init__.py`` *also* reports ``full_name == handle``
+(Jedi resolves the import one hop to the definition) and ``type == "class"``.
+Whenever the deepest-module pass fails to yield a match — the #419-class Jedi
+``full_name`` non-determinism — the loop falls through and returns that import
+binding. The result is silently wrong: ``inspect`` reports ``members: 0,
+superclasses: 0`` at the ``__init__`` line for a real class.
+
+The fix anchors any match on its definition via ``goto`` (follow-through),
+which is idempotent on a real definition and corrective on a re-export binding,
+and rides the same deterministic ``goto`` path ``resolve_at`` uses.
+
+Fixture layout (``tests/fixtures/reexport_grouped``)
+----------------------------------------------------
+``gp/sub/related.py`` — defines ``ForeignObject``, ``ForeignKey`` and
+``OneToOneField`` (canonical definition site).
+``gp/sub/__init__.py`` — re-exports them via a GROUPED, parenthesized import
+(``from gp.sub.related import ( ... )``), each name on its own line — the
+Django ``db/models/__init__.py`` pattern.
+
+The deepest-module pass is simulated as "missing" by monkeypatching
+``find_module_file`` to return ``None`` for the definition module — the
+deterministic stand-in for the #419 flake that triggers the fall-through.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle, inspect
+
+# NOTE: fetch the *module* via ``sys.modules`` — the ``operations`` package
+# ``__init__`` does ``from .inspect import inspect``, which rebinds the
+# ``inspect`` attribute to the *function*, so any attribute-based import
+# (``from ...operations import inspect`` or ``import ...operations.inspect``)
+# yields the function, not the module. Monkeypatching needs the real module.
+inspect_ops = sys.modules["pyeye.mcp.operations.inspect"]
+
+_FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "reexport_grouped"
+
+_HANDLE = "gp.sub.related.OneToOneField"
+_DEFINITION_MODULE = "gp.sub.related"
+_DEFINITION_FILE = "related.py"
+_DEFINITION_LINE = 24  # ``class OneToOneField(ForeignKey):`` in the fixture
+
+
+@pytest.fixture
+def analyzer() -> JediAnalyzer:
+    """JediAnalyzer pointed at the grouped re-export fixture."""
+    return JediAnalyzer(str(_FIXTURE))
+
+
+@pytest.fixture
+def simulate_deepest_miss(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the definition-module lookup to miss (stand-in for the #419 flake).
+
+    Mirrors the production trigger: the deepest (definition) module pass fails
+    to yield a ``full_name`` match, so ``_find_jedi_name_for_handle`` falls
+    through to the shallower ``__init__`` whose grouped-import binding matches.
+    """
+    real_find_module_file = inspect_ops.find_module_file
+
+    def fake_find_module_file(module_dotted: str, az: JediAnalyzer) -> Path | None:
+        if module_dotted == _DEFINITION_MODULE:
+            return None
+        return real_find_module_file(module_dotted, az)
+
+    monkeypatch.setattr(inspect_ops, "find_module_file", fake_find_module_file)
+
+
+class TestReexportResolvesToDefinition:
+    """#429 — the FQN must resolve to the class body, not the re-export line."""
+
+    @pytest.mark.usefixtures("simulate_deepest_miss")
+    def test_find_name_lands_on_definition_when_deepest_pass_misses(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        """The resolved Jedi Name must point at the class definition file/line.
+
+        Without the fix, the fall-through returns the ``__init__`` import
+        binding (``__init__.py`` at the grouped-import line) instead.
+        """
+        name = _find_jedi_name_for_handle(_HANDLE, analyzer)
+
+        assert name is not None
+        assert name.module_path is not None
+        assert name.module_path.name == _DEFINITION_FILE
+        assert name.line == _DEFINITION_LINE
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("simulate_deepest_miss")
+    async def test_inspect_reports_real_members_when_deepest_pass_misses(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        """inspect must report the class's real members/superclasses, not 0/0.
+
+        ``members: 0`` at the ``__init__`` line is the exact silent-wrong
+        symptom reported in #429.
+        """
+        node = await inspect(_HANDLE, analyzer)
+
+        assert node["kind"] == "class"
+        assert node["location"]["file"].endswith(_DEFINITION_FILE)
+        assert node["location"]["line_start"] == _DEFINITION_LINE
+        # OneToOneField has 2 methods + 1 attribute; ForeignKey base.
+        assert node["edge_counts"].get("members", 0) > 0
+        assert node["edge_counts"].get("superclasses", 0) == 1
+
+    @pytest.mark.asyncio
+    async def test_inspect_agrees_with_resolve_at(self, analyzer: JediAnalyzer) -> None:
+        """Acceptance criterion #2: inspect(handle) and resolve_at(def) agree.
+
+        Entry points must not be entry-point-dependent: the FQN handle and a
+        position on the definition line must resolve to the same location.
+        """
+        from pyeye.mcp.operations.resolve import resolve_at
+
+        node = await inspect(_HANDLE, analyzer)
+
+        def_file = _FIXTURE / "gp" / "sub" / _DEFINITION_FILE
+        at = await resolve_at(str(def_file), _DEFINITION_LINE, 6, analyzer)
+
+        assert at["found"] is True
+        at_location = cast(dict[str, Any], at)["location"]
+        assert node["location"]["file"] == at_location["file"]
+        assert node["location"]["line_start"] == at_location["line_start"]
+
+
+class _FakeTarget:
+    def __init__(self, full_name: str | None, module_path: Path | None) -> None:
+        self.full_name = full_name
+        self.module_path = module_path
+
+
+class _FakeName:
+    """Minimal Jedi-Name stand-in for unit-testing ``_anchor_on_definition``."""
+
+    def __init__(self, goto_result: Any) -> None:
+        self._goto_result = goto_result
+
+    def goto(self, **kwargs: Any) -> Any:  # noqa: ARG002 - test double swallows goto kwargs
+        if isinstance(self._goto_result, Exception):
+            raise self._goto_result
+        return self._goto_result
+
+
+class TestAnchorOnDefinitionFallbacks:
+    """Defensive branches of the follow-through helper (issue #429)."""
+
+    def test_returns_original_when_goto_raises(self) -> None:
+        """If ``goto`` raises, keep the original matched name (never crash)."""
+        from pyeye.mcp.operations.inspect import _anchor_on_definition
+
+        name = _FakeName(RuntimeError("jedi blew up"))
+        assert _anchor_on_definition(name, _HANDLE) is name
+
+    def test_returns_original_when_no_target_matches_handle(self) -> None:
+        """If no goto target matches the handle, keep the original name.
+
+        Guards against ``goto`` wandering to an unrelated symbol — a genuine
+        definition must not be discarded for a worse one.
+        """
+        from pyeye.mcp.operations.inspect import _anchor_on_definition
+
+        wrong = _FakeTarget(full_name="some.other.Symbol", module_path=Path("x.py"))
+        no_path = _FakeTarget(full_name=_HANDLE, module_path=None)
+        name = _FakeName([wrong, no_path])
+        assert _anchor_on_definition(name, _HANDLE) is name
+
+    def test_returns_definition_target_when_it_matches(self) -> None:
+        """The matching, located target replaces the original (the repair)."""
+        from pyeye.mcp.operations.inspect import _anchor_on_definition
+
+        target = _FakeTarget(full_name=_HANDLE, module_path=Path("related.py"))
+        name = _FakeName([target])
+        assert _anchor_on_definition(name, _HANDLE) is target

--- a/tests/unit/mcp/operations/test_reexport_resolution.py
+++ b/tests/unit/mcp/operations/test_reexport_resolution.py
@@ -138,6 +138,32 @@ class TestReexportResolvesToDefinition:
         assert node["location"]["file"] == at_location["file"]
         assert node["location"]["line_start"] == at_location["line_start"]
 
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("simulate_deepest_miss")
+    async def test_inspect_agrees_with_resolve_at_when_deepest_pass_misses(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        """Criterion #2 must hold on the path that actually broke.
+
+        The plain agreement check passes even without the fix, because the
+        deepest-module pass normally matches the definition directly. Forcing
+        that pass to miss (the #419 fall-through) is the only path where the
+        unfixed walk lands ``inspect`` on the ``__init__`` re-export line while
+        ``resolve_at`` (position-based) stays on the definition — so this is the
+        case where FQN-string and position resolution would *disagree*.
+        """
+        from pyeye.mcp.operations.resolve import resolve_at
+
+        node = await inspect(_HANDLE, analyzer)
+
+        def_file = _FIXTURE / "gp" / "sub" / _DEFINITION_FILE
+        at = await resolve_at(str(def_file), _DEFINITION_LINE, 6, analyzer)
+
+        assert at["found"] is True
+        at_location = cast(dict[str, Any], at)["location"]
+        assert node["location"]["file"] == at_location["file"]
+        assert node["location"]["line_start"] == at_location["line_start"]
+
 
 class _FakeTarget:
     def __init__(self, full_name: str | None, module_path: Path | None) -> None:


### PR DESCRIPTION
## Summary

A re-exported class's **canonical definition-site FQN** could resolve to the package `__init__` re-export line instead of the class definition, **silently** returning empty structural data — `inspect` reporting `members: 0, superclasses: 0` for a real class, `expand`/`trace` returning empty. No error, no caveat. This is the worst failure class for a structural tool.

Affected the entire handle-consuming surface: `inspect`, `expand`, `trace`, and `outline` all share `_find_jedi_name_for_handle`. Only `resolve`/`resolve_at` (position-based) were immune.

## Root cause

`_find_jedi_name_for_handle` maps an FQN handle back to a Jedi `Name` by walking progressively shorter module paths and accepting the first `Name` whose `full_name == handle`. For a grouped re-export, Jedi resolves the import binding in `__init__.py` one hop to the definition, so that binding *also* reports `full_name == handle` **and** `type == "class"` — but its tree node is the import statement, not the class body. The deepest (definition) module is tried first, so this is usually correct; but whenever that pass fails to produce a match — the #419-class `full_name` non-determinism — the walk falls through and returns the `__init__` import binding.

Reproduced deterministically against Django: with the deepest-module pass forced to miss, `inspect("django.db.models.fields.related.OneToOneField")` returned `__init__.py:68` with `members: 0` instead of `related.py:1343` with `members: 13`.

## Fix

Add `_anchor_on_definition` at the shared chokepoint: after a handle→`Name` match, `goto(follow_imports=True)`-follow it to the definition site. This is:
- **idempotent** on a true definition (`goto` returns itself),
- **corrective** on a re-export import binding (`goto` follows to the class body),
- **#419-independent** — it rides the same deterministic `goto` path `resolve_at` already uses, so `inspect`/`expand`/`trace`/`outline` now agree with `resolve_at` (acceptance criterion #2).

A `full_name`/`module_path` guard keeps a genuine definition if `goto` ever wanders.

## Verification

- New regression tests (grouped-reexport fixture + simulated deepest-miss + `resolve_at`-agreement + helper-branch units): **6 passed**.
- Real Django, end-to-end: `OneToOneField` / `ForeignKey` / `Model` all resolve to their definition sites with correct member counts in **both** the normal and simulated-flake paths.
- Full suite: **2065 passed, 8 skipped**, coverage **86.9%** (>85% gate).
- All pre-commit hooks pass (black, ruff, mypy, conformance linter).

## Acceptance criteria

- [x] FQN of a re-exported class resolves to its definition site, regardless of single-line vs grouped re-export.
- [x] `inspect`/`expand`/`trace` agree with `resolve_at` for the same symbol.
- [x] Regression test using a grouped `from x import ( A, B, C )` re-export.

## Scope note / follow-up

This fixes the reported **canonical-handle** case (Mode A). Investigation surfaced a distinct, deterministic sibling bug — feeding a re-export **alias** path (e.g. `django.db.models.OneToOneField`) returns a silent not-found (`kind: variable`) — which needs canonicalize-first (async `resolve_canonical`) and is tracked separately in #431.

Fixes #429