### PR TITLE
docs: refresh api-redesign status + correct removed-vs-deprecated wording (#403)

### DIFF
--- a/.claude/instructions/03-mcp-dogfooding.md
+++ b/.claude/instructions/03-mcp-dogfooding.md
@@ -32,10 +32,14 @@ absence-vs-zero invariant, and operate on canonical handles that collapse
 re-exported paths to the definition site.
 
 The old Jedi-shaped tools (`find_symbol`, `goto_definition`, `get_type_info`,
-`find_references`, etc.) remain only for backwards compatibility and are
-**deprecated** — do not reach for them, and never use the reverse-reference
-tools to answer "who calls / references this" (see the honest-limits rule in the
-skill). See `docs/api-redesign.md` for the redesign background.
+`find_imports`, `find_subclasses`, `list_packages`, `list_modules`,
+`get_module_info`, `list_project_structure`) have been **removed** from the MCP
+surface — they are gone, not just discouraged. Three legacy tools survive but
+are **deprecated**: `find_references`, `get_call_hierarchy`, and
+`analyze_dependencies`. Do not reach for any of them, and never use the
+reverse-reference tools to answer "who calls / references this" (see the
+honest-limits rule in the skill). See `docs/api-redesign.md` for the redesign
+background.
 
 ## Tool mechanics live in the `python-explore` skill
 

--- a/docs/api-redesign.md
+++ b/docs/api-redesign.md
@@ -3,9 +3,13 @@
 ## Overview
 
 This document describes the redesigned PyEye API surface introduced across
-Phases 1–4, 6, and 7. The redesign adds three new operations — `resolve`,
-`resolve_at`, and `inspect` — optimised for cheap, pointer-first code
-navigation.
+Phases 1–8. The redesign replaces the legacy LSP-bridge tools with six
+progressive-disclosure operations — `resolve`, `resolve_at`, `inspect`,
+`outline`, `expand`, and `trace` — optimised for cheap, pointer-first code
+navigation. All six are shipped, live MCP tools. The canonical,
+conformance-tested reference for the full set (and the supported edges) lives in
+`skills/python-explore/SKILL.md`; this document covers the design background and
+documents the `resolve` / `resolve_at` / `inspect` intake operations in detail.
 
 ### Why a redesign?
 
@@ -27,17 +31,25 @@ roughly 0.03× the wire cost.
 | 2 | `resolve()` operation | Done |
 | 3 | `resolve_at()` operation | Done |
 | 4 | `inspect()` with edge counts | Done |
-| 5 | `outline()` operation | Deferred |
+| 5 | `outline()` operation | Done |
 | 6 | `re_exports` wired into `inspect` | Done |
 | 7.1 | Conformance linter + pre-commit hook | Done |
 | 7.2–7.5 | Spec acceptance tests (closeout) | Done |
 | 8 | TypeRef recursive trees on type-bearing fields | Done |
 
-`expand()` and `trace()` are future operations, not yet planned.
+`expand()` and `trace()` are also shipped, live MCP tools. The full primitive
+set (`resolve` / `resolve_at` / `inspect` / `outline` / `expand` / `trace`) and
+the complete static edge set (`members` / `callees` / `imported_by` /
+`subclasses` / `superclasses` / `imports` / `enclosing_scope`) are implemented;
+see `skills/python-explore/SKILL.md` for the live, conformance-tested reference.
 
 ---
 
-## The three operations
+## The intake operations: `resolve` / `resolve_at` / `inspect`
+
+These three intake operations are documented in full below. The remaining
+primitives — `outline`, `expand`, and `trace` — are shipped and documented in
+`skills/python-explore/SKILL.md` (the single source of truth, per #374).
 
 ### `resolve(identifier, project_path?)`
 


### PR DESCRIPTION
## Summary

Two documentation-only fixes from the v2.0 release checklist (#470, "Should fix" tier). Both are the same stale-doc-drift class: shipped guidance still describes the pre-2.0 tool surface.

- **`docs/api-redesign.md` (#403)** — the status table/overview still framed the redesign as in-progress:
  - Overview "three new operations" → names all **six** primitives (`resolve` / `resolve_at` / `inspect` / `outline` / `expand` / `trace`), all marked shipped.
  - Status table: Phase 5 `outline()` `Deferred` → **Done**.
  - Dropped the "`expand()` and `trace()` are future operations, not yet planned" line; replaced with shipped reality + the full static edge set.
  - Renamed the "The three operations" heading → "The intake operations" with a pointer to `skills/python-explore/SKILL.md` as the single source of truth (per #374), so the doc stops re-rotting.
- **`.claude/instructions/03-mcp-dogfooding.md`** — corrected wording: the 9 removed MCP tools are **removed**, not "deprecated"; only `find_references` / `get_call_hierarchy` / `analyze_dependencies` remain deprecated-but-live.

The only remaining "deferred" mentions in `api-redesign.md` are the legitimate callers/references → Pyright backend limits (#333), which #403 requires stay accurate — verified untouched.

## Test plan

- [x] `markdownlint` passes (#403 acceptance gate)
- [x] Full pre-commit hook set passes, incl. the PyEye conformance linter
- [x] No shipped primitive described as deferred/not-planned
- [x] Docs-only diff — no code/contract surfaces touched, so the pytest suite is not affected

Addresses #403
Part of #470 (also clears the `03-mcp-dogfooding.md` "should-fix" wording item)