### PR TITLE
fix(analyzer): include from-package submodule importers in imported_by edge (#436)

### DIFF
--- a/src/pyeye/analyzers/jedi_analyzer.py
+++ b/src/pyeye/analyzers/jedi_analyzer.py
@@ -1963,20 +1963,28 @@ class JediAnalyzer:
             try:
                 importer_module = self._get_import_path_for_file(py_file)
                 # Pre-filter (avoids AST parse for unrelated files; the AST
-                # check below is authoritative).  Parse when EITHER the
-                # absolute path appears textually (absolute imports) OR the
-                # file shares the target's top-level package — a relative
-                # import (`from .x import y`) can resolve into the target
-                # without ever spelling its absolute path (#343).  Source is
-                # read but not cached or returned — a heuristic, not content.
+                # check below is authoritative).  Parse when ANY of:
+                #   - the absolute path appears textually (absolute imports);
+                #   - the file shares the target's top-level package — a
+                #     relative import (`from .x import y`) can resolve into the
+                #     target without ever spelling its absolute path (#343);
+                #   - the target's PARENT package appears textually — the
+                #     `from <parent> import <submodule>` idiom (#436) spells the
+                #     parent, never the submodule's dotted path, and may live in
+                #     a different top-level package than the target (so
+                #     `shares_package` does not cover it).
+                # Source is read but not cached or returned — a heuristic, not
+                # content.
                 source = await read_file_async(py_file)
                 shares_package = bool(
                     importer_module and importer_module.split(".")[0] == target_root
                 )
+                parent_pkg = module_path.rsplit(".", 1)[0] if "." in module_path else None
                 if (
                     module_path in source
                     or module_path.replace(".", "/") in source
                     or shares_package
+                    or (parent_pkg is not None and parent_pkg in source)
                 ):
                     importer_is_package = py_file.name == "__init__.py"
                     # Bucket 1: AST for the precise check comes from cache.
@@ -1998,8 +2006,22 @@ class JediAnalyzer:
                                 importer_module or "",
                                 importer_is_package,
                             )
+                            # The `from` clause names a package/module; an
+                            # imported NAME may itself be the target submodule
+                            # (`from <pkg> import <submodule>`, #436).  Match
+                            # both: the from-clause directly (dotted-path form
+                            # `from <pkg>.<sub> import <name>`), and each name
+                            # normalized to `<resolved>.<name>` (submodule form).
+                            # A from-import names a leaf, so the submodule match
+                            # is exact equality — never a `startswith` prefix.
                             if resolved and (
-                                resolved == module_path or resolved.startswith(module_path + ".")
+                                resolved == module_path
+                                or resolved.startswith(module_path + ".")
+                                or any(
+                                    f"{resolved}.{alias.name}" == module_path
+                                    for alias in node.names
+                                    if alias.name != "*"
+                                )
                             ):
                                 if importer_module and importer_module not in importers:
                                     importers[importer_module] = py_file

--- a/tests/fixtures/resolve_project/mypackage/_core/submod_importer.py
+++ b/tests/fixtures/resolve_project/mypackage/_core/submod_importer.py
@@ -1,0 +1,21 @@
+"""Importer that reaches widgets via the ``from package import submodule`` idiom.
+
+Exercises the previously-missed ``ast.ImportFrom`` path of ``find_importers``
+(#436): ``from mypackage._core import widgets`` imports the *submodule*
+``widgets``. The ``from`` clause resolves to the package
+``mypackage._core``; the submodule handle is reconstructed by appending the
+imported name, so the importer must be attributed to
+``mypackage._core.widgets`` even though that dotted path is never spelled.
+
+Same top-level package as the target, so the textual pre-filter admits it via
+``shares_package``; this isolates the AST-matching half of the fix.
+"""
+
+from mypackage._core import widgets
+
+__all__ = ["build"]
+
+
+def build() -> object:
+    """Return a widget, referencing the submodule import so it is used."""
+    return widgets.make_widget("submod")

