### PR TITLE
fix(resolve): canonicalize re-export alias handles before resolution (#431)

### DIFF
--- a/src/pyeye/mcp/operations/expand.py
+++ b/src/pyeye/mcp/operations/expand.py
@@ -65,7 +65,7 @@ from pyeye.mcp.operations.edges import (
     STATUS_NOT_YET_IMPLEMENTED,
     edge_status,
 )
-from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
+from pyeye.mcp.operations.inspect import _resolve_handle_to_jedi_name
 from pyeye.mcp.operations.resolve import _normalise_kind
 from pyeye.mcp.operations.stubs import build_stub
 
@@ -163,7 +163,7 @@ async def expand(handle: str, edge: str, analyzer: JediAnalyzer) -> dict[str, An
     # ------------------------------------------------------------------
     # Implemented edge — resolve the source handle to a Jedi Name.
     # ------------------------------------------------------------------
-    jedi_name = _find_jedi_name_for_handle(handle, analyzer)
+    jedi_name = await _resolve_handle_to_jedi_name(handle, analyzer)
 
     if jedi_name is None:
         # Source handle unresolvable → graceful supported-empty result, mirroring

--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -52,7 +52,7 @@ from pyeye._ast_targets import (
 )
 from pyeye._jedi_location import location_from_name
 from pyeye._module_sentinel import ModuleSentinel
-from pyeye.canonicalization import collect_re_exports, find_module_file
+from pyeye.canonicalization import collect_re_exports, find_module_file, resolve_canonical
 from pyeye.handle import Handle
 from pyeye.mcp.operations.edges import resolve_members, resolve_superclasses
 
@@ -629,6 +629,46 @@ def _find_jedi_name_for_handle(handle: str, analyzer: JediAnalyzer) -> Any | Non
     return None
 
 
+async def _resolve_handle_to_jedi_name(handle: str, analyzer: JediAnalyzer) -> Any | None:
+    """Resolve a handle to a Jedi ``Name``, canonicalizing re-export aliases (#431).
+
+    First tries the direct handle→``Name`` walk (:func:`_find_jedi_name_for_handle`).
+    A re-export *alias* path — a public import path such as
+    ``package.Thing`` rather than the canonical definition handle
+    ``package._impl.Thing`` — never matches any ``full_name``: Jedi reports the
+    re-export binding's ``full_name`` as the *canonical* handle, not the alias
+    string, so the direct walk misses and ``inspect`` would emit a not-found
+    ``kind: variable`` node.
+
+    On a miss, canonicalize via :func:`resolve_canonical` (which matches by
+    *name*, not ``full_name``, so it resolves the alias) and retry once with the
+    canonical handle. This is the shared entry point for
+    ``inspect``/``expand``/``trace``/``outline`` so all four agree with
+    ``resolve``/``resolve_at`` on alias inputs (issue #431, acceptance #2).
+
+    The canonicalization is paid only on a miss — the common case (a canonical
+    handle that resolves directly) returns from the first call with no extra
+    work.
+
+    Args:
+        handle: Any dotted-name handle (canonical or re-export alias).
+        analyzer: Active analyzer for the project.
+
+    Returns:
+        A Jedi ``Name`` object, or ``None`` if the handle cannot be resolved
+        even after canonicalization.
+    """
+    name = _find_jedi_name_for_handle(handle, analyzer)
+    if name is not None:
+        return name
+
+    canonical = await resolve_canonical(handle, analyzer)
+    if canonical is not None and str(canonical) != handle:
+        return _find_jedi_name_for_handle(str(canonical), analyzer)
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Edge-count helpers
 # ---------------------------------------------------------------------------
@@ -918,9 +958,9 @@ async def inspect(handle: str, analyzer: JediAnalyzer) -> dict[str, Any]:
         with kind ``"variable"`` as the safest default.
     """
     # ------------------------------------------------------------------
-    # Step 1 — Locate the symbol
+    # Step 1 — Locate the symbol (canonicalizing re-export aliases, #431)
     # ------------------------------------------------------------------
-    jedi_name = _find_jedi_name_for_handle(handle, analyzer)
+    jedi_name = await _resolve_handle_to_jedi_name(handle, analyzer)
 
     if jedi_name is None:
         # Minimal fallback — handle not found

--- a/src/pyeye/mcp/operations/outline.py
+++ b/src/pyeye/mcp/operations/outline.py
@@ -55,7 +55,7 @@ from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from pyeye.mcp.operations.edges import resolve_members
-from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
+from pyeye.mcp.operations.inspect import _resolve_handle_to_jedi_name
 from pyeye.mcp.operations.stubs import build_stub
 
 if TYPE_CHECKING:
@@ -132,7 +132,7 @@ async def outline(
     # ------------------------------------------------------------------
     # 1. Resolve root handle to a Jedi Name.
     # ------------------------------------------------------------------
-    root_jedi_name = _find_jedi_name_for_handle(handle, analyzer)
+    root_jedi_name = await _resolve_handle_to_jedi_name(handle, analyzer)
 
     if root_jedi_name is None:
         # Unresolvable — return minimal single-node fallback (mirrors inspect).

--- a/src/pyeye/mcp/operations/trace.py
+++ b/src/pyeye/mcp/operations/trace.py
@@ -41,7 +41,7 @@ from typing import TYPE_CHECKING, Any
 
 from pyeye.mcp.operations.edges import EDGE_RESOLVERS, STATUS_IMPLEMENTED, edge_status
 from pyeye.mcp.operations.expand import _unsupported_detail
-from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
+from pyeye.mcp.operations.inspect import _resolve_handle_to_jedi_name
 from pyeye.mcp.operations.stubs import build_stub
 
 if TYPE_CHECKING:
@@ -173,7 +173,7 @@ async def trace(
     queue: deque[tuple[str, Any, int]] = deque()
 
     for root in starts:
-        jedi_name = _find_jedi_name_for_handle(root, analyzer)
+        jedi_name = await _resolve_handle_to_jedi_name(root, analyzer)
         if jedi_name is None:
             continue
         canonical = getattr(jedi_name, "full_name", None) or root

--- a/tests/unit/mcp/operations/test_reexport_resolution.py
+++ b/tests/unit/mcp/operations/test_reexport_resolution.py
@@ -56,6 +56,12 @@ _DEFINITION_MODULE = "gp.sub.related"
 _DEFINITION_FILE = "related.py"
 _DEFINITION_LINE = 24  # ``class OneToOneField(ForeignKey):`` in the fixture
 
+# Re-export *alias* path (issue #431): the public import path created by the
+# grouped re-export in ``gp/sub/__init__.py``. ``resolve()`` accepts it and
+# canonicalizes it to ``_HANDLE``; ``inspect``/``expand``/``trace``/``outline``
+# must resolve it to the same definition site, not a not-found ``variable`` node.
+_ALIAS = "gp.sub.OneToOneField"
+
 
 @pytest.fixture
 def analyzer() -> JediAnalyzer:
@@ -213,3 +219,62 @@ class TestAnchorOnDefinitionFallbacks:
         target = _FakeTarget(full_name=_HANDLE, module_path=Path("related.py"))
         name = _FakeName([target])
         assert _anchor_on_definition(name, _HANDLE) is target
+
+
+class TestAliasResolvesToDefinition:
+    """#431 — a re-export *alias* FQN must resolve to the definition, not 404.
+
+    Distinct from #429: the alias never matches any ``full_name`` (Jedi reports
+    the binding's ``full_name`` as the canonical handle, not the alias string),
+    so the handle->Name walk misses entirely and ``inspect`` emits its minimal
+    ``kind: variable`` fallback. The fix canonicalizes the input on a miss.
+    """
+
+    @pytest.mark.asyncio
+    async def test_inspect_alias_resolves_to_class_definition(self, analyzer: JediAnalyzer) -> None:
+        """inspect(alias) must report the class at its definition site, not 404."""
+        node = await inspect(_ALIAS, analyzer)
+
+        assert node["kind"] == "class"
+        assert node["location"]["file"].endswith(_DEFINITION_FILE)
+        assert node["location"]["line_start"] == _DEFINITION_LINE
+        assert node["edge_counts"].get("members", 0) > 0
+        assert node["edge_counts"].get("superclasses", 0) == 1
+
+    @pytest.mark.asyncio
+    async def test_inspect_alias_agrees_with_canonical_and_resolve_at(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        """Acceptance #2: inspect(alias) == inspect(canonical) == resolve_at(def)."""
+        from pyeye.mcp.operations.resolve import resolve_at
+
+        alias_node = await inspect(_ALIAS, analyzer)
+        canon_node = await inspect(_HANDLE, analyzer)
+
+        def_file = _FIXTURE / "gp" / "sub" / _DEFINITION_FILE
+        at = await resolve_at(str(def_file), _DEFINITION_LINE, 6, analyzer)
+        assert at["found"] is True
+        at_location = cast(dict[str, Any], at)["location"]
+
+        assert alias_node["location"]["file"] == canon_node["location"]["file"]
+        assert alias_node["location"]["line_start"] == canon_node["location"]["line_start"]
+        assert alias_node["location"]["file"] == at_location["file"]
+        assert alias_node["location"]["line_start"] == at_location["line_start"]
+
+    @pytest.mark.asyncio
+    async def test_expand_alias_resolves_superclasses(self, analyzer: JediAnalyzer) -> None:
+        """expand(alias, 'superclasses') must resolve via the same path (not empty)."""
+        from pyeye.mcp.operations.expand import expand
+
+        result = await expand(_ALIAS, "superclasses", analyzer)
+        bases = [s.get("handle") for s in result.get("stubs", [])]
+        assert "gp.sub.related.ForeignKey" in bases
+
+    @pytest.mark.asyncio
+    async def test_outline_alias_resolves_to_class(self, analyzer: JediAnalyzer) -> None:
+        """outline(alias) must produce the class node, not a not-found stub."""
+        from pyeye.mcp.operations.outline import outline
+
+        result = await outline(_ALIAS, analyzer)
+        assert result["node"]["kind"] == "class"
+        assert result["node"]["line_start"] == _DEFINITION_LINE


### PR DESCRIPTION
## Summary

Feeding a re-export **alias** FQN — a public import path such as `django.db.models.OneToOneField`, rather than the canonical definition handle `django.db.models.fields.related.OneToOneField` — into `inspect`/`expand`/`trace`/`outline` **silently returned a not-found node** (`kind: variable`, empty location, `members: None`) instead of resolving to the class.

This is the sibling of #429 (which fixed the *canonical* handle landing on the `__init__` re-export line). Both are silent-wrong resolution bugs; this one is **deterministic** (no #419 flake needed).

## Root cause

`_find_jedi_name_for_handle` matches a handle by `name.full_name == handle`. For an alias input, Jedi reports the re-export binding's `full_name` as the **canonical** handle (the definition site), which never equals the alias string. So the module walk, `project.search`, and the synthetic-import fallback all miss → `None` → `inspect` emits its minimal `kind: variable` node.

`resolve_canonical("django.db.models.OneToOneField")` already returns the correct canonical handle (it matches by *name*, not `full_name`) — the resolver just wasn't using it.

## Fix

Add an async wrapper `_resolve_handle_to_jedi_name` in `inspect.py`:
1. Try the direct `_find_jedi_name_for_handle` walk (unchanged fast path).
2. On a **miss**, `await resolve_canonical(handle)` and retry once with the canonical handle.

The four consumers (`inspect`/`expand`/`trace`/`outline`) now call the wrapper, so all four agree with `resolve`/`resolve_at` on alias inputs. Canonicalization is paid **only on a miss** — the common case (a canonical handle that resolves directly) is unaffected.

This is the deliberately-scoped variant of the "option (3)" direction from #429's review: a thin async wrapper at the 4 consumers, keeping the widely-called sync `_find_jedi_name_for_handle` (used at ~30 sites incl. tests) sync — zero test ripple.

## Verification

- New regression tests (`TestAliasResolvesToDefinition`, reusing the `reexport_grouped` fixture): alias resolves to the definition via `inspect`, agrees with `inspect(canonical)` and `resolve_at`, and the same through `expand(superclasses)` and `outline`. **4 new tests pass** (11 total in the file).
- Real Django, alias inputs: `django.db.models.OneToOneField` / `ForeignKey` / `Model` now resolve to their definition sites with correct member counts (were `kind: variable`).
- Full suite: **2070 passed, 8 skipped**, coverage **86.9%** (>85% gate). The only failure was a timing-flaky perf benchmark (`test_parallel_vs_sequential`) that **passes in isolation** and is unrelated (the wrapper adds an `await` only on a miss).
- All pre-commit hooks pass.

## Acceptance criteria

- [x] An alias/re-export path accepted by `resolve()` resolves through `inspect`/`expand`/`trace`/`outline` to the definition site (not `kind: variable`).
- [x] `inspect(alias).location == inspect(canonical).location == resolve_at(definition).location`.
- [x] Regression test using a public re-export alias (the grouped `reexport_grouped` fixture from #429).

Fixes #431