### PR TITLE
docs(skills): refresh django scenario baseline for report_issues (#467)

### DIFF
--- a/.claude/skills/pyeye-scenarios/SKILL.md
+++ b/.claude/skills/pyeye-scenarios/SKILL.md
@@ -83,7 +83,7 @@ Single source tree — the depth/scale baseline. No `.pyeye.json`, no namespace.
 | `project_path` | `<TARGET>/django` |
 | root / `.pyeye.json` | none |
 
-### Probe suite + recorded baseline *(captured 2026-06-21, global server)*
+### Probe suite + recorded baseline *(captured 2026-06-22, build `dev416+g406783dd6` = main incl. #458; re-verified unchanged vs the 2026-06-21 global-server capture except row 5's `report_issues` key)*
 
 | # | Probe | Expected (baseline) | Demonstrates |
 |---|-------|---------------------|--------------|
@@ -91,7 +91,7 @@ Single source tree — the depth/scale baseline. No `.pyeye.json`, no namespace.
 | 2 | `inspect("django.db.models.Model")` | `superclasses:["…utils.AltersData"]`, `signature:"Model()"`, `edge_counts:{members:68, superclasses:1}`, `re_exports:["…operations.fields.Model"]`; **no `callers`/`references` key** | **absence-vs-zero** (no caller key) + **static-surface ceiling** (`members:68` omits metaclass-injected `_meta`/`objects`/`DoesNotExist`) |
 | 3 | `expand("django.db.models.Model", "superclasses")` | one stub: `django.db.models.utils.AltersData` | matches `edge_counts.superclasses` |
 | 4 | `expand("django.core.signing", "imported_by")` | 10 module stubs incl. `django.http.request`, `django.contrib.sessions.backends.base`, and `tests.*` | reverse-static import graph (deterministic) |
-| 5 | `expand("django.db.models.Model", "callers")` | `unsupported, reason:"deferred_reference_backend"` (#333) | **honest-limit refusal** — not faked, not empty |
+| 5 | `expand("django.db.models.Model", "callers")` | `unsupported, reason:"deferred_reference_backend"` (#333), plus a `report_issues` URL (**#458**, PR #460) | **honest-limit refusal** — not faked, not empty; refusal now carries the in-band report path |
 
 > Probe 2's `members:68` is a count of *statically written* members. Reporting it as
 > "Model's complete attribute set" would be wrong — `_meta`, `objects`, `DoesNotExist`


### PR DESCRIPTION
## Summary

Refreshes the `django` scenario recorded baseline in `.claude/skills/pyeye-scenarios/SKILL.md` (maintainer-only dogfooding skill) to reflect the **#458** in-band bug-reporting path (PR #460).

Re-verified the full django probe suite against the restarted server (build `1.1.3.dev416+g406783dd6`, confirmed via `pyeye://about`):

- Probes 1–4 match the prior `2026-06-21` baseline **byte-for-byte** — no regression.
- Probe 5 (`expand("django.db.models.Model", "callers")`) still refuses with `deferred_reference_backend` (#333) but the payload now **also** carries a `report_issues` URL — the #458 addition.

Updated the build tag and row 5 to record it. PR #461 had refreshed only the `namespace-jaraco` section; this closes the same gap for `django`.

## Test plan

- [x] django scenario provisioned at pinned SHA `cd385e6b8c` (via `--reference`, gitignored `.scenario-repos/`)
- [x] All 5 probes re-run; diff vs baseline = row 5 `report_issues` only
- [x] pre-commit green (markdownlint)
- [ ] CI green

Fixes #467