--- a/tests/fixtures/resolve_project/submod_script_importer.py
+++ b/tests/fixtures/resolve_project/submod_script_importer.py
@@ -1,0 +1,15 @@
+"""Standalone script using the ``from package import submodule`` idiom.
+
+Lives at the fixture root, OUTSIDE ``mypackage``, so its path-derived handle
+(``submod_script_importer``) shares no top-level package with the target. The
+textual pre-filter therefore cannot admit it via ``shares_package`` — only the
+parent-package trigger (``mypackage._core`` appearing in the source) lets the
+authoritative AST check run. This exercises the cross-package half of the #436
+fix (the pre-filter widening), distinct from the same-package
+``submod_importer``.
+"""
+
+from mypackage._core import widgets
+
+if __name__ == "__main__":
+    print(widgets.make_widget("submod-script"))

--- a/tests/integration/jedi_integration/test_module_analysis.py
+++ b/tests/integration/jedi_integration/test_module_analysis.py
@@ -575,3 +575,37 @@ class TestFindImporters:
 
         result = await analyzer.analyze_dependencies(_TARGET, scope="all")
         assert result["imported_by"] == expected
+
+    @pytest.mark.asyncio
+    async def test_find_importers_reports_from_package_import_submodule(self):
+        """``from package import submodule`` importers are attributed (#436).
+
+        ``submod_importer`` reaches the target via
+        ``from mypackage._core import widgets`` — the submodule idiom whose
+        ``from`` clause names the *package* (``mypackage._core``) and whose
+        imported name (``widgets``) completes the target's dotted handle. The
+        reverse scan must reconstruct ``mypackage._core.widgets`` and attribute
+        the importer, matching the forward ``imports`` edge which already
+        resolves this idiom.
+        """
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        pairs = await analyzer.find_importers(_TARGET, _TARGET_FILE, scope="all")
+
+        modules = {m for m, _ in pairs}
+        assert "mypackage._core.submod_importer" in modules
+
+    @pytest.mark.asyncio
+    async def test_find_importers_reports_cross_package_submodule_script(self):
+        """A cross-package ``from package import submodule`` importer is found.
+
+        ``submod_script_importer`` lives at the fixture root (top-level handle
+        ``submod_script_importer``), so it shares no top-level package with the
+        target and cannot be admitted by ``shares_package``. Only the
+        parent-package textual trigger (``mypackage._core`` appears in source)
+        lets the AST check run — exercising the pre-filter half of the #436 fix.
+        """
+        analyzer = JediAnalyzer(str(_FIXTURE))
+        pairs = await analyzer.find_importers(_TARGET, _TARGET_FILE, scope="all")
+
+        modules = {m for m, _ in pairs}
+        assert "submod_script_importer" in modules

--- a/tests/unit/mcp/operations/test_edges.py
+++ b/tests/unit/mcp/operations/test_edges.py
@@ -59,6 +59,7 @@ from pyeye.mcp.operations.edges import (
     resolve_superclasses,
 )
 from pyeye.mcp.operations.inspect import _find_jedi_name_for_handle
+from pyeye.mcp.operations.resolve import _normalise_kind
 
 _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_project"
 
@@ -1718,4 +1719,81 @@ class TestResolveEnclosingScopeParentNoneDefensive:
         result = resolve_enclosing_scope(mock_jedi_name, analyzer=MagicMock())
         assert isinstance(result, EdgeResult)
         assert result.adjacents == []  # empty, not None
