### PR TITLE
fix(analyzer): reconstruct decorated method signatures from source AST (#437)

### DIFF
--- a/src/pyeye/analyzers/jedi_analyzer.py
+++ b/src/pyeye/analyzers/jedi_analyzer.py
@@ -2723,6 +2723,10 @@ class JediAnalyzer:
             return result
 
         sig = sigs[0]
+        # FOLLOW-UP (#437): dual-source smell — this deprecated path still leaks a
+        # decorator wrapper's signature/params (e.g. functools.cache → _lru_cache_wrapper),
+        # whereas inspect._build_signature now detects and reconstructs from the AST.
+        # The two signature sources should converge on the AST-first builder.
         result["signature"] = sig.to_string()
 
         # Create script for contextual type resolution

--- a/src/pyeye/mcp/operations/inspect.py
+++ b/src/pyeye/mcp/operations/inspect.py
@@ -287,6 +287,36 @@ async def _build_parameters(
     return params
 
 
+def _signature_from_source_ast(jedi_name: Any) -> str | None:
+    """Reconstruct a function/method signature string from the source AST.
+
+    Used to recover the real signature when Jedi leaks a decorator wrapper's
+    signature (issue #437).  Returns ``None`` when the defining ``FunctionDef``
+    cannot be located in source (builtins, C extensions, stub-only externals),
+    so the caller can fall back to Jedi's render.
+
+    Args:
+        jedi_name: A Jedi ``Name`` object for a function/method.
+
+    Returns:
+        A single-line ``name(args) -> ret`` string, or ``None``.
+    """
+    module_path = getattr(jedi_name, "module_path", None)
+    line = getattr(jedi_name, "line", None)
+    name = getattr(jedi_name, "name", None)
+    if module_path is None or not line or not name:
+        return None
+    fn_node = _find_function_def_at_line(Path(module_path), line)
+    if fn_node is None:
+        return None
+    try:
+        args = ast.unparse(fn_node.args)
+        ret = f" -> {ast.unparse(fn_node.returns)}" if fn_node.returns is not None else ""
+    except Exception:
+        return None
+    return f"{name}({args}){ret}"
+
+
 def _build_signature(jedi_name: Any) -> str | None:
     """Extract a single-line signature string from a Jedi Name object.
 
@@ -296,6 +326,14 @@ def _build_signature(jedi_name: Any) -> str | None:
     empty/whitespace render normalises to ``None`` so callers never have to
     distinguish ``""`` from "absent" (the stub contract: present-with-real-value
     or omitted, never ``""``; issue #407).
+
+    Decorator wrapper leak (issue #437): a decorated symbol resolves to the
+    wrapper the decorator returns (e.g. ``@functools.cache`` →
+    ``_lru_cache_wrapper(*args, **kwargs)``), so Jedi renders the wrapper's
+    signature, not the symbol's own.  This is detected by the rendered leading
+    identifier not matching the symbol name; when it happens the real signature
+    is reconstructed from the source AST, falling back to the Jedi render if the
+    source definition cannot be located.
 
     Args:
         jedi_name: A Jedi ``Name`` object.
@@ -311,7 +349,15 @@ def _build_signature(jedi_name: Any) -> str | None:
             if "\n" in sig_str:
                 sig_str = sig_str.split("\n")[0]
             # Normalise an empty/whitespace render to None — never return "".
-            return str(sig_str) if sig_str and sig_str.strip() else None
+            if not (sig_str and sig_str.strip()):
+                return None
+            rendered_name = sig_str.split("(", 1)[0]
+            symbol_name = getattr(jedi_name, "name", None)
+            if symbol_name and rendered_name != symbol_name:
+                ast_sig = _signature_from_source_ast(jedi_name)
+                if ast_sig is not None:
+                    return ast_sig
+            return str(sig_str)
     except Exception:
         pass
     return None

--- a/tests/fixtures/resolve_project/mypackage/_core/decorated.py
+++ b/tests/fixtures/resolve_project/mypackage/_core/decorated.py
@@ -1,0 +1,30 @@
+"""Decorated-method fixtures — the wrapper-signature-leak regression (#437).
+
+``@functools.cache`` (and ``@functools.lru_cache`` without ``maxsize``) resolve
+through typeshed to ``_lru_cache_wrapper``, so Jedi's ``get_signatures()`` leaks
+``_lru_cache_wrapper(*args: Hashable, **kwargs: Hashable) -> _T_co`` instead of
+the method's own signature.  ``_build_signature`` must reconstruct the real
+signature from the source AST in that case.
+
+This lives in its own module so the line-number-sensitive ``widgets.py`` layout
+stays untouched.
+
+Canonical handles:
+- mypackage._core.decorated.Cached.cached_method  (decorated — leaks via Jedi)
+- mypackage._core.decorated.Cached.plain_method    (undecorated — control)
+"""
+
+import functools
+
+
+class Cached:
+    """Holds a @functools.cache-decorated method and an undecorated control."""
+
+    @functools.cache  # noqa: B019 — intentional: reproduces the #437 wrapper leak
+    def cached_method(self, a: int, b: int = 2) -> int:
+        """Decorated method — Jedi leaks the wrapper signature for this."""
+        return a + b
+
+    def plain_method(self, a: int, b: int = 2) -> int:
+        """Undecorated control — renders its own signature already."""
+        return a + b

--- a/tests/unit/mcp/operations/test_inspect.py
+++ b/tests/unit/mcp/operations/test_inspect.py
@@ -118,6 +118,7 @@ _GREET_HANDLE = "mypackage._core.widgets.Widget.greet"
 _SLOW_GREET_HANDLE = "mypackage._core.widgets.Widget.slow_greet"
 _DEFAULT_HANDLE = "mypackage._core.widgets.Widget.default"
 _NORMALIZE_HANDLE = "mypackage._core.widgets.Widget.normalize"
+_CACHED_COMPUTE_HANDLE = "mypackage._core.decorated.Cached.cached_method"
 _DISPLAY_NAME_HANDLE = "mypackage._core.widgets.Widget.display_name"
 _COLOR_HANDLE = "mypackage._core.widgets.Widget.color"
 _MODULE_HANDLE = "mypackage._core.widgets"
@@ -407,6 +408,54 @@ class TestInspectMethod:
         assert result["kind"] == "method"
         assert result["is_staticmethod"] is True
         assert result["is_classmethod"] is False
+
+
+# ---------------------------------------------------------------------------
+# TestInspectDecoratedMethodSignature — issue #437
+# ---------------------------------------------------------------------------
+
+
+class TestInspectDecoratedMethodSignature:
+    """Regression tests for #437: a decorated method must render its OWN
+    signature, not the decorator wrapper's.
+
+    ``@functools.cache`` (and ``@functools.lru_cache`` without ``maxsize``)
+    resolves through typeshed to ``_lru_cache_wrapper``, so Jedi's
+    ``get_signatures()`` returns ``_lru_cache_wrapper(*args: Hashable,
+    **kwargs: Hashable) -> _T_co``.  ``_build_signature`` must detect that the
+    rendered identifier does not match the symbol name and reconstruct the real
+    signature from the source AST.
+    """
+
+    @pytest.mark.asyncio
+    async def test_decorated_method_renders_own_signature(self, analyzer: JediAnalyzer) -> None:
+        """inspect reports the method's real signature, not the wrapper's."""
+        from pyeye.mcp.operations.inspect import inspect
+
+        result = await inspect(_CACHED_COMPUTE_HANDLE, analyzer)
+
+        assert result["kind"] == "method"
+        assert result["signature"] == "cached_method(self, a: int, b: int=2) -> int"
+        # The wrapper artifact must NOT leak through.
+        assert "_lru_cache_wrapper" not in result["signature"]
+
+    @pytest.mark.asyncio
+    async def test_decorated_method_signature_matches_parameters(
+        self, analyzer: JediAnalyzer
+    ) -> None:
+        """The signature string must agree with the AST-derived parameters list.
+
+        Before the fix, inspect self-contradicted: a wrapper signature string
+        (``*args, **kwargs``) alongside the correct AST parameters.
+        """
+        from pyeye.mcp.operations.inspect import inspect
+
+        result = await inspect(_CACHED_COMPUTE_HANDLE, analyzer)
+
+        param_names = [p["name"] for p in result["parameters"]]
+        assert param_names == ["self", "a", "b"]
+        for name in param_names:
+            assert name in result["signature"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/operations/test_stubs.py
+++ b/tests/unit/mcp/operations/test_stubs.py
@@ -60,6 +60,7 @@ _FIXTURE = Path(__file__).parent.parent.parent.parent / "fixtures" / "resolve_pr
 _WIDGET_HANDLE = "mypackage._core.widgets.Widget"
 _MAKE_WIDGET_HANDLE = "mypackage._core.widgets.make_widget"
 _GREET_HANDLE = "mypackage._core.widgets.Widget.greet"
+_CACHED_COMPUTE_HANDLE = "mypackage._core.decorated.Cached.cached_method"
 _MODULE_HANDLE = "mypackage._core.widgets"
 _DISPLAY_NAME_HANDLE = "mypackage._core.widgets.Widget.display_name"
 _COLOR_HANDLE = "mypackage._core.widgets.Widget.color"
@@ -225,6 +226,14 @@ class TestStubMethod:
         """Method stub carries no source content."""
         stub = _get_stub(_GREET_HANDLE, analyzer)
         _assert_no_content(stub)
+
+    def test_decorated_method_renders_own_signature(self, analyzer: JediAnalyzer) -> None:
+        """A @functools.cache-decorated method stub must carry its OWN signature,
+        not the ``_lru_cache_wrapper`` artifact (#437) — this is the outline path.
+        """
+        stub = _get_stub(_CACHED_COMPUTE_HANDLE, analyzer)
+        assert stub["signature"] == "cached_method(self, a: int, b: int=2) -> int"
+        assert "_lru_cache_wrapper" not in stub["signature"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`inspect`/`outline` reported the **decorator wrapper's** signature for decorated methods. `@functools.cache` / `@functools.lru_cache` resolve through typeshed to `_lru_cache_wrapper`, so Jedi's `get_signatures()` leaked:

```
_lru_cache_wrapper(*args: Hashable, **kwargs: Hashable) -> _T_co
```

instead of the method's real signature (e.g. `get_models(self, include_auto_created=False, include_swapped=False)`).

## Root cause

`inspect._build_signature` rendered Jedi's inferred *value* of the decorated name, which is the wrapper object returned by the decorator. Note `inspect`'s structured `parameters` already walk the source AST, so the response self-contradicted (wrong signature string, correct params).

## Fix (Option C — targeted detect-and-fallback)

- New helper `_signature_from_source_ast(jedi_name)` reconstructs `name(args) -> ret` from the source `FunctionDef` (reuses `find_function_def_at_line`); returns `None` when no source def exists.
- `_build_signature` compares the rendered leading identifier against the symbol name. On mismatch (the wrapper leak) it rebuilds from the AST, **falling back gracefully to the Jedi render** for builtins / C-extensions / stub-only externals where no source def is available.
- Normal (undecorated) methods are untouched → near-zero regression. Fixes both `inspect` and `outline` (the latter via `build_stub` → `_build_signature`).
- Follow-up note added at the deprecated `_enrich_method` path recording the dual-source smell (it still leaks signature + params) and the intent to converge on the AST-first builder.

## Test plan

- [x] New regression tests RED→GREEN (`TestInspectDecoratedMethodSignature`, `TestStubMethod::test_decorated_method_renders_own_signature`) using a dedicated fixture module `decorated.py` (keeps the line-number-pinned `widgets.py` untouched).
- [x] Verified end-to-end against a real Django checkout: `get_models` and `get_swappable_settings_name` now render their true signatures in both `inspect` and `outline`.
- [x] Full suite: 2072 passed, coverage 86.98% (the one failure, `test_cache_hit_performance`, is the known-flaky perf benchmark #428 — passes in isolation, unrelated).
- [x] black + ruff clean on all changed files.

Fixes #437