### PR TITLE
fix(hooks): pin uv to --frozen in all pre-commit entries so uv.lock isn't rewritten (#479)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         # - GHSA-4xh5-x5gv-qwph: pip vulnerability, awaiting pip 25.3
         # - CVE-2025-69872: diskcache pickle deserialization, no fix available (issue #289)
         # - CVE-2026-4539: pygments vulnerability, no fix available yet (latest is 2.19.2)
-        entry: uv run pip-audit --skip-editable --ignore-vuln GHSA-4xh5-x5gv-qwph --ignore-vuln CVE-2025-69872 --ignore-vuln CVE-2026-4539
+        entry: uv run --frozen pip-audit --skip-editable --ignore-vuln GHSA-4xh5-x5gv-qwph --ignore-vuln CVE-2025-69872 --ignore-vuln CVE-2026-4539
         language: system
         pass_filenames: false
         files: '(requirements.*\.txt|pyproject\.toml|uv\.lock)$'
@@ -59,7 +59,7 @@ repos:
       # Code formatting
       - id: black
         name: black
-        entry: uv run black
+        entry: uv run --frozen black
         language: system
         types: [python]
         args: ['--line-length=100']
@@ -68,7 +68,7 @@ repos:
       # ruff-format disabled since we use black for formatting)
       - id: ruff
         name: ruff
-        entry: uv run ruff check
+        entry: uv run --frozen ruff check
         language: system
         types: [python]
         args: ['--fix', '--exit-non-zero-on-fix']
@@ -81,7 +81,7 @@ repos:
       # in the pyproject dev group so `uv run mypy` picks them up.
       - id: mypy
         name: mypy
-        entry: uv run mypy
+        entry: uv run --frozen mypy
         language: system
         types: [python]
         pass_filenames: false
@@ -156,7 +156,7 @@ repos:
     hooks:
       - id: conformance-linter
         name: PyEye conformance linter (layering + absence-vs-zero)
-        entry: uv run pytest tests/conformance/ -q --no-header --no-cov
+        entry: uv run --frozen pytest tests/conformance/ -q --no-header --no-cov
         language: system
         pass_filenames: false
         always_run: true
@@ -193,7 +193,7 @@ repos:
     hooks:
       - id: refresh-version-file
         name: Refresh setuptools_scm version file
-        entry: uv run python scripts/refresh_version.py
+        entry: uv run --frozen python scripts/refresh_version.py
         language: system
         stages: [post-merge, post-checkout]
         pass_filenames: false
@@ -207,7 +207,7 @@ repos:
     hooks:
       - id: start-metrics-session
         name: Start dogfooding metrics session
-        entry: uv run python scripts/dogfooding_metrics.py start-on-checkout
+        entry: uv run --frozen python scripts/dogfooding_metrics.py start-on-checkout
         language: system
         stages: [post-checkout]
         pass_filenames: false

--- a/tests/test_precommit_hook_config.py
+++ b/tests/test_precommit_hook_config.py
@@ -90,6 +90,26 @@ def test_only_intended_hooks_run_on_checkout_and_merge():
     assert _hooks_at(config, "post-merge") == {"refresh-version-file"}
 
 
+def test_all_uv_run_entries_are_frozen():
+    """No hook may invoke a bare ``uv run`` — it must be ``uv run --frozen`` (#479).
+
+    Bare ``uv run`` can re-resolve and rewrite ``uv.lock`` as a side effect
+    (notably behind a PyPI mirror), which trips pre-commit's framework-level
+    "files were modified by this hook" check and fails the hook — independent of
+    the script's own exit code. ``--frozen`` pins the lock so the hooks run the
+    tools without ever mutating it.
+    """
+    offenders = []
+    for repo in _load()["repos"]:
+        for hook in repo["hooks"]:
+            entry = hook.get("entry", "")
+            if "uv run" in entry and "uv run --frozen" not in entry:
+                offenders.append(hook["id"])
+    assert (
+        not offenders
+    ), f"hooks using a bare 'uv run' (must be 'uv run --frozen', #479): {offenders}"
+
+
 def test_default_stages_scopes_unscoped_hooks_to_commit():
     """The conformance-linter (unscoped, always_run) must resolve to commit-only."""
     config = _load()


### PR DESCRIPTION
## Summary

Every pre-commit hook entry used **bare `uv run`**, which can re-resolve and rewrite `uv.lock` as a side effect. Behind a **PyPI mirror**, `uv run` rewrites the lock (mirror index URLs/hashes); pre-commit's framework-level **"files were modified by this hook"** check then fails the hook — independent of the script's exit code, so the "failure-tolerant" scripts don't help.

First seen on `git checkout` (the `refresh-version-file` hook, #462), but it affects **all 7** bare-`uv run` entries, so a normal `git commit` fails too via whichever hook fires first.

## Fix

`uv run` → `uv run --frozen` on all 7 entries (`pip-audit`, `black`, `ruff`, `mypy`, `conformance-linter`, `refresh-version-file`, `start-metrics-session`). `--frozen` = "never update the lockfile; use it as-is" — so uv can't rewrite `uv.lock` even against a mirror, while still creating the env from the lock on a fresh clone.

`--frozen` (not `--locked`): `--frozen` never touches the lock and never blocks; `--locked` errors when the lock is stale — fine as a dedicated CI guard, but it would block local commits whenever the lock drifts. So hooks use `--frozen`.

## Regression guard

New `tests/test_precommit_hook_config.py::test_all_uv_run_entries_are_frozen` asserts **no** hook entry uses a bare `uv run` — fails on the pre-fix config, passes after.

## Verification (local, against a fresh clone)

- `uv run --frozen python scripts/refresh_version.py` on a fresh clone: `.venv` created, `_version.py` correct, **`uv.lock` unchanged**.
- `--frozen` hooks still execute (`mypy`/`ruff` Passed) and leave `uv.lock` clean.
- Full suite: **2252 passed**, 8 skipped, **87.38%** coverage. pre-commit green.

## Test plan

- [x] All 7 entries use `uv run --frozen`
- [x] New contract test fails on bare `uv run`, passes after
- [x] `uv run --frozen pytest --cov=src/pyeye --cov-fail-under=85` (2252 passed, 87.38%)
- [ ] CI green

## Follow-up (separate, lower risk)

- [ ] Broader consistency pass on `.github` CI `uv run` calls (CI runs `uv sync` first against pypi.org, so no mirror rewrite in practice) — e.g. `uv sync --locked` as a lock-currency guard.

Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)