### PR TITLE
chore(hooks): scope default pre-commit stages to commit (#477)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,15 @@ default_language_version:
 # the new hook types.
 default_install_hook_types: [pre-commit, commit-msg, post-commit, post-merge, post-checkout]
 
+# Default stage for hooks that don't declare their own `stages`. Without this,
+# pre-commit runs an unscoped hook in EVERY installed stage — so widening the
+# install types above (#462) made the lint/format/security/conformance hooks
+# (notably the always_run `conformance-linter`, a pytest run) fire on every
+# `git checkout`/`pull`/`merge` too (#477). Scoping the default to commit time
+# keeps those at `git commit`; the four hooks that intentionally run on other
+# stages declare their own `stages` and are unaffected.
+default_stages: [pre-commit]
+
 repos:
   # Security checks
   - repo: https://github.com/Yelp/detect-secrets

--- a/tests/test_precommit_hook_config.py
+++ b/tests/test_precommit_hook_config.py
@@ -31,6 +31,28 @@ def _hook(config, hook_id):
     raise AssertionError(f"hook {hook_id!r} not found in .pre-commit-config.yaml")
 
 
+def _runs_at(hook, config, stage):
+    """Whether *hook* runs at *stage*, mirroring pre-commit's resolution.
+
+    A hook with explicit ``stages`` runs only in those. A hook WITHOUT ``stages``
+    falls back to the top-level ``default_stages``; when that is absent too,
+    pre-commit runs the hook in *every* installed stage (the #477 footgun).
+    """
+    if "stages" in hook:
+        return stage in hook["stages"]
+    default = config.get("default_stages")
+    return default is None or stage in default
+
+
+def _hooks_at(config, stage):
+    return {
+        hook["id"]
+        for repo in config["repos"]
+        for hook in repo["hooks"]
+        if _runs_at(hook, config, stage)
+    }
+
+
 def test_install_types_include_checkout_and_merge():
     """A bare `pre-commit install` must wire post-merge and post-checkout."""
     install_types = _load()["default_install_hook_types"]
@@ -48,3 +70,29 @@ def test_metrics_session_runs_on_checkout_only():
     hook = _hook(_load(), "start-metrics-session")
     assert hook["stages"] == ["post-checkout"]
     assert hook["pass_filenames"] is False
+
+
+def test_only_intended_hooks_run_on_checkout_and_merge():
+    """Unscoped lint/format/conformance hooks must NOT fire on checkout/merge (#477).
+
+    Adding post-merge/post-checkout to ``default_install_hook_types`` (#462) made
+    every hook lacking explicit ``stages`` also run on those git events — notably
+    the ``always_run`` ``conformance-linter`` (a multi-second pytest run) on every
+    ``git checkout``/``git pull``. A top-level ``default_stages: [pre-commit]``
+    scopes the unscoped hooks back to commit time; only the two hooks that
+    explicitly opt into the git-state stages should fire there.
+    """
+    config = _load()
+    assert _hooks_at(config, "post-checkout") == {
+        "refresh-version-file",
+        "start-metrics-session",
+    }
+    assert _hooks_at(config, "post-merge") == {"refresh-version-file"}
+
+
+def test_default_stages_scopes_unscoped_hooks_to_commit():
+    """The conformance-linter (unscoped, always_run) must resolve to commit-only."""
+    config = _load()
+    assert config.get("default_stages") == ["pre-commit"]
+    assert _runs_at(_hook(config, "conformance-linter"), config, "post-checkout") is False
+    assert _runs_at(_hook(config, "conformance-linter"), config, "pre-commit") is True


### PR DESCRIPTION
## Summary

Follow-up to #462. Adding `post-merge`/`post-checkout` to `default_install_hook_types` had a side effect: every hook **without an explicit `stages:`** also fired on `git checkout`/`pull`/`merge`, because pre-commit runs an unscoped hook in *all* installed stages by default. Most are file-based and just `Skip` (noise), but the **`conformance-linter`** (`always_run`, `pass_filenames: false`) **ran its full `pytest tests/conformance/` on every checkout/pull/merge** — multi-second latency on routine git ops. Spotted live while updating `main` after the #476 merge.

## Fix (one-liner)

Add a top-level `default_stages: [pre-commit]` so unscoped hooks resolve to commit time. The four hooks that intentionally run on other stages declare their own `stages` and are **unaffected**:

- `commitizen` → `[commit-msg]`
- `decision-log-nudge` → `[post-commit]`
- `refresh-version-file` → `[post-merge, post-checkout]`
- `start-metrics-session` → `[post-checkout]`

## Verification

- **Behavioral proof:** `pre-commit run --hook-stage post-checkout` now runs only `refresh-version-file` + `start-metrics-session`; `--hook-stage post-merge` runs only `refresh-version-file`. The conformance linter and file-based hooks no longer fire on those events.
- **`git commit` unchanged** — full pre-commit + commit-msg + post-commit set still runs.
- New behavioral contract tests in `tests/test_precommit_hook_config.py` compute each hook's effective stage from config and assert only the intended hooks fire on checkout/merge (these **fail on the pre-fix config**, pass after).
- Full suite: **2251 passed**, 8 skipped, **87.38%** coverage. Pre-commit clean.

## Test plan

- [x] `uv run pytest --cov=src/pyeye --cov-fail-under=85` (2251 passed, 87.38%)
- [x] New tests fail on pre-fix config, pass after
- [x] `pre-commit validate-config` passes; behavioral stage proof confirmed
- [ ] CI green

Fixes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)