-        assert result is not None  # resolver NEVER returns None
+
+
+class TestImportEdgeRoundTrip:
+    """Forward/reverse conformance over the fixture tree (#436 fix-oracle).
+
+    Invariant: for every project module ``N``, if the forward ``imports`` edge
+    of ``N`` yields a project module ``M``, then ``N`` MUST appear in the reverse
+    ``imported_by(M)``. The forward edge Jedi-resolves each import to its target,
+    so it is trusted ground truth; the reverse pure-AST scan must agree on the
+    same fact. This catches the whole class of reverse under-reports — the
+    ``from package import submodule`` idiom of #436 plus relative, aliased, and
+    grouped forms — not just the single idiom in the report, and is precisely the
+    test that would have caught the regression.
+
+    Uses the committed ``resolve_project`` fixture (a real directory) so Jedi
+    resolution is path-stable (no tmp-dir symlink degradation).
+    """
+
+    @pytest.mark.asyncio
+    async def test_forward_imports_are_mirrored_by_reverse_imported_by(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        imported_by_cache: dict[str, set[str]] = {}
+
+        async def _reverse_importers(module_handle: str) -> set[str]:
+            if module_handle not in imported_by_cache:
+                jedi_name = _find_jedi_name_for_handle(module_handle, analyzer)
+                if jedi_name is None:
+                    imported_by_cache[module_handle] = set()
+                else:
+                    res = await resolve_imported_by(jedi_name, analyzer)
+                    imported_by_cache[module_handle] = (
+                        {str(h) for h in res.handles} if res is not None else set()
+                    )
+            return imported_by_cache[module_handle]
+
+        py_files = sorted(_FIXTURE.rglob("*.py"), key=lambda p: p.as_posix())
+        assert py_files, "fixture tree must contain Python files"
+
+        violations: list[str] = []
+        module_imports_checked = 0
+        for py_file in py_files:
+            n_handle = analyzer._get_import_path_for_file(py_file)
+            if not n_handle:
+                continue
+            n_name = _find_jedi_name_for_handle(n_handle, analyzer)
+            if n_name is None:
+                continue
+            forward = resolve_imports(n_name, analyzer)
+            if forward is None:
+                continue
+            for m_handle, m_name in forward.adjacents:
+                # Module-to-module invariant only: the forward edge also yields
+                # symbol handles (``from mod import Class``); reverse imported_by
+                # is module-level, so restrict to forward targets that are
+                # themselves project modules.
+                if _normalise_kind(getattr(m_name, "type", None)) != "module":
+                    continue
+                m_path = getattr(m_name, "module_path", None)
+                if m_path is None:
+                    continue
+                try:
+                    Path(m_path).relative_to(_FIXTURE)
+                except ValueError:
+                    continue  # external module — outside the fixture project
+                module_imports_checked += 1
+                reverse = await _reverse_importers(str(m_handle))
+                if n_handle not in reverse:
+                    violations.append(
+                        f"{n_handle} imports {m_handle} "
+                        f"but {n_handle} ∉ imported_by({m_handle})"
+                    )
+
+        assert module_imports_checked >= 5, (
+            "expected the fixture tree to exercise several module-level project "
+            f"imports; only checked {module_imports_checked}"
+        )
+        assert not violations, "forward/reverse import disagreement:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary

The reverse `imported_by` edge silently dropped importers using the
`from <package> import <submodule>` idiom, so it **disagreed with the forward
`imports` edge** on the same fact — making "who imports this module?" unreliable
for change-impact.

**Root cause:** `JediAnalyzer.find_importers`' `ast.ImportFrom` branch matched
only the resolved *`from` clause* against the target and never the imported
*names*. So `from django.core.handlers import base` was read as importing the
*package* `django.core.handlers`, and `base` was never normalized to the
submodule handle `django.core.handlers.base`. Only the dotted form
`from <pkg>.<sub> import <name>` landed on the submodule key.

**Fix (two parts):**
1. **AST match** — for each imported name, also test
   `f"{resolved}.{alias.name}" == module_path` (exact equality; a from-import
   names a leaf, never a deeper prefix). Covers both absolute and relative
   submodule imports.
2. **Pre-filter widening** — admit files where the target's *parent package*
   appears textually, so a cross-package `from <parent> import <sub>` (which
   shares no top-level package with the target) reaches the authoritative AST
   check.

The fix appends to `_resolve_relative_import`'s output rather than forking
resolver logic, so it stays compatible with #426's consolidation goal.

## Tests

- **Focused regression** (`TestFindImporters`): same-package
  `from mypackage._core import widgets` and a cross-package root script — both
  previously missed.
- **Forward/reverse round-trip conformance** (`TestImportEdgeRoundTrip`) — the
  fix-oracle requested on the issue: for every project module `N`, if
  `M ∈ imports(N)` then `N ∈ imported_by(M)`. This catches the whole class
  (submodule, relative, aliased, grouped), and it also surfaced a **pre-existing
  latent instance** — `inheritance_via_attr`'s `from mypackage import _core`.
- New fixtures: `submod_importer.py`, `submod_script_importer.py`.

All three new tests failed before the fix (for the right reason) and pass after.

## Test plan

- [x] New tests RED before fix, GREEN after
- [x] Full suite: 2072 passed, coverage 86.94% (≥85%). Only failure is the
      known-flaky `test_cache_hit_performance` timing benchmark (#428), which
      passes in isolation; this change touches no cache code.
- [x] `black --check` clean; mypy shows only pre-existing `jedi` untyped-import notes
- [x] pre-commit hooks passed

Fixes #436