### PR TITLE
test(analyzer): guard find_subclasses cross-process determinism (#419)

### DIFF
--- a/scripts/measure_subclass_fallback.py
+++ b/scripts/measure_subclass_fallback.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Measure AST-vs-``goto`` fallback in subclass base resolution (#419).
+
+``find_subclasses`` resolves each class base AST-first (:func:`resolve_base` —
+deterministic) and only falls back to Jedi forward ``goto`` (non-deterministic
+across processes, #419) when the AST cannot commit. This script replicates the
+cold-build resolution-table construction and classifies every class base in a
+target project as an **AST hit** or a **``goto`` fallback**, so the fallback rate
+can be measured and regressions caught.
+
+It is the reproducible record behind #419's "reduce the fallback rate" criterion:
+the ``import *`` re-export following that landed in #405 cut Django's fallback
+from ~1636 punts to ~647 (≈93% AST hit), and the residual is dominated by
+builtins/stdlib that ``goto`` resolves deterministically anyway.
+
+Usage::
+
+    uv run python scripts/measure_subclass_fallback.py /path/to/project
+
+The script depends only on the public ``base_resolution`` helpers and the
+``resolve_relative_import`` seam, so it never imports Jedi and runs in seconds.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import NamedTuple
+
+# Add src to path so the script runs without an editable install.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from pyeye.analyzers.base_resolution import (  # noqa: E402
+    build_import_table,
+    build_module_defines,
+    build_star_sources,
+    resolve_base,
+)
+from pyeye.import_analyzer import resolve_relative_import  # noqa: E402
+
+
+def _module_name(py_file: Path, root: Path) -> str:
+    rel = py_file.relative_to(root).with_suffix("")
+    parts = list(rel.parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else py_file.stem
+
+
+def _base_dotted(node: ast.expr) -> str | None:
+    """Dotted name of a class-base expression (``Name``/``Attribute``), or None."""
+    parts: list[str] = []
+    cur: ast.expr = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+class Stats(NamedTuple):
+    """AST-hit / goto-fallback tallies for one project's class bases."""
+
+    modules: int
+    total_bases: int
+    ast_hits: int
+    goto_fallbacks: int
+    top_fallback_heads: list[tuple[str, int]]
+
+
+def measure(root: Path) -> Stats:
+    """Return AST-hit / goto-fallback counts for every class base under *root*."""
+    py_files = sorted(root.rglob("*.py"), key=lambda p: p.as_posix())
+
+    import_tables: dict[str, dict[str, str]] = {}
+    module_defines: dict[str, dict[str, str]] = {}
+    star_sources: dict[str, list[str]] = {}
+    trees: dict[str, ast.Module] = {}
+
+    for py_file in py_files:
+        module = _module_name(py_file, root)
+        if module in trees:
+            continue
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+        trees[module] = tree
+        is_package = py_file.name == "__init__.py"
+        import_tables[module] = build_import_table(
+            tree, module, resolve_relative_import, is_package
+        )
+        module_defines[module] = build_module_defines(tree)
+        stars = build_star_sources(tree, module, resolve_relative_import, is_package)
+        if stars:
+            star_sources[module] = stars
+
+    hits = 0
+    punts = 0
+    punt_heads: Counter[str] = Counter()
+    for module, tree in trees.items():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for base in node.bases:
+                dotted = _base_dotted(base)
+                if not dotted or dotted == "object":
+                    continue
+                resolved = resolve_base(module, dotted, import_tables, module_defines, star_sources)
+                if resolved is not None:
+                    hits += 1
+                else:
+                    punts += 1
+                    punt_heads[dotted.split(".")[0]] += 1
+
+    return Stats(
+        modules=len(trees),
+        total_bases=hits + punts,
+        ast_hits=hits,
+        goto_fallbacks=punts,
+        top_fallback_heads=punt_heads.most_common(20),
+    )
+
+
+def main(argv: list[str]) -> int:
+    """Run the AST-hit vs goto-fallback measurement for a project root."""
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} <project-root>", file=sys.stderr)
+        return 2
+    root = Path(argv[1]).expanduser().resolve()
+    if not root.is_dir():
+        print(f"not a directory: {root}", file=sys.stderr)
+        return 2
+
+    stats = measure(root)
+    total = stats.total_bases or 1
+    print(f"project root    : {root}")
+    print(f"modules parsed  : {stats.modules}")
+    print(f"class bases     : {stats.total_bases}")
+    print(f"AST hits        : {stats.ast_hits}  ({100 * stats.ast_hits / total:.1f}%)")
+    print(f"goto fallbacks  : {stats.goto_fallbacks}  ({100 * stats.goto_fallbacks / total:.1f}%)")
+    print("top fallback heads (base's head identifier):")
+    for name, count in stats.top_fallback_heads:
+        print(f"  {count:5d}  {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/pyeye/analyzers/base_resolution.py
+++ b/src/pyeye/analyzers/base_resolution.py
@@ -9,12 +9,26 @@ Design contract
 ---------------
 - Returns the **definition site** (where ``class X`` physically appears), never
   a re-export path.
-- Returns ``None`` when the AST cannot commit (star/`__all__` re-exports,
-  externals/builtins, dynamic constructs). ``None`` means "ask Jedi" — the
-  caller falls back to ``goto``, which remains the authority.
+- Returns ``None`` when the AST cannot commit (conditional / ``TYPE_CHECKING``
+  imports, externals/builtins, dynamic constructs). ``None`` means "ask Jedi" —
+  the caller falls back to ``goto``, which remains the authority.
 - It must NEVER return a *wrong* definition: the #405 Django measurement found
   0 disagreements with Jedi, and that safety property is what lets the caller
   trust the committed answer instead of verifying it.
+
+Determinism (#419)
+------------------
+This AST resolution is **deterministic** — it is pure string/table logic with
+no process-state dependence. Jedi forward ``goto``, the fallback for the
+``None`` cases, is **not**: it can return different targets across fresh
+processes for some bases (conditional imports, package re-exports), so any
+``find_subclasses`` result whose membership depends on a ``goto``-resolved base
+can vary run-to-run. Following ``import *`` re-exports here (#405) moved most
+bases onto this deterministic path — measured ≈93% AST hits on Django,
+``scripts/measure_subclass_fallback.py`` — shrinking but not eliminating the
+non-deterministic surface. The residual is the second, forward-resolution
+argument for a deterministic backend (#333), independent of the reverse-
+reference one (#332).
 
 The function is pure (no filesystem, no Jedi): it operates on pre-built tables,
 so it is cheap and trivially testable. Building those tables from ASTs is a

--- a/src/pyeye/analyzers/jedi_analyzer.py
+++ b/src/pyeye/analyzers/jedi_analyzer.py
@@ -3119,6 +3119,17 @@ class JediAnalyzer:
         2. Builds a parent->children graph for efficient indirect lookups
         3. Uses Jedi Script.goto() to resolve aliased imports
 
+        Determinism ceiling (#419): bases are resolved AST-first
+        (:func:`base_resolution.resolve_base` — deterministic) with a Jedi
+        forward ``goto`` fallback only when the AST cannot commit (conditional /
+        ``TYPE_CHECKING`` imports, externals, dynamic constructs). Forward
+        ``goto`` is non-deterministic across fresh processes for some bases, so
+        a subclass whose membership hinges on a ``goto``-resolved base can vary
+        run-to-run. AST ``import *`` re-export following (#405) keeps the vast
+        majority of bases on the deterministic path (~93% AST hits on Django);
+        the residual non-determinism is a forward-resolution argument for the
+        deterministic backend tracked in #333.
+
         Args:
             base_class: Name of the base class to find subclasses for
             scope: Search scope (default from smart defaults):

--- a/tests/fixtures/determinism_subclasses/pkg/base.py
+++ b/tests/fixtures/determinism_subclasses/pkg/base.py
@@ -1,0 +1,5 @@
+"""Definition site of the base class under test."""
+
+
+class Base:
+    """The base class whose subclasses are queried."""

--- a/tests/fixtures/determinism_subclasses/pkg/child_ast.py
+++ b/tests/fixtures/determinism_subclasses/pkg/child_ast.py
@@ -1,0 +1,11 @@
+"""Subclass whose base is resolvable by the AST resolver (deterministic path).
+
+``from .base import Base`` is a top-level import, so ``resolve_base`` commits to
+``pkg.base.Base`` without ever consulting Jedi ``goto``.
+"""
+
+from .base import Base
+
+
+class ChildAst(Base):
+    """Direct subclass resolved via the AST import table."""

--- a/tests/fixtures/determinism_subclasses/pkg/child_goto.py
+++ b/tests/fixtures/determinism_subclasses/pkg/child_goto.py
@@ -1,0 +1,18 @@
+"""Subclass whose base falls back to Jedi ``goto`` (the non-deterministic path).
+
+The base is imported inside an ``if TYPE_CHECKING:`` guard — a conditional
+import, so it is NOT a top-level import node. ``build_import_table`` cannot see
+it and ``resolve_base`` punts to ``None``. ``find_subclasses`` then resolves the
+base via ``script.goto(follow_imports=True)``, crossing the ``reexport``
+boundary to ``pkg.base.Base``. This is exactly the resolution path #419 is
+about; the determinism test asserts its result is stable across processes.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .reexport import Base
+
+
+class ChildGoto(Base):  # noqa: F821 - resolved statically (TYPE_CHECKING-only import)
+    """Direct subclass resolved via the Jedi ``goto`` fallback."""

--- a/tests/fixtures/determinism_subclasses/pkg/reexport.py
+++ b/tests/fixtures/determinism_subclasses/pkg/reexport.py
@@ -1,0 +1,5 @@
+"""Re-export of Base, so a conditional import crosses a re-export boundary."""
+
+from .base import Base
+
+__all__ = ["Base"]

--- a/tests/integration/test_subclasses_determinism.py
+++ b/tests/integration/test_subclasses_determinism.py
@@ -1,0 +1,81 @@
+"""Cross-process determinism guard for ``find_subclasses`` base resolution (#419).
+
+``find_subclasses`` resolves each class base AST-first (``resolve_base`` —
+deterministic) and falls back to Jedi forward ``goto`` only when the AST cannot
+commit. Jedi ``goto`` is known to return *different* targets across fresh
+processes for some bases (conditional imports, package re-exports) — a
+hash-seed / cache-state dependence (#419), distinct from the reverse-reference
+non-determinism behind the Pyright backend (#333).
+
+This pins the property that, on a fixture exercising BOTH paths — ``ChildAst``
+(top-level import → AST) and ``ChildGoto`` (``TYPE_CHECKING`` import → ``goto``
+fallback) — the subclass set is identical across processes started with
+different ``PYTHONHASHSEED``.
+
+It is a regression guard: today the property holds (project bases that fall back
+to ``goto`` still resolve to a stable in-project target), so the test passes. A
+future change that makes resolution order- or seed-dependent fails here. The bug
+is cross-*process*, so the runs are real subprocesses — in-process re-runs share
+the interpreter's hash seed and Jedi's inference cache and would not catch it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_FIXTURE = Path(__file__).parent.parent / "fixtures" / "determinism_subclasses"
+_BASE = "pkg.base.Base"
+_EXPECTED = ["pkg.child_ast.ChildAst", "pkg.child_goto.ChildGoto"]
+
+# Runs find_subclasses and prints the sorted subclass FQNs as a single JSON line.
+# Executed in a fresh interpreter so each invocation gets its own hash seed and
+# Jedi cache state.
+_RUNNER = """
+import asyncio, json, sys
+from pyeye.analyzers.jedi_analyzer import JediAnalyzer
+from pyeye.config import ProjectConfig
+
+
+async def main():
+    project, base = sys.argv[1], sys.argv[2]
+    analyzer = JediAnalyzer(project, config=ProjectConfig(project))
+    res = await analyzer.find_subclasses(base, scope="main", include_indirect=True)
+    print("RESULT:" + json.dumps(sorted(s["full_name"] for s in res["subclasses"])))
+
+
+asyncio.run(main())
+"""
+
+
+def _run_in_subprocess(hashseed: str) -> list[str]:
+    """Run the fixture query in a fresh interpreter with a fixed PYTHONHASHSEED."""
+    env = dict(os.environ, PYTHONHASHSEED=hashseed)
+    proc = subprocess.run(
+        [sys.executable, "-c", _RUNNER, str(_FIXTURE), _BASE],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+    )
+    assert proc.returncode == 0, f"runner failed (PYTHONHASHSEED={hashseed}):\n{proc.stderr}"
+    line = next(line for line in proc.stdout.splitlines() if line.startswith("RESULT:"))
+    return json.loads(line[len("RESULT:") :])
+
+
+def test_find_subclasses_stable_across_process_hash_seeds() -> None:
+    """The subclass set is identical across processes with different hash seeds.
+
+    Asserts both the expected membership (so the test fails loudly if resolution
+    breaks entirely) AND equality across seeds (the determinism property #419).
+    ``ChildGoto`` is the load-bearing case: it is attributed only via the Jedi
+    ``goto`` fallback, the path prone to cross-process drift.
+    """
+    results = {seed: _run_in_subprocess(seed) for seed in ("0", "1", "424242")}
+
+    for seed, subs in results.items():
+        assert subs == _EXPECTED, f"unexpected subclasses (PYTHONHASHSEED={seed}): {subs}"
+
+    distinct = {tuple(subs) for subs in results.values()}
+    assert len(distinct) == 1, f"non-deterministic across hash seeds: {results}"


### PR DESCRIPTION
## Summary

Jedi forward ``goto`` is non-deterministic across fresh processes, so
``find_subclasses`` results can vary run-to-run when a base is reached via the
``goto`` fallback rather than the AST path (#419).

**Investigation finding:** the issue's proposed lever — *"extend `resolve_base`
to follow `*`/`__all__`"* — was **already delivered by #405** (`import *`
following). Measuring against a Django checkout:

| | class bases | AST hits | `goto` fallbacks |
|---|---|---|---|
| issue baseline (`ec66d96`, pre-star) | ~10.7k | — | ~1636 |
| **now (post-#405)** | 9724 | **9077 (93.3%)** | **647 (6.7%)** |

The residual 647 fallbacks are dominated by **builtins/stdlib** (`Exception`,
`unittest`, `list`, …) that `goto` resolves *deterministically*; only a small
tail (conditional imports, inconsistent package re-exports) is genuinely flaky,
and most of those resolve to externals. So further AST extension has low
leverage and risks the `resolve_base` *"never returns a wrong definition"*
safety contract. **No resolver logic is changed here.**

## What this delivers (the three acceptance criteria)

1. **Reproducible measurement** — `scripts/measure_subclass_fallback.py`
   classifies every class base in a target project as AST-hit vs `goto`-fallback
   (the before/after evidence above; pure-AST, no Jedi, runs in seconds).
2. **Cross-process determinism guard** —
   `tests/integration/test_subclasses_determinism.py` runs `find_subclasses` in
   subprocesses with differing `PYTHONHASHSEED` and asserts **identical** subclass
   sets. The fixture exercises **both** paths: `ChildAst` (top-level import → AST,
   deterministic) and `ChildGoto` (`TYPE_CHECKING` import → `goto` fallback). The
   guard was verified to actually fail on a simulated non-determinism.
3. **Documentation** — the forward-`goto` non-determinism is now documented as a
   known limitation in `base_resolution.py` (module docstring) and
   `find_subclasses` (jedi_analyzer.py), linked to #333.

Docs were deliberately kept to `base_resolution.py` + `jedi_analyzer.py`
(**not** `edges.py`/`SKILL.md`), which the in-flight #423 edits — so this stays
conflict-free.

## Test plan

- [x] Determinism guard passes across `PYTHONHASHSEED` 0/1/424242; verified it
      fails on injected non-determinism
- [x] Full suite: 2106 passed, 8 skipped, coverage 87.02% (≥85%)
- [x] black + ruff clean; mypy (`src/pyeye`) clean; bandit clean
- [x] measurement script reproduces 93.3% AST / 647 fallbacks on Django

Refs #405, #397, #333, #332.

Closes #419